### PR TITLE
Fix bascula-ui service configuration and installer

### DIFF
--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -5,14 +5,15 @@ After=network-online.target sound.target
 [Service]
 User=pi
 Group=audio
-WorkingDirectory=%h/bascula-cam
+WorkingDirectory=/home/pi/bascula-cam
 # Opcional: forzar tarjeta (comentado por defecto)
 # Environment=BASCULA_APLAY_DEVICE=plughw:1,0
 Environment=BASCULA_CFG_DIR=%h/.config/bascula
 ExecStart=/bin/bash -lc 'if [ -x %h/bascula-cam/.venv/bin/python ]; then %h/bascula-cam/.venv/bin/python %h/bascula-cam/main.py; else python3 %h/bascula-cam/main.py; fi'
 Restart=on-failure
 RestartSec=3
-DeviceAllow=char-116:*    # /dev/snd/*
+# Permitir acceso a /dev/snd/*
+DeviceAllow=char-116:*
 
 [Install]
 WantedBy=graphical.target multi-user.target


### PR DESCRIPTION
## Summary
- set an absolute working directory and valid DeviceAllow in the bascula-ui service file
- update the install script to sync into the app directory, apply audio group ownership, and reload/enable the service reliably

## Testing
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68c85880215083268b9294fb84ef369a