### PR TITLE
Add event bus and configurable mascot brain

### DIFF
--- a/bascula/services/event_bus.py
+++ b/bascula/services/event_bus.py
@@ -1,0 +1,31 @@
+class EventBus:
+    """Simple publish/subscribe event bus."""
+
+    def __init__(self):
+        self._subs = {}
+
+    def subscribe(self, topic, fn):
+        self._subs.setdefault(topic, []).append(fn)
+
+    def publish(self, topic, payload=None):
+        for fn in self._subs.get(topic, []):
+            try:
+                fn(payload)
+            except Exception:
+                pass
+
+
+# Known topics
+TOPICS = [
+    "IDLE_TICK",
+    "TIMER_STARTED",
+    "TIMER_FINISHED",
+    "WEIGHT_CAPTURED",
+    "TARA",
+    "SCANNER_OPEN",
+    "SCANNER_DETECTED",
+    "THEME_CHANGED",
+    "BG_UPDATE",
+    "BG_HYPO",
+    "BG_NORMAL",
+]

--- a/bascula/services/mascot_brain.py
+++ b/bascula/services/mascot_brain.py
@@ -1,0 +1,95 @@
+import random
+import time
+from typing import Callable
+
+from bascula.ui.mascot_messages import MSGS, get_message
+
+
+class SimpleLLMClient:
+    """Placeholder LLM client with opt-in sensitive data."""
+
+    def __init__(self, send_bg: bool = False):
+        self.send_bg = send_bg
+
+    def complete(self, prompt: str) -> str | None:
+        # Real implementation would call an online API with guardrails
+        return None
+
+
+class MascotBrain:
+    """Local mascot brain with optional LLM client.
+
+    It listens to events published on the EventBus and decides simple
+    reactions.  A small idle loop publishes ``IDLE_TICK`` every minute.
+    """
+
+    def __init__(self, bus, messenger, cfg_provider: Callable[[], dict], root=None):
+        self.bus = bus
+        self.messenger = messenger
+        self.cfg_provider = cfg_provider
+        self.root = root or messenger.get_mascot().winfo_toplevel()
+        cfg = cfg_provider() or {}
+        self.llm = None
+        if cfg.get('mascot_llm_enabled'):
+            self.llm = SimpleLLMClient(send_bg=bool(cfg.get('mascot_llm_send_bg')))
+
+        # subscribe to events
+        bus.subscribe("TIMER_STARTED", self.on_timer_started)
+        bus.subscribe("TIMER_FINISHED", self.on_timer_finished)
+        bus.subscribe("BG_HYPO", self.on_bg_hypo)
+        bus.subscribe("BG_NORMAL", self.on_bg_normal)
+        bus.subscribe("THEME_CHANGED", self.on_theme_changed)
+        bus.subscribe("IDLE_TICK", self.on_idle_tick)
+
+        # idle ticker
+        self._schedule_tick()
+
+    # ---- event helpers -------------------------------------------------
+    def _schedule_tick(self):
+        try:
+            self.root.after(60000, self._tick)
+        except Exception:
+            pass
+
+    def _tick(self):
+        self.bus.publish("IDLE_TICK")
+        self._schedule_tick()
+
+    def _show(self, key, *args, **kwargs):
+        text, action, anim = get_message(key, *args)
+        self.messenger.show(text, anim=anim, action=action, **kwargs)
+
+    # ---- event handlers ------------------------------------------------
+    def on_timer_started(self, payload):
+        self._show("timer_started", payload, kind="info", priority=3, icon="⏱")
+
+    def on_timer_finished(self, _payload):
+        self._show("timer_finished", kind="success", priority=6, icon="⏱")
+
+    def on_bg_hypo(self, value):
+        # Supportive only, no medical advice
+        msg = f"BG {value} mg/dL. ¿Te sientes bien?" if value is not None else "BG bajo"
+        self.messenger.show(msg, kind="warning", priority=8, icon="⚠️", anim="shake")
+
+    def on_bg_normal(self, value):
+        msg = f"BG {value} mg/dL" if value is not None else "BG OK"
+        self.messenger.show(msg, kind="info", priority=2, icon="💬", anim="wink")
+
+    def on_theme_changed(self, _payload):
+        self._show("theme_changed", kind="info", priority=1, icon="🎨")
+
+    def on_idle_tick(self, _payload):
+        cfg = self.cfg_provider() or {}
+        if cfg.get('mascot_no_molestar'):
+            return
+        personality = cfg.get('mascot_personality', 'normal')
+        if personality == 'off':
+            return
+        if random.random() < 0.2:  # moderate initiative
+            choices = {
+                'discreto': ["todo tranquilo"],
+                'normal': ["¿Cómo va todo?"],
+                'jugueton': ["¡Hola!"],
+            }
+            text = random.choice(choices.get(personality, choices['normal']))
+            self.messenger.show(text, kind="info", priority=1, icon="💬", anim="wink")

