### PR TITLE
Fix Piper installation and ALSA defaults

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -156,10 +156,15 @@ if [[ "${DO_CORE}" == "true" ]]; then
     libjpeg-dev zlib1g-dev libpng-dev
     alsa-utils sox ffmpeg
     libzbar0 gpiod python3-rpi.gpio
-    network-manager sqlite3 tesseract-ocr tesseract-ocr-spa espeak-ng
-    patchelf
+    network-manager sqlite3 tesseract-ocr tesseract-ocr-spa espeak-ng espeak-ng-data
+    patchelf jq
   )
   apt-get install -y "${APT_PACKAGES[@]}"
+  if dpkg -s espeak-ng-data >/dev/null 2>&1; then
+    log espeak "espeak-ng-data instalado"
+  else
+    log espeak "espeak-ng-data no se pudo instalar"
+  fi
 
   CONFIG_FILE="/boot/firmware/config.txt"
   if [[ ! -f "${CONFIG_FILE}" ]]; then

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -6,8 +6,9 @@ After=network-online.target sound.target
 User=pi
 Group=audio
 WorkingDirectory=%h/bascula-cam
-# Opcional: forzar tarjeta (comentado por defecto)
-# Environment=BASCULA_APLAY_DEVICE=plughw:MAX98357A,0
+# Opcional: forzar dispositivo ALSA (comentado por defecto)
+# Environment=BASCULA_APLAY_DEVICE=plughw:1,0
+Environment=ESPEAK_DATA_PATH=/usr/share/espeak-ng-data
 Environment=BASCULA_CFG_DIR=%h/.config/bascula
 ExecStart=/bin/bash -lc 'if [ -x %h/bascula-cam/.venv/bin/python ]; then %h/bascula-cam/.venv/bin/python %h/bascula-cam/main.py; else python3 %h/bascula-cam/main.py; fi'
 Restart=on-failure


### PR DESCRIPTION
## Summary
- ensure espeak-ng-data is installed alongside other system dependencies and log its status
- update the application installer to fetch the correct Piper archive, install its libraries with ldconfig, wrap the binary to export ESPEAK_DATA_PATH, and configure ALSA for card 1, device 0
- set the bascula-ui service environment for ESPEAK data and correct the optional ALSA override comment

## Testing
- bash -n scripts/install-1-system.sh
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68c84d0a40e4832690445cf608ba996b