### PR TITLE
Ensure Piper voices use release source only

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-# Forward TARGET_USER if provided, else let install-all.sh default to SUDO_USER or pi
+
+STATUS=0
 if [[ -n "${TARGET_USER:-}" ]]; then
-  exec sudo PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
+  if ! sudo PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"; then
+    STATUS=$?
+  fi
 else
-  exec sudo PHASE=2 bash "${SCRIPT_DIR}/install-all.sh" "$@"
+  if ! sudo PHASE=2 bash "${SCRIPT_DIR}/install-all.sh" "$@"; then
+    STATUS=$?
+  fi
 fi
+
+if [[ ${STATUS} -eq 0 ]]; then
+  cat <<'EOF'
+[info] Prueba de aceptación: ejecuta estos comandos tras la instalación
+which piper && ls -lh /opt/piper/models
+echo 'Hola' | piper -m /opt/piper/models/${PIPER_VOICE}.onnx -f /tmp/tts.wav && aplay /tmp/tts.wav
+EOF
+fi
+
+exit "${STATUS}"


### PR DESCRIPTION
## Summary
- update the Piper voice installer to only allow the three supported Spanish models from the project release bucket and add stricter download validation
- install the Piper binary using the extracted executable from the architecture-specific tarball and set the default voice after successful downloads
- keep the phase-2 wrapper script but show the acceptance commands after a successful installation run

## Testing
- bash -n scripts/install-2-app.sh
- bash -n scripts/install-piper-voices.sh

------
https://chatgpt.com/codex/tasks/task_e_68c83dd6a7088326be8f340dd49ea25a