--- a/bascula/ui/settings_tabs/tabs_general.py
+++ b/bascula/ui/settings_tabs/tabs_general.py
@@ -32,6 +32,81 @@ def add_tab(screen, notebook):
             pass
     ttk.Checkbutton(row_focus, text="UI simplificada con overlays", variable=var_focus, command=on_toggle_focus).pack(side='left', padx=8)
 
+    # Mascota
+    row_masc = tk.Frame(inner, bg=COL_CARD)
+    row_masc.pack(fill='x', pady=6)
+    tk.Label(row_masc, text="Mascota:", bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 14)).pack(side='left')
+
+    var_person = tk.StringVar(value=str(screen.app.get_cfg().get('mascot_personality', 'normal')))
+    cb_person = ttk.Combobox(row_masc, textvariable=var_person, state='readonly', width=10,
+                             values=['off', 'discreto', 'normal', 'jugueton'])
+    cb_person.pack(side='left', padx=8)
+
+    def on_person_change(_e=None):
+        try:
+            cfg = screen.app.get_cfg(); cfg['mascot_personality'] = var_person.get(); screen.app.save_cfg()
+            screen.toast.show('Personalidad actualizada', 900)
+        except Exception:
+            pass
+
+    cb_person.bind("<<ComboboxSelected>>", on_person_change)
+
+    row_limit = tk.Frame(inner, bg=COL_CARD)
+    row_limit.pack(fill='x', pady=6)
+    tk.Label(row_limit, text='Límite/hora:', bg=COL_CARD, fg=COL_TEXT).pack(side='left')
+    var_lim = tk.IntVar(value=int(screen.app.get_cfg().get('mascot_limit_hour', 10)))
+    ent_lim = tk.Entry(row_limit, textvariable=var_lim, width=4)
+    bind_numeric_entry(ent_lim)
+    ent_lim.pack(side='left', padx=8)
+
+    def on_save_lim():
+        try:
+            cfg = screen.app.get_cfg(); cfg['mascot_limit_hour'] = int(var_lim.get()); screen.app.save_cfg()
+            screen.toast.show('Límite guardado', 900)
+        except Exception:
+            pass
+
+    tk.Button(row_limit, text='Guardar', command=on_save_lim, bg=COL_ACCENT, fg='white', bd=0, relief='flat', cursor='hand2').pack(side='left')
+
+    row_nm = tk.Frame(inner, bg=COL_CARD)
+    row_nm.pack(fill='x', pady=6)
+    tk.Label(row_nm, text='No molestar:', bg=COL_CARD, fg=COL_TEXT).pack(side='left')
+    var_nm = tk.BooleanVar(value=bool(screen.app.get_cfg().get('mascot_no_molestar', False)))
+
+    def on_nm():
+        try:
+            cfg = screen.app.get_cfg(); cfg['mascot_no_molestar'] = bool(var_nm.get()); screen.app.save_cfg()
+            screen.toast.show('No molestar: ' + ('ON' if cfg['mascot_no_molestar'] else 'OFF'), 900)
+        except Exception:
+            pass
+
+    ttk.Checkbutton(row_nm, text='Activado', variable=var_nm, command=on_nm).pack(side='left', padx=8)
+
+    row_llm = tk.Frame(inner, bg=COL_CARD)
+    row_llm.pack(fill='x', pady=6)
+    tk.Label(row_llm, text='LLM:', bg=COL_CARD, fg=COL_TEXT).pack(side='left')
+    var_llm = tk.BooleanVar(value=bool(screen.app.get_cfg().get('mascot_llm_enabled', False)))
+
+    def on_llm():
+        try:
+            cfg = screen.app.get_cfg(); cfg['mascot_llm_enabled'] = bool(var_llm.get()); screen.app.save_cfg()
+            if cfg['mascot_llm_enabled']:
+                screen.toast.show('Recuerda consentimiento para datos BG', 1600)
+        except Exception:
+            pass
+
+    ttk.Checkbutton(row_llm, text='Activado', variable=var_llm, command=on_llm).pack(side='left', padx=8)
+
+    var_sendbg = tk.BooleanVar(value=bool(screen.app.get_cfg().get('mascot_llm_send_bg', False)))
+
+    def on_sendbg():
+        try:
+            cfg = screen.app.get_cfg(); cfg['mascot_llm_send_bg'] = bool(var_sendbg.get()); screen.app.save_cfg()
+        except Exception:
+            pass
+
+    ttk.Checkbutton(row_llm, text='Enviar BG', variable=var_sendbg, command=on_sendbg).pack(side='left', padx=8)
+
     # Sonido: toggle + tema + probar
     row1 = tk.Frame(inner, bg=COL_CARD)
     row1.pack(fill="x", pady=6)

