### PR TITLE
Fix Piper installation flow

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Forward TARGET_USER if provided, else let install-all.sh default to SUDO_USER or pi
 if [[ -n "${TARGET_USER:-}" ]]; then
   exec sudo PHASE=1 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Forward TARGET_USER if provided, else let install-all.sh default to SUDO_USER or pi
 if [[ -n "${TARGET_USER:-}" ]]; then
   exec sudo PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -134,8 +134,10 @@ else
   log "Usuario pi añadido a grupos audio,video,input"
 fi
 
-# Instala Piper y la voz por defecto (PIPER_VOICE=es_ES-sharvard-medium)
-PIPER_VOICE="${PIPER_VOICE:-es_ES-sharvard-medium}" bash "$SCRIPT_DIR/install-piper-voices.sh"
+# Instala Piper y la voz por defecto (PIPER_VOICE=es_ES-sharvard-medium) solo en fase 2
+if [[ "${PHASE:-all}" != "1" ]]; then
+  PIPER_VOICE="${PIPER_VOICE:-es_ES-sharvard-medium}" bash "$SCRIPT_DIR/install-piper-voices.sh"
+fi
 
 # Configura ALSA default para MAX98357A si se solicita
 if [[ "$AUDIO_ARG" == "max98357a" ]]; then

--- a/scripts/install-piper-voices.sh
+++ b/scripts/install-piper-voices.sh
@@ -15,23 +15,46 @@ VOICES_BASE="${VOICES_BASE:-https://github.com/bascula-cam/voices/releases/downl
 DEST="/opt/piper/models"
 install -d -m 0755 "$DEST"
 
-# --- Piper binary ---
-if ! command -v piper >/dev/null 2>&1; then
-  arch="$(uname -m)"
+TMPDIR=""
+cleanup_tmpdir() {
+  if [[ -n "${TMPDIR}" && -d "${TMPDIR}" ]]; then
+    rm -rf "${TMPDIR}"
+  fi
+  TMPDIR=""
+}
+trap cleanup_tmpdir EXIT
+
+install_piper() {
+  if command -v piper >/dev/null 2>&1; then
+    log "Piper ya está instalado"
+    return 0
+  fi
+
+  local arch="$(uname -m)"
+  local tarball
   case "$arch" in
-    aarch64) BIN="piper_linux_aarch64";;
-    armv7l|armv8l|armv6l) BIN="piper_linux_armv7";;
-    x86_64) BIN="piper_linux_x86_64";;
-    *) err "Arquitectura no soportada: $arch"; exit 1;;
+    aarch64) tarball="piper_linux_aarch64" ;;
+    armv7l|armv8l|armv6l) tarball="piper_linux_armv7" ;;
+    x86_64) tarball="piper_linux_x86_64" ;;
+    *) err "Arquitectura no soportada: $arch"; return 1 ;;
   esac
-  tmp="$(mktemp -d)"
-  curl -fsSL "https://github.com/rhasspy/piper/releases/latest/download/${BIN}.tar.gz" | tar -xz -C "$tmp"
-  install -m 0755 "$tmp/piper" /usr/local/bin/piper
-  rm -rf "$tmp"
+
+  TMPDIR="$(mktemp -d)"
+
+  curl -fsSL "https://github.com/rhasspy/piper/releases/latest/download/${tarball}.tar.gz" \
+    | tar -xz -C "${TMPDIR}"
+
+  local piper_bin
+  piper_bin="$(find "${TMPDIR}" -type f -name piper -perm -111 | head -n1 || true)"
+  if [[ -z "$piper_bin" ]]; then
+    err "No se encontró el binario de Piper dentro del tar"
+    return 1
+  fi
+
+  install -Dm 0755 "$piper_bin" /usr/local/bin/piper
+  cleanup_tmpdir
   log "Piper instalado en /usr/local/bin"
-else
-  log "Piper ya está instalado"
-fi
+}
 
 VOICE_ONNX="${DEST}/${PIPER_VOICE}.onnx"
 VOICE_JSON="${DEST}/${PIPER_VOICE}.onnx.json"
@@ -42,15 +65,14 @@ get_from_base(){
   curl -fsSL --retry 3 -o "$VOICE_JSON" "${base}/${PIPER_VOICE}.onnx.json" || return 1
 }
 
+install_piper
+
 if get_from_base "$VOICES_BASE"; then
   log "Voz ${PIPER_VOICE} descargada desde Release"
 else
   warn "Voz no encontrada en Release; usando HuggingFace"
-  locale="${PIPER_VOICE%%-*}"
-  rest="${PIPER_VOICE#*-}"
-  quality="${rest##*-}"
-  corpus="${rest%-${quality}}"
-  HF_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main/es/${locale}/${corpus}/${quality}"
+  lang="${PIPER_VOICE%%_*}"
+  HF_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/main/${lang}/${PIPER_VOICE}"
   if get_from_base "$HF_BASE"; then
     log "Voz ${PIPER_VOICE} descargada desde HuggingFace"
   else


### PR DESCRIPTION
## Summary
- ensure the phase 1 system script only delegates without touching Piper assets
- guard Piper installation in the shared installer so it only runs during phase 2
- harden Piper installer to extract the correct binary, clean up temporary files, and fall back to HuggingFace voice downloads when the release asset is missing

## Testing
- bash -n scripts/install-1-system.sh
- bash -n scripts/install-2-app.sh
- bash -n scripts/install-all.sh
- bash -n scripts/install-piper-voices.sh

------
https://chatgpt.com/codex/tasks/task_e_68c83a6f89b88326a5e5a6d354361689