### PR TITLE
Make project installable as editable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Estructura:
 - docs/SETUP_XINITRC.md: guía para arrancar la UI sin LightDM usando .xinitrc y autologin en tty1.
 - docs/INSTALL_STEP_BY_STEP.md: guía paso a paso (mini-web + UI con .xinitrc).
 - docs/MINIWEB_OVERRIDE.md: override menos estricto (0.0.0.0) y notas.
+
+## Testing
+
+```bash
+source .venv/bin/activate
+python -m pip install -e .
+python -m pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bascula-cam"
+version = "0.0.0"
+description = "Báscula con cámara y TTS Piper"
+requires-python = ">=3.11"
+dependencies = []
+
+[tool.setuptools]
+packages = ["bascula"]
+include-package-data = true

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -128,6 +128,17 @@ else
   log WARN "No se encontró requirements.txt; omitiendo instalación"
 fi
 
+log INFO "Instalando bascula-cam en modo editable"
+run_as_target "${VENV}/bin/python" -m pip install -e "${APP_DIR}"
+
+if [[ -f "${APP_DIR}/pyproject.toml" && -d "${APP_DIR}/tests" ]]; then
+  echo "[test] Ejecutando pytest..."
+  run_as_target "${VENV}/bin/python" -m pip install -U pytest
+  if ! run_as_target "${VENV}/bin/python" -m pytest -q "${APP_DIR}/tests"; then
+    echo "[warn] pytest falló (no bloquea la instalación)"
+  fi
+fi
+
 SERVICE_SRC="${REPO_ROOT}/systemd/bascula-ui.service"
 SERVICE_DST="/etc/systemd/system/bascula-ui.service"
 if [[ ! -f "${SERVICE_SRC}" ]]; then


### PR DESCRIPTION
## Summary
- add a setuptools-based pyproject so the bascula code can be installed as a package
- update install-2-app.sh to install the package in editable mode and optionally run pytest
- document the editable install and pytest workflow in the README

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c85d0b0ebc832686ea3022861f4300