### PR TITLE
fix: search all releases for piper voices

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -795,17 +795,20 @@ install -d -m 0755 /opt/piper/models
 # Descarga voces desde cualquiera de los Releases del repositorio
 GH_API="https://api.github.com/repos/DanielGTdiabetes/bascula-cam/releases"
 GH_JSON="$(curl -fsSL "$GH_API" 2>/dev/null || true)"
-for f in \
-  es_ES-mls_10246-medium.onnx es_ES-mls_10246-medium.onnx.json \
-  es_ES-sharvard-medium.onnx  es_ES-sharvard-medium.onnx.json
-do
+
+voices=(
+  es_ES-mls_10246-medium.onnx
+  es_ES-mls_10246-medium.onnx.json
+  es_ES-sharvard-medium.onnx
+  es_ES-sharvard-medium.onnx.json
+)
+
+for f in "${voices[@]}"; do
   if [ ! -s "/opt/piper/models/$f" ]; then
     url="$(printf '%s' "$GH_JSON" | jq -r --arg N "$f" '.[]?.assets[]? | select(.name==$N) | .browser_download_url' 2>/dev/null | head -n1)"
     if [ -n "$url" ] && [ "$url" != "null" ]; then
       echo "  - $f"
-      curl -fL --retry 4 --retry-delay 2 --continue-at - \
-        -o "/opt/piper/models/$f" \
-        "$url"
+      curl -fL --retry 4 --retry-delay 2 --continue-at - -o "/opt/piper/models/$f" "$url"
     else
       warn "No encontré $f en GitHub Release (saltando)"
     fi

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -792,17 +792,23 @@ apt-get install -y piper jq sox curl
 # Carpeta de voces del sistema
 install -d -m 0755 /opt/piper/models
 
-# Descarga desde el Release voices-v1 de tu repo
-GH_BASE="https://github.com/DanielGTdiabetes/bascula-cam/releases/download/voices-v1"
+# Descarga voces desde cualquiera de los Releases del repositorio
+GH_API="https://api.github.com/repos/DanielGTdiabetes/bascula-cam/releases"
+GH_JSON="$(curl -fsSL "$GH_API" 2>/dev/null || true)"
 for f in \
   es_ES-mls_10246-medium.onnx es_ES-mls_10246-medium.onnx.json \
   es_ES-sharvard-medium.onnx  es_ES-sharvard-medium.onnx.json
 do
   if [ ! -s "/opt/piper/models/$f" ]; then
-    echo "  - $f"
-    curl -fL --retry 4 --retry-delay 2 --continue-at - \
-      -o "/opt/piper/models/$f" \
-      "${GH_BASE}/$f?download=1"
+    url="$(printf '%s' "$GH_JSON" | jq -r --arg N "$f" '.[]?.assets[]? | select(.name==$N) | .browser_download_url' 2>/dev/null | head -n1)"
+    if [ -n "$url" ] && [ "$url" != "null" ]; then
+      echo "  - $f"
+      curl -fL --retry 4 --retry-delay 2 --continue-at - \
+        -o "/opt/piper/models/$f" \
+        "$url"
+    else
+      warn "No encontré $f en GitHub Release (saltando)"
+    fi
   fi
 done
 echo "[ok  ] Voces Piper listas"


### PR DESCRIPTION
## Summary
- search all GitHub releases for Piper voice assets instead of only the latest release

## Testing
- `bash -n scripts/install-all.sh`
- `shellcheck scripts/install-all.sh` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y shellcheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c70110ad2c8326a78e89dcec62b3fe