### PR TITLE
Add event-driven mascot brain with LLM and settings

### DIFF
--- a/bascula/services/llm_client.py
+++ b/bascula/services/llm_client.py
@@ -1,0 +1,43 @@
+"""Small provider‑agnostic LLM client wrapper.
+
+This module defines :class:`LLMClient`, a very light facade used by the
+``MascotBrain``.  It merely stores an API key and exposes a ``generate``
+method.  Real implementations can subclass this class and override
+``generate`` to call a remote provider.  The key is obtained from the
+configuration or from environment variables so tests can run without
+network access.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+class LLMClient:
+    """Minimal LLM client.
+
+    Parameters
+    ----------
+    api_key:
+        Optional API key.  If not provided, ``LLM_API_KEY`` from the
+        environment is used.  This class does not perform any network call; it
+        simply stores the key and returns empty strings when ``generate`` is
+        invoked.
+    """
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.getenv("LLM_API_KEY") or ""
+
+    def generate(self, prompt: str) -> str:
+        """Return a completion for *prompt*.
+
+        The base implementation is a stub returning an empty string.  Real
+        integrations should override this method.
+        """
+
+        return ""
+
+
+__all__ = ["LLMClient"]
+

--- a/bascula/ui/overlay_scanner.py
+++ b/bascula/ui/overlay_scanner.py
@@ -153,6 +153,10 @@ class ScannerOverlay(OverlayBase):
         self._on_result(code)
         self.after(450, self.hide)
         try:
+            self.app.event_bus.publish("SCANNER_DETECTED")
+        except Exception:
+            pass
+        try:
             self.app.messenger.show(MSGS["scanner_detected"](), kind='success', priority=5, icon='✅')
         except Exception:
             pass

--- a/bascula/ui/overlay_weight.py
+++ b/bascula/ui/overlay_weight.py
@@ -138,6 +138,10 @@ class WeightOverlay(OverlayBase):
             self.app.messenger.show(MSGS["tara_applied"](), kind="info", priority=4, icon="ℹ️")
         except Exception:
             pass
+        try:
+            self.app.event_bus.publish("TARA")
+        except Exception:
+            pass
 
     def _on_zero(self):
         try:
@@ -159,6 +163,10 @@ class WeightOverlay(OverlayBase):
         self._autocap_debounce_until = time.time() + 0.5
         try:
             self.app.messenger.show(MSGS["zero_applied"](), kind="info", priority=4, icon="ℹ️")
+        except Exception:
+            pass
+        try:
+            self.app.event_bus.publish("TARA")
         except Exception:
             pass
 
@@ -259,6 +267,11 @@ class WeightOverlay(OverlayBase):
             pass
         self.last_captured_weight = self._get_weight()
         self._autocap_debounce_until = time.time() + 1.5
+        try:
+            self.app.last_capture_g = float(delta_g)
+            self.app.event_bus.publish("WEIGHT_CAPTURED", float(delta_g))
+        except Exception:
+            pass
         try:
             if getattr(self.app, "sound_on", True) and getattr(self.app, "audio", None):
                 self.app.audio.play_event("preset_added")


### PR DESCRIPTION
## Summary
- Introduce event-driven mascot brain that reacts to app events, supports personalities and optional LLM prompts.
- Wire application and widgets to publish events such as scanner detections, weight captures and BG updates.
- Expand settings with mascot controls, LLM options and API key field; provide generic LLM client stub.

## Testing
- `python -m py_compile bascula/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7fccad6d083269a059fdd8f7a7b9f