### PR TITLE
Handle Picamera2 quality argument removal

### DIFF
--- a/bascula/services/camera.py
+++ b/bascula/services/camera.py
@@ -160,7 +160,11 @@ class CameraService:
             path = os.path.join(self._save_dir, f"capture_{ts}.jpg")
 
         try:
-            self.picam.capture_file(path, format="jpeg", quality=self._jpeg_quality)
+            try:
+                self.picam.capture_file(path, format="jpeg", quality=self._jpeg_quality)
+            except TypeError:
+                # Picamera2 >= 0.5 removed the 'quality' argument
+                self.picam.capture_file(path, format="jpeg")
             return path
         except Exception:
             if not _PIL_OK:


### PR DESCRIPTION
## Summary
- Handle removed `quality` argument in Picamera2's `capture_file`

## Testing
- `python3 -m scripts.test_camera` *(fails: Picamera2 no disponible)*

------
https://chatgpt.com/codex/tasks/task_e_68c693f57d008326b867e02432973906