### PR TITLE
feat: expose autocapture settings and recipes

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -7,6 +7,7 @@ import time
 from bascula.config.theme import apply_theme, get_current_colors
 from bascula.ui.widgets import TopBar, Mascot
 from bascula.ui import screens
+from bascula.ui.overlay_recipe import RecipeOverlay
 
 
 class BasculaApp:
@@ -33,6 +34,9 @@ class BasculaApp:
         self.timer_job = None
         self.timer_end = 0.0
         self.diabetic_mode = False
+        self.auto_capture_enabled = True
+        self.auto_capture_min_delta_g = 8.0
+        self._recipe_overlay: RecipeOverlay | None = None
 
         self.show_main()
 
@@ -91,6 +95,11 @@ class BasculaApp:
     def open_settings(self) -> None:
         self.show_settings()
 
+    def open_recipes(self) -> None:
+        if self._recipe_overlay is None:
+            self._recipe_overlay = RecipeOverlay(self.root, self)
+        self._recipe_overlay.show()
+
     def quit(self) -> None:  # exposed to button
         self.root.destroy()
 
@@ -144,13 +153,28 @@ class BasculaApp:
 
     # ----- state helpers -------------------------------------------
     def get_state(self) -> dict:
-        return {'theme': self.theme_name, 'diabetic_mode': self.diabetic_mode}
+        return {
+            'theme': self.theme_name,
+            'diabetic_mode': self.diabetic_mode,
+            'auto_capture_enabled': self.auto_capture_enabled,
+            'auto_capture_min_delta_g': self.auto_capture_min_delta_g,
+        }
 
     def set_state(self, state: dict) -> None:
         if 'theme' in state:
             self.change_theme(state['theme'])
         if 'diabetic_mode' in state:
             self.set_diabetic_mode(state['diabetic_mode'])
+        if 'auto_capture_enabled' in state:
+            self.auto_capture_enabled = bool(state['auto_capture_enabled'])
+        if 'auto_capture_min_delta_g' in state:
+            try:
+                self.auto_capture_min_delta_g = float(state['auto_capture_min_delta_g'])
+            except Exception:
+                pass
+
+    def get_cfg(self) -> dict:
+        return self.get_state()
 
 
 if __name__ == '__main__':

--- a/bascula/ui/overlay_weight.py
+++ b/bascula/ui/overlay_weight.py
@@ -168,7 +168,7 @@ class WeightOverlay(OverlayBase):
 
     def _beep(self):
         try:
-            if getattr(self.app, "audio", None):
+            if getattr(self.app, "sound_on", True) and getattr(self.app, "audio", None):
                 self.app.audio.play_event("stable")
         except Exception:
             pass
@@ -191,12 +191,16 @@ class WeightOverlay(OverlayBase):
             self._clear_suggestion()
         now = time.time()
         if is_stable and now >= self.autocap_debounce_until:
-            cfg = getattr(self.app, "get_cfg", lambda: {})()
+            cfg = self.app.get_cfg() if hasattr(self.app, "get_cfg") else {}
             if bool(cfg.get("auto_capture_enabled", True)):
                 try:
                     min_delta = float(cfg.get("auto_capture_min_delta_g", 8))
                 except Exception:
                     min_delta = 8.0
+                if min_delta < 1.0:
+                    min_delta = 1.0
+                if min_delta > 100.0:
+                    min_delta = 100.0
                 delta = w - self.last_captured_weight
                 if delta >= min_delta:
                     self.begin_auto_capture(delta)
@@ -228,7 +232,7 @@ class WeightOverlay(OverlayBase):
         self.last_captured_weight = self._get_weight()
         self.autocap_debounce_until = time.time() + 1.5
         try:
-            if getattr(self.app, "audio", None):
+            if getattr(self.app, "sound_on", True) and getattr(self.app, "audio", None):
                 self.app.audio.play_event("preset_added")
         except Exception:
             pass

--- a/main.py
+++ b/main.py
@@ -27,14 +27,18 @@ log = logging.getLogger("main")
 def main():
     """Función principal."""
     log.info("=== BÁSCULA DIGITAL PRO - INICIO ===")
-    
+
+    if not os.environ.get('DISPLAY') and sys.platform != 'win32':
+        log.error('Entorno sin DISPLAY, no se puede iniciar la interfaz gráfica')
+        return 1
+
     try:
         # Importar y ejecutar la aplicación
         from bascula.ui.app import BasculaApp
 
         app = BasculaApp()
         app.root.mainloop()
-        
+
         return 0
         
     except ImportError as e:


### PR DESCRIPTION
## Summary
- respect configured auto-capture threshold with sane clamp
- allow toggling auto-capture and its threshold from settings
- add recipes button on home screen and hook to recipe overlay
- avoid crash when DISPLAY is missing
- clamp auto-capture threshold inputs and mute beeps when sound is off

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7dc7b50c0832698f86e6c958e9dc4