### PR TITLE
Fix pip invocation in installer script

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -110,10 +110,10 @@ else
 fi
 
 log INFO "Actualizando pip/setuptools/wheel"
-run_as_target "${VENV_PATH}/bin/pip" install --upgrade pip setuptools wheel
+run_as_target "${VENV_PATH}/bin/python" -m pip install --upgrade pip setuptools wheel
 if [[ -f "${APP_DIR}/requirements.txt" ]]; then
   log INFO "Instalando dependencias desde requirements.txt"
-  run_as_target "${VENV_PATH}/bin/pip" install -r "${APP_DIR}/requirements.txt"
+  run_as_target "${VENV_PATH}/bin/python" -m pip install -r "${APP_DIR}/requirements.txt"
 else
   log WARN "No se encontró requirements.txt; omitiendo instalación"
 fi


### PR DESCRIPTION
## Summary
- update the installer to invoke pip through the venv python interpreter
- ensure both upgrade and requirements installs use `python -m pip`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8562885488326b009a86c773dddd0