### PR TITLE
Fix syntax error in WeightOverlay causing startup failure

### DIFF
--- a/bascula/ui/overlay_weight.py
+++ b/bascula/ui/overlay_weight.py
@@ -42,13 +42,13 @@ class WeightOverlay(OverlayBase):
         self.suggestion_frame.pack(fill="x", pady=(0, 12))
 
         btns = tk.Frame(c, bg=COL_CARD)
-        codex/increase-weight-value-size-and-add-tare-button-aefulp
         btns.pack(fill="x", pady=(12, 0))
-        BigButton(btns, text="Tara", command=self._on_tare).pack(side="left", expand=True, fill="x", padx=(0, 4))
-        BigButton(btns, text="Cerrar", command=self.hide, bg=COL_DANGER).pack(side="right", expand=True, fill="x", padx=(4, 0))
-
-        
-        main
+        BigButton(btns, text="Tara", command=self._on_tare).pack(
+            side="left", expand=True, fill="x", padx=(0, 4)
+        )
+        BigButton(btns, text="Cerrar", command=self.hide, bg=COL_DANGER).pack(
+            side="right", expand=True, fill="x", padx=(4, 0)
+        )
 
     # --- lifecycle ---
     def _open(self):


### PR DESCRIPTION
## Summary
- remove stray text in `WeightOverlay` constructor
- restore button frame with working Tare and Close buttons

## Testing
- `python -m compileall -f bascula/ui`


------
https://chatgpt.com/codex/tasks/task_e_68c69b0c3abc83268bcb7b5342cba0ff