--- a/bascula/ui/widgets_mascota.py
+++ b/bascula/ui/widgets_mascota.py
@@ -1,3 +1,71 @@
-from .widgets import Mascot as MascotaCanvas
+from __future__ import annotations
+
+from .widgets import Mascot, COL_ACCENT
+
+
+class MascotaCanvas(Mascot):
+    """Mascota con animaciones simples (shake, wink, bounce)."""
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(parent, **kwargs)
+        self._orig_pos = None
+
+    # ---- Animaciones -------------------------------------------------
+    def shake(self, dist: int = 10, times: int = 4, delay: int = 50):
+        info = self.place_info()
+        x = int(info.get("x", 0))
+        y = int(info.get("y", 0))
+
+        def step(i=0):
+            if i >= times * 2:
+                self.place(x=x, y=y)
+                return
+            dx = dist if i % 2 == 0 else -dist
+            self.place(x=x + dx, y=y)
+            self.after(delay, step, i + 1)
+
+        step()
+
+    def bounce(self, height: int = 20, delay: int = 40):
+        info = self.place_info()
+        x = int(info.get("x", 0))
+        y = int(info.get("y", 0))
+
+        def up(i=0):
+            if i >= height:
+                down()
+                return
+            self.place(x=x, y=y - i)
+            self.after(delay, up, i + 4)
+
+        def down(i=height):
+            if i <= 0:
+                self.place(x=x, y=y)
+                return
+            self.place(x=x, y=y - i)
+            self.after(delay, down, i - 4)
+
+        up()
+
+    def wink(self, duration_ms: int = 400):
+        old = self.state
+        self.state = "wink"
+        self._render()
+        self.after(duration_ms, lambda: (setattr(self, "state", old), self._render()))
+
+    # Override render to support wink state
+    def _render(self):
+        super()._render()
+        if self.state == "wink":
+            w = self.winfo_width() or self.size
+            h = self.winfo_height() or self.size
+            cx, cy = w // 2, h // 2
+            r = min(w, h) // 5
+            # cubre ojo derecho y dibuja línea
+            self.create_rectangle(cx + r//2 - 8, cy - r, cx + r//2, cy - r + 8,
+                                  fill=self["bg"], outline=self["bg"])
+            self.create_line(cx + r//2 - 8, cy - r + 4, cx + r//2, cy - r + 4,
+                              fill=COL_ACCENT, width=2)
+
 
 __all__ = ["MascotaCanvas"]


### PR DESCRIPTION
## Summary
- add simple EventBus and MascotBrain with optional LLM stub
- support message animations/actions and mascot shake/wink/bounce
- add mascot controls in settings and wire events in app

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f8c3149c83268cc05655176b7038