### PR TITLE
Add Nightscout BG monitor and diabetic mode integration

### DIFF
--- a/bascula/services/bg_monitor.py
+++ b/bascula/services/bg_monitor.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json, os
+from pathlib import Path
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - graceful fallback
+    requests = None
+
+
+class BgMonitor:
+    """Polls Nightscout for the latest BG value using Tk's ``after``."""
+
+    def __init__(self, app, interval_s: int = 60):
+        self.app = app
+        self.interval_s = interval_s
+        self._job = None
+        self._last_bg: tuple[int, str] | None = None
+
+    def start(self) -> None:
+        self._tick()
+
+    def stop(self) -> None:
+        if self._job is not None:
+            try:
+                self.app.root.after_cancel(self._job)
+            except Exception:
+                pass
+            self._job = None
+
+    # ---- internal helpers -----------------------------------------
+    def _read_ns_cfg(self) -> tuple[str, str]:
+        cfg_dir_env = os.environ.get("BASCULA_CFG_DIR", "").strip()
+        cfg_dir = Path(cfg_dir_env) if cfg_dir_env else (Path.home() / ".config" / "bascula")
+        try:
+            data = json.loads((cfg_dir / "nightscout.json").read_text(encoding="utf-8"))
+            return data.get("url", "").strip().rstrip("/"), data.get("token", "").strip()
+        except Exception:
+            return "", ""
+
+    def _tick(self) -> None:
+        url, token = self._read_ns_cfg()
+        if requests is not None and url:
+            try:
+                resp = requests.get(
+                    f"{url}/api/v1/entries.json",
+                    params={"count": 1, "token": token},
+                    timeout=8,
+                )
+                if resp.ok:
+                    arr = resp.json()
+                    if isinstance(arr, list) and arr:
+                        entry = arr[0]
+                        try:
+                            val = int(entry.get("sgv") or entry.get("glucose"))
+                        except Exception:
+                            val = None
+                        if val is not None:
+                            trend_raw = str(entry.get("direction", ""))
+                            trend = {
+                                "DoubleUp": "up",
+                                "SingleUp": "up",
+                                "FortyFiveUp": "up",
+                                "DoubleDown": "down",
+                                "SingleDown": "down",
+                                "FortyFiveDown": "down",
+                                "Flat": "flat",
+                            }.get(trend_raw, "")
+                            bg_tuple = (val, trend)
+                            if bg_tuple != self._last_bg:
+                                self._last_bg = bg_tuple
+                                try:
+                                    self.app.on_bg_update(val, trend)
+                                except Exception:
+                                    pass
+            except Exception:
+                pass
+
+        self._job = self.app.root.after(self.interval_s * 1000, self._tick)

--- a/bascula/ui/settings_tabs/tabs_diabetes.py
+++ b/bascula/ui/settings_tabs/tabs_diabetes.py
@@ -45,6 +45,27 @@ def add_tab(screen, notebook):
             pass
     tk.Checkbutton(nsdef, text='Activado', variable=var_send_def, command=on_send_def, bg=COL_CARD, fg=COL_TEXT, selectcolor=COL_CARD).pack(side='left', padx=8)
 
+    # Umbrales simples e intervalo de lectura
+    simple = tk.Frame(inner, bg=COL_CARD); simple.pack(anchor='w', pady=6)
+    tk.Label(simple, text='BG baja (mg/dL)', bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=0, sticky='w')
+    var_bg_low = tk.StringVar(value=str(screen.app.get_cfg().get('bg_low_mgdl', 70)))
+    ent_low = tk.Entry(simple, textvariable=var_bg_low, width=6)
+    ent_low.grid(row=1, column=0, sticky='w')
+    tk.Label(simple, text='BG alta (mg/dL)', bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=1, sticky='w', padx=(10,0))
+    var_bg_high = tk.StringVar(value=str(screen.app.get_cfg().get('bg_high_mgdl', 180)))
+    ent_high = tk.Entry(simple, textvariable=var_bg_high, width=6)
+    ent_high.grid(row=1, column=1, sticky='w', padx=(10,0))
+    tk.Label(simple, text='Intervalo (s)', bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=2, sticky='w', padx=(10,0))
+    var_poll = tk.StringVar(value=str(screen.app.get_cfg().get('bg_poll_s', 60)))
+    ent_poll = tk.Entry(simple, textvariable=var_poll, width=6)
+    ent_poll.grid(row=1, column=2, sticky='w', padx=(10,0))
+    try:
+        bind_numeric_entry(ent_low, decimals=0)
+        bind_numeric_entry(ent_high, decimals=0)
+        bind_numeric_entry(ent_poll, decimals=0)
+    except Exception:
+        pass
+
     # Parámetros de bolo
     params = [
         ("Objetivo (mg/dL)", 'target_bg_mgdl', 110),
@@ -114,6 +135,9 @@ def add_tab(screen, notebook):
             def to_int(v, d):
                 try: return int(float(v))
                 except Exception: return d
+            cfg['bg_low_mgdl'] = to_int(var_bg_low.get(), 70)
+            cfg['bg_high_mgdl'] = to_int(var_bg_high.get(), 180)
+            cfg['bg_poll_s'] = to_int(var_poll.get(), 60)
             cfg['target_bg_mgdl'] = to_int(vars_map['target_bg_mgdl'].get(), 110)
             cfg['isf_mgdl_per_u'] = to_int(vars_map['isf_mgdl_per_u'].get(), 50)
             cfg['carb_ratio_g_per_u'] = to_int(vars_map['carb_ratio_g_per_u'].get(), 10)


### PR DESCRIPTION
## Summary
- Poll Nightscout in a new `BgMonitor` service and map direction trends
- Start/stop monitor with diabetic mode and raise mascot/audio alerts on updates
- Expose low/high/poll interval settings in the Diabetes tab

## Testing
- `python -m py_compile bascula/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7e892a3cc8326a2b749324dce1e17