### PR TITLE
Replace Tkinter app implementation

### DIFF
--- a/bascula/main.py
+++ b/bascula/main.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import logging
+from bascula.ui.app import BasculaApp
+
+def main():
+    logging.basicConfig(level=logging.INFO,
+                        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s')
+    app = BasculaApp(theme='modern')
+    logging.getLogger(__name__).info("UI inicializada. Entrando en mainloop()")
+    app.run()
+
+if __name__ == '__main__':
+    main()

--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -1,63 +1,39 @@
-from __future__ import annotations
-
-"""Entry point for the redesigned Bascula-Cam UI."""
-
-import logging
+# -*- coding: utf-8 -*-
 import tkinter as tk
 import time
+import logging
+
 from bascula.config.theme import apply_theme, get_current_colors
 from bascula.ui.widgets import TopBar
 from bascula.ui.widgets_mascota import MascotaCanvas
-from bascula.ui import screens
-from bascula.ui.overlay_recipe import RecipeOverlay
-from bascula.ui.mascot_messages import MascotMessenger, MSGS
-from bascula.services.bg_monitor import BgMonitor
+# Intento de importar pantallas reales; si falla, usaremos placeholders
+try:
+    from bascula.ui import screens  # HomeScreen, ScaleScreen, ScannerScreen, SettingsScreen, TimerPopup
+    _ = (screens.HomeScreen, screens.ScaleScreen, screens.ScannerScreen, screens.SettingsScreen)
+except Exception:
+    screens = None
+
+from bascula.ui.mascot_messages import MascotMessenger
 from bascula.services.event_bus import EventBus
 from bascula.services.mascot_brain import MascotBrain
 from bascula.services.llm_client import LLMClient
 from bascula.state import AppState
 
-
 logger = logging.getLogger(__name__)
 
 
 class BasculaApp:
+    """App principal Tkinter de Bascula-Cam (versión robusta)"""
+
     def __init__(self, theme: str = 'modern') -> None:
+        # Raíz y tema
         self.root = tk.Tk()
         self.root.title('Báscula Cam')
-        self.root.configure(bg="#111")
-        self.theme_name = theme
-        apply_theme(self.root, theme)
+        self.root.geometry('1024x600')
 
-        pal = get_current_colors()
-        self.topbar = TopBar(self.root, app=self)
-        self.topbar.pack(fill='x')
-
-        self.screen_container = tk.Frame(self.root, bg=pal['COL_BG'])
-
-        self._boot_label = tk.Label(
-            self.root,
-            text="Cargando Báscula…",
-            fg="#EEE",
-            bg="#111",
-            font=("DejaVu Sans", 20),
-        )
-        self._boot_label.pack(expand=True, fill="both")
-
-        self.mascot_host = tk.Frame(self.screen_container, bg=pal['COL_BG'])
-        self.mascot_host.place(relx=0, rely=0, relwidth=1, relheight=1)
-        self.mascot = MascotaCanvas(self.mascot_host, width=300, height=300, with_legs=True)
-        self.mascot.place(x=0, y=0)
-
-        self.messenger = MascotMessenger(
-            get_mascot_widget=lambda: self.current_mascot_widget(),
-            get_topbar=lambda: getattr(self, "topbar", None),
-            theme_colors=pal,
-        )
-
-        self.event_bus = EventBus()
-        # Initialize state-related attributes before accessing configuration
+        # Estado y propiedades base
         self.state = AppState()
+        self.screens = {}
         self.current_screen = None
         self.current_screen_name = "home"
         self.sound_on = True
@@ -67,91 +43,67 @@ class BasculaApp:
         self.diabetic_mode = False
         self.auto_capture_enabled = True
         self.auto_capture_min_delta_g = 8.0
-        self.bg_monitor: BgMonitor | None = None
-        self._recipe_overlay: RecipeOverlay | None = None
+        self.bg_monitor = None
+        self._recipe_overlay = None
         self._last_low_alarm_ts = 0.0
         self._last_high_alarm_ts = 0.0
         self._last_nightscout_err_ts = 0.0
         self.last_capture_g = None
         self.bg_value = None
         self.bg_trend = None
+        self.reader = None
+        self.tare_manager = None
+        self.camera = None
+        self.audio = None
 
-        self._diagnostics_overlay: tk.Toplevel | None = None
+        # Tema y fondo
+        self.theme_name = theme
+        apply_theme(self.root, theme)
+        pal = get_current_colors()
+        self.root.configure(bg=pal['COL_BG'])
+
+        # Topbar + contenedor principal
+        self.topbar = TopBar(self.root, app=self)
+        self.topbar.pack(fill='x')
+        self.screen_container = tk.Frame(self.root, bg=pal['COL_BG'])
+        self.screen_container.pack(fill='both', expand=True)
+
+        # Host de mascota por encima de pantallas
+        self.mascot_host = tk.Frame(self.screen_container, bg='')
+        self.mascot_host.place(relx=0, rely=0, relwidth=1, relheight=1)
+        self.mascot_host.lower()
+        self.mascot = MascotaCanvas(self.mascot_host, width=300, height=300, with_legs=True)
+        self.mascot.place(x=362, y=150)
+
+        # Messenger/brain/eventos/LLM tolerante
+        self.messenger = MascotMessenger(
+            get_mascot_widget=lambda: self.current_mascot_widget(),
+            get_topbar=lambda: getattr(self, "topbar", None),
+            theme_colors=pal,
+        )
+        self.event_bus = EventBus()
         try:
-            self.root.bind("<Control-d>", self._toggle_diagnostics_overlay)
-            self.root.bind("<Control-D>", self._toggle_diagnostics_overlay)
+            api_key = self.get_cfg().get("llm_api_key")
+            self.llm_client = LLMClient(api_key) if api_key else None
         except Exception:
-            pass
-
-        self.llm_client = LLMClient(self.get_cfg().get("llm_api_key"))
+            self.llm_client = None
         self.mascot_brain = MascotBrain(self, self.event_bus)
 
-        logger.info("Creando pantalla inicial…")
-        try:
-            self.show_main()
-        except Exception as exc:
-            logger.exception("Error al crear la pantalla inicial")
-            self._display_boot_error(exc)
-        else:
-            logger.info("Pantalla inicial mostrada")
+        # Fallback visual para evitar blanco
+        self._boot_label = tk.Label(self.root, text="Cargando Báscula…",
+                                    fg="#EEE", bg=pal['COL_BG'], font=("DejaVu Sans", 20))
+        self._boot_label.pack(expand=True, fill="both")
+
+        # Servicios tolerantes
+        self._init_services()
+
+        # Pantalla inicial + idle
+        self.show_screen('home')
         self.root.after(20000, self._idle_tick)
 
-    # ----- screen management ------------------------------------------
-    def _set_screen(self, scr: tk.Frame) -> None:
-        if not self.screen_container.winfo_ismapped():
-            try:
-                self.screen_container.pack(fill='both', expand=True)
-            except Exception:
-                pass
-        if self.current_screen is not None:
-            self.current_screen.destroy()
-        self.current_screen = scr
-        self.current_screen.pack(fill='both', expand=True)
-        self._remove_boot_label()
-        self.mascot_host.lift()
-        self.current_screen_name = getattr(scr, "name", scr.__class__.__name__)
-
-    def show_main(self) -> None:
-        self.topbar.set_message('')
-        self._set_screen(screens.HomeScreen(self.screen_container, self))
-        x, y = self._center_coords(300)
-        self.mascot.animate_to(self.mascot_host, x, y, 300)
-
-    def show_scale(self) -> None:
-        self.topbar.set_message('')
-        x, y = self._corner_coords()
-        self.mascot.animate_to(self.mascot_host, x, y, 140)
-        self._set_screen(screens.ScaleScreen(self.screen_container, self))
-
-    def show_scanner(self) -> None:
-        self.topbar.set_message('Acerca un código...')
-        x, y = self._corner_coords()
-        self.mascot.animate_to(self.mascot_host, x, y, 140)
-        self._set_screen(screens.ScannerScreen(self.screen_container, self))
-        self.event_bus.publish("SCANNER_OPEN")
-
-    def show_settings(self) -> None:
-        self.topbar.set_message('Ajustes')
-        x, y = self._corner_coords()
-        self.mascot.animate_to(self.mascot_host, x, y, 140)
-        self._set_screen(screens.SettingsScreen(self.screen_container,
-                                               self,
-                                               self.get_state, self.set_state,
-                                               self.change_theme, self.show_main))
-
-    def _center_coords(self, size: int) -> tuple[int, int]:
-        self.root.update_idletasks()
-        w = self.screen_container.winfo_width()
-        h = self.screen_container.winfo_height()
-        return (w - size) // 2, (h - size) // 2
-
-    def _corner_coords(self, size: int = 140) -> tuple[int, int]:
-        self.root.update_idletasks()
-        w = self.screen_container.winfo_width()
-        return w - size - 16, 16
-
+    # ---------- helpers mascota ----------
     def current_mascot_widget(self):
-        """Return the mascot widget currently in use."""
+        """Return the current mascot widget for messenger"""
         if self.current_screen is not None:
             for attr in ("mascot", "mascota"):
                 widget = getattr(self.current_screen, attr, None)
@@ -159,51 +111,199 @@ class BasculaApp:
                     return widget.as_widget() if hasattr(widget, "as_widget") else widget
         return self.mascot
 
-    # ----- idle ticker -----------------------------------------------
-    def _idle_tick(self) -> None:
+    # ---------- servicios ----------
+    def _init_services(self):
+        cfg = self.get_cfg()
+        # Báscula
         try:
-            self.event_bus.publish("IDLE_TICK")
-        except Exception:
-            pass
+            from bascula.services.scale import ScaleService
+            self.reader = ScaleService(port=cfg.get('port', '/dev/serial0'),
+                                       baud=cfg.get('baud', 115200),
+                                       fail_fast=False)
+            self.reader.start()
+        except Exception as e:
+            logger.warning(f"Scale service not available: {e}")
+            self.reader = None
+        # Tara
         try:
-            self.root.after(20000, self._idle_tick)
-        except Exception:
-            pass
+            from bascula.services.tare_manager import TareManager
+            self.tare_manager = TareManager(calib_factor=cfg.get('calib_factor', 1.0),
+                                            min_display=0.0)
+        except Exception as e:
+            logger.warning(f"Tare manager not available: {e}")
+            self.tare_manager = None
+        # Audio
+        try:
+            from bascula.services.audio import AudioService
+            self.audio = AudioService(cfg, logger)
+        except Exception as e:
+            logger.warning(f"Audio service not available: {e}")
+            self.audio = None
+        # Cámara
+        try:
+            from bascula.services.camera import CameraService
+            self.camera = CameraService()
+        except Exception as e:
+            logger.warning(f"Camera service not available: {e}")
+            self.camera = None
 
-    # ----- callbacks from buttons ------------------------------------
-    def open_timer_popup(self) -> None:
-        screens.TimerPopup(self)
+    # ---------- pantallas / navegación ----------
+    def _set_screen(self, scr: tk.Frame) -> None:
+        if self.current_screen is not None:
+            try:
+                if hasattr(self.current_screen, 'on_hide'):
+                    self.current_screen.on_hide()
+            except Exception:
+                pass
+            self.current_screen.destroy()
+        self.current_screen = scr
+        self.current_screen.pack(fill='both', expand=True)
+        # quita fallback
+        if getattr(self, "_boot_label", None):
+            self._boot_label.destroy()
+            self._boot_label = None
+        # mascota por encima
+        self.mascot_host.lift()
+        self.current_screen_name = getattr(scr, "name", scr.__class__.__name__)
 
-    def open_scanner(self) -> None:
-        self.show_scanner()
+    def show_screen(self, screen_name: str):
+        try:
+            if screen_name not in self.screens:
+                self._create_screen(screen_name)
+            scr = self.screens.get(screen_name)
+            if scr is None:
+                pal = get_current_colors()
+                f = tk.Frame(self.screen_container, bg=pal['COL_BG'])
+                tk.Label(f, text=f"{screen_name} no disponible", fg="#EEE",
+                         bg=pal['COL_BG']).pack(pady=20)
+                self.screens[screen_name] = f
+                scr = f
+            self._set_screen(scr)
+            if hasattr(scr, 'on_show'):
+                scr.on_show()
+        except Exception as e:
+            logger.error(f"Failed to show screen {screen_name}: {e}")
+            pal = get_current_colors()
+            f = tk.Frame(self.screen_container, bg=pal['COL_BG'])
+            tk.Label(f, text=f"Error mostrando {screen_name}", fg="#EEE",
+                     bg=pal['COL_BG']).pack(pady=20)
+            self._set_screen(f)
 
-    def open_settings(self) -> None:
-        self.show_settings()
+    def _create_screen(self, screen_name: str):
+        try:
+            if screen_name == 'home':
+                if self.get_cfg().get('focus_mode', True):
+                    from bascula.ui.focus_screen import FocusScreen
+                    self.screens[screen_name] = FocusScreen(self.screen_container, self)
+                else:
+                    if screens:
+                        self.screens[screen_name] = screens.HomeScreen(self.screen_container, self)
+            elif screen_name == 'scale' and screens:
+                self.screens[screen_name] = screens.ScaleScreen(self.screen_container, self)
+            elif screen_name == 'scanner' and screens:
+                self.screens[screen_name] = screens.ScannerScreen(self.screen_container, self)
+            elif screen_name == 'settings' and screens:
+                self.screens[screen_name] = screens.SettingsScreen(
+                    self.screen_container, self,
+                    self.get_state, self.set_state,
+                    self.change_theme, lambda: self.show_screen('home')
+                )
+            elif screen_name == 'settingsmenu':
+                from bascula.ui.screens_tabs_ext import TabbedSettingsMenuScreen
+                self.screens[screen_name] = TabbedSettingsMenuScreen(self.screen_container, self)
+            elif screen_name == 'wifi':
+                from bascula.ui.screens_wifi import WifiScreen
+                self.screens[screen_name] = WifiScreen(self.screen_container, self)
+            elif screen_name == 'nightscout':
+                from bascula.ui.screens_nightscout import NightscoutScreen
+                self.screens[screen_name] = NightscoutScreen(self.screen_container, self)
+            elif screen_name == 'apikey':
+                from bascula.ui.screens_apikey import ApiKeyScreen
+                self.screens[screen_name] = ApiKeyScreen(self.screen_container, self)
+            elif screen_name == 'diabetes':
+                from bascula.ui.screens_diabetes import DiabetesSettingsScreen
+                self.screens[screen_name] = DiabetesSettingsScreen(self.screen_container, self)
+            elif screen_name == 'history':
+                from bascula.ui.history_screen import HistoryScreen
+                self.screens[screen_name] = HistoryScreen(self.screen_container, self)
+            elif screen_name == 'calib':
+                self.screens[screen_name] = self._create_calib_screen()
+        except Exception as e:
+            logger.error(f"Failed to create screen {screen_name}: {e}")
+            # show_screen se encargará del placeholder si hace falta
 
-    def open_recipes(self) -> None:
+    def _create_calib_screen(self):
+        pal = get_current_colors()
+        f = tk.Frame(self.screen_container, bg=pal['COL_BG'])
+        tk.Label(f, text="Calibración", fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 24)).pack(pady=20)
+        tk.Button(f, text="Volver", command=lambda: self.show_screen('settingsmenu')).pack()
+        return f
+
+    def show_main(self) -> None:
+        self.topbar.set_message('')
+        x, y = self._center_coords(300)
+        self.mascot.animate_to(self.mascot_host, x, y, 300)
+        self.show_screen('home')
+
+    def show_scale(self): self.show_screen('scale')
+    def show_scanner(self): self.show_screen('scanner')
+    def show_settings(self): self.show_screen('settingsmenu')
+
+    def open_timer_popup(self):
+        if screens and hasattr(screens, "TimerPopup"):
+            screens.TimerPopup(self)
+
+    def open_scanner(self): self.show_scanner()
+    def open_settings(self): self.show_settings()
+
+    def open_recipes(self):
         if self._recipe_overlay is None:
-            self._recipe_overlay = RecipeOverlay(self.root, self)
+            try:
+                from bascula.ui.overlay_recipe import RecipeOverlay
+                self._recipe_overlay = RecipeOverlay(self.root, self)
+            except Exception as e:
+                logger.warning(f"Recipe overlay not available: {e}")
+                return
         self._recipe_overlay.show()
 
-    def quit(self) -> None:  # exposed to button
-        self.root.destroy()
+    def _center_coords(self, size: int) -> tuple[int, int]:
+        self.root.update_idletasks()
+        w = self.screen_container.winfo_width() or 1024
+        h = self.screen_container.winfo_height() or 600
+        return (w - size) // 2, (h - size) // 2
 
-    # scale stubs ------------------------------------------------------
+    def _corner_coords(self, size: int = 140) -> tuple[int, int]:
+        self.root.update_idletasks()
+        w = self.screen_container.winfo_width() or 1024
+        return w - size - 16, 16
+
+    # ---------- acciones báscula ----------
     def zero_scale(self) -> None:
         if hasattr(self, 'messenger'):
-            self.messenger.show(MSGS["zero_applied"](), kind='info', priority=4, icon='ℹ️')
+            self.messenger.show("Cero aplicado", kind='info', priority=4, icon='ℹ️')
         self.event_bus.publish("TARA")
 
     def tare_scale(self) -> None:
         if hasattr(self, 'messenger'):
-            self.messenger.show(MSGS["tara_applied"](), kind='info', priority=4, icon='ℹ️')
+            self.messenger.show("Tara aplicada", kind='info', priority=4, icon='ℹ️')
         self.event_bus.publish("TARA")
 
     def toggle_unit(self) -> None:
-        if isinstance(self.current_screen, screens.ScaleScreen):
-            self.current_screen._toggle_unit()
+        if screens and isinstance(self.current_screen, getattr(screens, "ScaleScreen", tuple())):
+            try:
+                self.current_screen._toggle_unit()
+            except Exception:
+                pass
 
-    # ----- timer ------------------------------------------------------
+    def toggle_sound(self) -> None:
+        self.sound_on = not self.sound_on
+        try:
+            self.topbar.sound_btn.config(text='🔊' if self.sound_on else '🔇')
+        except Exception:
+            pass
+
+    # ---------- temporizador ----------
     def start_timer(self, seconds: int) -> None:
         self.timer_end = time.time() + seconds
         self.event_bus.publish("TIMER_STARTED", seconds)
@@ -212,228 +312,25 @@ class BasculaApp:
     def _update_timer(self) -> None:
         remaining = int(self.timer_end - time.time())
         if remaining <= 0:
-            self.topbar.set_timer('')
+            try:
+                self.topbar.set_timer('')
+            except Exception:
+                pass
             if self.timer_job:
-                self.root.after_cancel(self.timer_job)
+                try:
+                    self.root.after_cancel(self.timer_job)
+                except Exception:
+                    pass
             self.event_bus.publish("TIMER_FINISHED")
             return
         m, s = divmod(remaining, 60)
-        self.topbar.set_timer(f"{m:02d}:{s:02d}")
-        self.timer_job = self.root.after(1000, self._update_timer)
-
-    # ----- top bar helpers -------------------------------------------
-    def toggle_sound(self) -> None:
-        self.sound_on = not self.sound_on
-        self.topbar.sound_btn.config(text='🔊' if self.sound_on else '🔇')
-
-    # ----- settings helpers -----------------------------------------
-    def change_theme(self, name: str) -> None:
-        self.theme_name = name
-        apply_theme(self.root, name)
-        if hasattr(self, 'messenger'):
-            self.messenger.pal = get_current_colors()
-            self.messenger.scanlines = bool(self.get_cfg().get('theme_scanlines', False))
-        self.event_bus.publish("THEME_CHANGED", name)
         try:
-            self.root.event_generate('<<ThemeChanged>>', when='tail')
+            self.topbar.set_timer(f"{m:02d}:{s:02d}")
         except Exception:
             pass
+        self.timer_job = self.root.after(1000, self._update_timer)
 
-    def set_diabetic_mode(self, enabled: bool) -> None:
-        self.diabetic_mode = enabled
-        if not enabled:
-            if self.bg_monitor:
-                self.bg_monitor.stop()
-                self.bg_monitor = None
-            self.topbar.set_bg(None)
-        else:
-            interval = int(self.get_cfg().get('bg_poll_s', 60))
-            self.bg_monitor = BgMonitor(self, interval_s=interval)
-            self.bg_monitor.start()
-            self.topbar.set_bg('---')
-            if hasattr(self, 'messenger'):
-                self.messenger.show('Modo diabético activo.', kind='info', priority=4, icon='ℹ️')
-
-    def on_bg_update(self, value_mgdl: int, trend: str) -> None:
-        self.topbar.set_bg(str(value_mgdl), trend)
-        cfg = self.get_cfg()
-        low = int(cfg.get("bg_low_mgdl", 70))
-        high = int(cfg.get("bg_high_mgdl", 180))
-        self.bg_value = value_mgdl
-        self.bg_trend = trend
-        self.event_bus.publish("BG_UPDATE", {"bg": value_mgdl, "trend": trend})
-        if value_mgdl <= low:
-            self.event_bus.publish("BG_HYPO", value_mgdl)
-        elif value_mgdl >= low:
-            self.event_bus.publish("BG_NORMAL", value_mgdl)
-        low_cd = int(cfg.get("bg_low_cooldown_min", 10)) * 60
-        high_cd = int(cfg.get("bg_high_cooldown_min", 10)) * 60
-        now = time.time()
-        if value_mgdl < low:
-            if now - self._last_low_alarm_ts >= low_cd:
-                if getattr(self, "audio", None):
-                    self.audio.play_event("bg_low")
-                if hasattr(self, "messenger"):
-                    self.messenger.show("Glucosa baja", kind="warning", priority=7, icon="⚠️")
-                self._last_low_alarm_ts = now
-                self.start_hypo_flow(value_mgdl, trend)
-        elif value_mgdl > high:
-            if now - self._last_high_alarm_ts >= high_cd:
-                if getattr(self, "audio", None):
-                    self.audio.play_event("bg_high")
-                if hasattr(self, "messenger"):
-                    self.messenger.show("Glucosa alta", kind="warning", priority=6, icon="⚠️")
-                self._last_high_alarm_ts = now
-        else:
-            if getattr(self, "audio", None):
-                self.audio.play_event("bg_ok")
-        st = self.state
-        if st.hypo_modal_open and (low <= value_mgdl <= high):
-            st.hypo_modal_open = False
-            st.hypo_started_ts = None
-            if self.hypo_timer_job:
-                try:
-                    self.root.after_cancel(self.hypo_timer_job)
-                except Exception:
-                    pass
-                self.hypo_timer_job = None
-            try:
-                self.topbar.set_timer("")
-            except Exception:
-                pass
-            if hasattr(self, "messenger"):
-                self.messenger.show("Glucosa normalizada.", kind="success", priority=6, icon="✅")
-        if trend == "up":
-            if hasattr(self, "messenger"):
-                self.messenger.show("Flecha ↑, ojo con subidas.", kind="info", priority=2, icon="↗️")
-        elif trend == "down":
-            if hasattr(self, "messenger"):
-                self.messenger.show("Flecha ↓, prudencia.", kind="info", priority=2, icon="↘️")
-
-    def on_bg_error(self, msg: str):
-        now = time.time()
-        if now - getattr(self, "_last_nightscout_err_ts", 0.0) >= 300:
-            self._last_nightscout_err_ts = now
-            try:
-                self.messenger.show(msg, kind="info", priority=2, icon="ℹ️")
-            except Exception:
-                if hasattr(self, "topbar"):
-                    self.topbar.set_message(msg)
-
-    def start_hypo_flow(self, bg_value: int, trend: str):
-        st = self.state
-        if st.hypo_modal_open:
-            return
-        st.hypo_modal_open = True
-        st.hypo_started_ts = time.time()
-        st.hypo_cycle = st.hypo_cycle + 1
-        if hasattr(self, "messenger"):
-            self.messenger.show("Hipoglucemia: toma 15 g de HC rápidos.", kind="warning", priority=8, icon="🍬")
-        self._show_hypo_popup()
-
-    def _show_hypo_popup(self):
-        try:
-            import tkinter as tk
-            from bascula.ui.widgets import Card, BigButton, COL_BG, COL_CARD, COL_TEXT, COL_DANGER
-            top = tk.Toplevel(self.root)
-            top.title("Regla 15/15")
-            top.configure(bg=COL_BG)
-            card = Card(top)
-            card.pack(padx=10, pady=10)
-            tk.Label(
-                card,
-                text=(
-                    "Hipoglucemia detectada.\n"
-                    "Toma 15 g de HC de acción rápida (glucosa en gel, zumo, azúcar).\n"
-                    "Pulsa “He tomado 15 g” y espera 15 minutos. Luego vuelve a medir."
-                ),
-                bg=COL_CARD,
-                fg=COL_TEXT,
-                justify="left",
-                font=("DejaVu Sans", 16, "bold"),
-            ).pack(pady=6)
-            btns = tk.Frame(card, bg=COL_CARD)
-            btns.pack(pady=6)
-
-            BigButton(
-                btns,
-                text="He tomado 15 g",
-                command=lambda: (top.destroy(), self._start_15_timer()),
-            ).pack(side="left", padx=4)
-
-            def _cancel():
-                st = self.state
-                st.hypo_modal_open = False
-                st.hypo_started_ts = None
-                if getattr(self, "hypo_timer_job", None):
-                    try:
-                        self.root.after_cancel(self.hypo_timer_job)
-                    except Exception:
-                        pass
-                    self.hypo_timer_job = None
-                try:
-                    self.topbar.set_timer("")
-                except Exception:
-                    pass
-                if hasattr(self, "messenger"):
-                    self.messenger.show(
-                        "Flujo 15/15 cancelado.",
-                        kind="info",
-                        priority=5,
-                        icon="ℹ️",
-                    )
-                top.destroy()
-
-            BigButton(btns, text="Cancelar", command=_cancel, bg=COL_DANGER).pack(side="left", padx=4)
-            try:
-                top.lift()
-            except Exception:
-                pass
-        except Exception:
-            self.state.clear_hypo_flow()
-
-    def _start_15_timer(self):
-        if self.hypo_timer_job:
-            try:
-                self.root.after_cancel(self.hypo_timer_job)
-            except Exception:
-                pass
-            self.hypo_timer_job = None
-        end_ts = time.time() + 15 * 60
-
-        def tick():
-            remaining = int(end_ts - time.time())
-            if remaining <= 0:
-                try:
-                    self.topbar.set_timer("")
-                except Exception:
-                    pass
-                if hasattr(self, "messenger"):
-                    self.messenger.show("Revisa la glucosa.", kind="info", priority=7, icon="🩸")
-                self.hypo_timer_job = None
-                return
-            m, s = divmod(remaining, 60)
-            try:
-                self.topbar.set_timer(f"{m:02d}:{s:02d}")
-            except Exception:
-                pass
-            self.hypo_timer_job = self.root.after(1000, tick)
-
-        try:
-            self.topbar.set_timer("15:00")
-            self.hypo_timer_job = self.root.after(1000, tick)
-        except Exception:
-            self.hypo_timer_job = self.root.after(
-                15 * 60 * 1000,
-                lambda: self.messenger.show(
-                    "Revisa la glucosa.",
-                    kind="info",
-                    priority=7,
-                    icon="🩸",
-                ),
-            )
-
-    # ----- state helpers -------------------------------------------
+    # ---------- estado y tema ----------
     def get_state(self) -> dict:
         return {
             "theme": self.theme_name,
@@ -459,80 +356,151 @@ class BasculaApp:
             except Exception:
                 pass
 
-    def get_cfg(self) -> dict:
-        return self.get_state()
-
-    def save_cfg(self) -> None:
-        pass
-
-    # ----- boot helpers -----------------------------------------------
-    def _remove_boot_label(self) -> None:
-        lbl = getattr(self, "_boot_label", None)
-        if lbl is not None:
-            try:
-                lbl.destroy()
-            except Exception:
-                pass
-            self._boot_label = None
-
-    def _display_boot_error(self, exc: Exception) -> None:
-        message = f"Error al iniciar la pantalla: {exc}"
-        lbl = getattr(self, "_boot_label", None)
-        if lbl is None:
-            self._boot_label = tk.Label(
-                self.root,
-                text=message,
-                fg="#EEE",
-                bg="#111",
-                font=("DejaVu Sans", 14),
-                wraplength=600,
-                justify="center",
-            )
-            self._boot_label.pack(expand=True, fill="both")
-        else:
-            try:
-                lbl.configure(text=message)
-            except Exception:
-                pass
-
-    def _toggle_diagnostics_overlay(self, event=None):
+    def change_theme(self, name: str) -> None:
+        self.theme_name = name
+        apply_theme(self.root, name)
         try:
-            if self._diagnostics_overlay is not None and self._diagnostics_overlay.winfo_exists():
-                self._diagnostics_overlay.destroy()
-                self._diagnostics_overlay = None
-                return "break"
-        except Exception:
-            self._diagnostics_overlay = None
-            return "break"
-
-        overlay = tk.Toplevel(self.root)
-        overlay.title("Diagnóstico Báscula")
-        overlay.configure(bg="#222")
-        try:
-            overlay.attributes("-topmost", True)
+            self.messenger.pal = get_current_colors()
+            self.event_bus.publish("THEME_CHANGED", name)
         except Exception:
             pass
-        overlay.geometry("+40+40")
-        state = self.get_state()
-        info_lines = [
-            f"Tema: {self.theme_name}",
-            f"Modo diabético: {'activo' if self.diabetic_mode else 'apagado'}",
-            f"Autocaptura: {'sí' if state.get('auto_capture_enabled') else 'no'}",
-            f"BG: {self.bg_value if self.bg_value is not None else '---'} {self.bg_trend or ''}",
-        ]
-        tk.Label(
-            overlay,
-            text="\n".join(info_lines),
-            bg="#222",
-            fg="#EEE",
-            font=("DejaVu Sans", 14),
-            justify="left",
-        ).pack(padx=20, pady=20)
-        overlay.bind("<Escape>", lambda e: overlay.destroy())
-        self._diagnostics_overlay = overlay
-        return "break"
+
+    # ---------- BG / modo diabético ----------
+    def set_diabetic_mode(self, enabled: bool) -> None:
+        self.diabetic_mode = enabled
+        if not enabled:
+            if self.bg_monitor:
+                try:
+                    self.bg_monitor.stop()
+                except Exception:
+                    pass
+                self.bg_monitor = None
+            try:
+                self.topbar.set_bg(None)
+            except Exception:
+                pass
+        else:
+            try:
+                from bascula.services.bg_monitor import BgMonitor  # import en el lugar correcto
+                interval = int(self.get_cfg().get('bg_poll_s', 60))
+                self.bg_monitor = BgMonitor(self, interval_s=interval)
+                self.bg_monitor.start()
+                self.topbar.set_bg('---')
+            except Exception as e:
+                logger.warning(f"BG monitor not available: {e}")
+
+    def on_bg_update(self, value_mgdl: int, trend: str) -> None:
+        try:
+            self.topbar.set_bg(str(value_mgdl), trend)
+        except Exception:
+            pass
+        self.bg_value = value_mgdl
+        self.bg_trend = trend
+        self.event_bus.publish("BG_UPDATE", {"bg": value_mgdl, "trend": trend})
+
+    def on_bg_error(self, msg: str):
+        try:
+            if hasattr(self, 'messenger'):
+                self.messenger.show(msg, kind="info", priority=2, icon="ℹ️")
+            else:
+                self.topbar.set_message(msg)
+        except Exception:
+            pass
+
+    # ---------- cfg y servicios ----------
+    def get_cfg(self) -> dict:
+        """Get current configuration with all needed keys"""
+        try:
+            from bascula.utils import load_config, DEFAULT_CONFIG
+            cfg = load_config()
+            defaults = dict(DEFAULT_CONFIG)
+        except Exception:
+            cfg = {}
+            defaults = {}
+        # defaults adicionales necesarios por la app
+        defaults.update({
+            'focus_mode': True,
+            'llm_api_key': '',
+            'mascot_persona': 'discreto',
+            'mascot_max_per_hour': 3,
+            'mascot_dnd': False,
+            'mascot_llm_enabled': False,
+            'mascot_llm_send_health': False,
+            'theme_scanlines': False,
+            'theme_glow': False,
+            'textfx_enabled': True,
+            'vision_autosuggest_enabled': False,
+            'vision_confidence_threshold': 0.85,
+            'vision_min_weight_g': 20,
+            'vision_min_weight_g': 20,
+            'wakeword_enabled': False,
+            'piper_model': '',
+            'piper_enabled': False,
+            'foodshot_size': '4608x2592',
+            'port': '/dev/serial0',
+            'baud': 115200,
+            'calib_factor': 1.0,
+            'bg_low_mgdl': 70,
+            'bg_high_mgdl': 180,
+            'bg_poll_s': 60,
+        })
+        for k, v in defaults.items():
+            cfg.setdefault(k, v)
+        return cfg
+
+    def save_cfg(self) -> None:
+        try:
+            from bascula.utils import save_config
+            save_config(self.get_cfg())
+        except Exception as e:
+            logger.error(f"Failed to save config: {e}")
+
+    def get_reader(self): return self.reader
+    def get_tare(self): return self.tare_manager
+    def get_audio(self): return self.audio
+
+    def get_latest_weight(self) -> float:
+        if self.reader and self.tare_manager:
+            raw = self.reader.get_latest()
+            if raw is not None:
+                return self.tare_manager.compute_net(raw)
+        return 0.0
+
+    # ---------- ciclo ----------
+    def _idle_tick(self) -> None:
+        try:
+            self.event_bus.publish("IDLE_TICK")
+        except Exception:
+            pass
+        try:
+            self.root.after(20000, self._idle_tick)
+        except Exception:
+            pass
+
+    def run(self):
+        try:
+            self.root.mainloop()
+        except KeyboardInterrupt:
+            self.quit()
+        except Exception as e:
+            logger.error(f"Application error: {e}")
+            self.quit()
+
+    def quit(self):
+        try:
+            if self.reader:
+                self.reader.stop()
+            if self.bg_monitor:
+                self.bg_monitor.stop()
+            self.save_cfg()
+        except Exception:
+            pass
+        finally:
+            try:
+                self.root.destroy()
+            except Exception:
+                pass
 
 
-if __name__ == '__main__':
-    app = BasculaApp()
-    app.root.mainloop()
+# Alias compatibilidad
+BasculaAppTk = BasculaApp

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -1,286 +1,124 @@
-from __future__ import annotations
-
-"""Simplified screens for the redesigned Bascula UI."""
-
+# -*- coding: utf-8 -*-
 import tkinter as tk
-from tkinter import ttk
-from pathlib import Path
-from bascula.ui.widgets import ProButton, WeightLabel, Mascot, setup_ttk_styles
-from bascula.config.theme import get_current_colors, THEMES, apply_theme, set_theme
-from bascula.ui.mascot_messages import MSGS
+from bascula.config.theme import get_current_colors
 
-ASSETS = Path(__file__).resolve().parent.parent / 'assets' / 'icons'
+class BaseScreen(tk.Frame):
+    """Base class for all screens with common functionality"""
+    name = "base"
 
-
-def _icon_path(name: str) -> str | None:
-    p = ASSETS / f"{name}.png"
-    return str(p) if p.exists() else None
-
-
-class HomeScreen(tk.Frame):
-    """Home screen with mascot and big navigation buttons."""
-
-    def __init__(self, parent: tk.Misc, app) -> None:
-        pal = get_current_colors()
-        super().__init__(parent, bg=pal['COL_BG'])
+    def __init__(self, parent, app, **kwargs):
+        super().__init__(parent, bg=get_current_colors()['COL_BG'], **kwargs)
         self.app = app
+        self.name = self.__class__.__name__
 
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(0, weight=1)
-        self.grid_rowconfigure(1, weight=1)
+    def on_show(self):
+        pass
 
-        self.mascota = Mascot(self, width=320, height=280, bg=pal['COL_BG'])
-        self.mascota.grid(row=0, column=0, pady=20)
-
-        btns = tk.Frame(self, bg=pal['COL_BG'])
-        btns.grid(row=1, column=0, pady=20, sticky='nsew')
-        for col in range(3):
-            btns.grid_columnconfigure(col, weight=1)
-
-        ProButton(btns, 'Báscula', self.app.show_scale,
-                  icon=_icon_path('scale')).grid(row=0, column=0, padx=10, pady=10, sticky='nsew')
-        ProButton(btns, 'Temporizador', self.app.open_timer_popup,
-                  icon=_icon_path('timer')).grid(row=0, column=1, padx=10, pady=10, sticky='nsew')
-        ProButton(btns, 'Escáner', self.app.open_scanner,
-                  icon=_icon_path('scanner')).grid(row=0, column=2, padx=10, pady=10, sticky='nsew')
-        ProButton(btns, 'Ajustes', self.app.open_settings,
-                  icon=_icon_path('settings')).grid(row=1, column=0, padx=10, pady=10, sticky='nsew')
-        ProButton(btns, 'Salir', self.app.quit,
-                  icon=_icon_path('exit')).grid(row=1, column=1, padx=10, pady=10, sticky='nsew')
-        ProButton(btns, '🍳 Recetas', self.app.open_recipes,
-                  icon=_icon_path('recipes')).grid(row=1, column=2, padx=10, pady=10, sticky='nsew')
+    def on_hide(self):
+        pass
 
 
-class ScaleScreen(tk.Frame):
-    """Digital scale display screen."""
-
-    def __init__(self, parent: tk.Misc, app) -> None:
+class HomeScreen(BaseScreen):
+    name = "home"
+    def __init__(self, parent, app):
+        super().__init__(parent, app)
         pal = get_current_colors()
-        super().__init__(parent, bg=pal['COL_BG'])
-        self.app = app
-        self.unit = 'g'
+        tk.Label(self, text="Inicio", fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 28, "bold")).pack(pady=24)
 
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(0, weight=1)
-        self.grid_rowconfigure(1, weight=1)
+        grid = tk.Frame(self, bg=pal['COL_BG'])
+        grid.pack(expand=True)
 
-        header = tk.Frame(self, bg=pal['COL_BG'])
-        header.grid(row=0, column=0, sticky='new', pady=10)
-        ProButton(header, '← Volver', self.app.show_main, small=True).pack(side='left', padx=10)
+        def btn(txt, cmd, r, c):
+            b = tk.Button(grid, text=txt, width=16, height=2, command=cmd)
+            b.grid(row=r, column=c, padx=10, pady=10)
+            return b
 
-        weight_card = tk.Frame(self, bg=pal['COL_CARD'], bd=1,
-                               highlightbackground=pal['COL_BORDER'])
-        weight_card.grid(row=1, column=0, padx=40, pady=20, sticky='nsew')
-        weight_card.grid_propagate(False)
-        weight_card.config(height=220)
-
-        self.weight_lbl = WeightLabel(weight_card, bg=pal['COL_CARD'])
-        self.weight_lbl.pack(expand=True, fill='both')
-
-        btns = tk.Frame(self, bg=pal['COL_BG'])
-        btns.grid(row=2, column=0, pady=10)
-        ProButton(btns, 'Cero', self.app.zero_scale, small=True).grid(row=0, column=0, padx=5, pady=5)
-        ProButton(btns, 'Tara', self.app.tare_scale, small=True).grid(row=0, column=1, padx=5, pady=5)
-        ProButton(btns, 'Unidad', self._toggle_unit, small=True).grid(row=0, column=2, padx=5, pady=5)
-
-        self.mascota = Mascot(self, width=120, height=120, bg=pal['COL_BG'])
-        self.mascota.place(relx=1.0, rely=1.0, anchor='se', x=-10, y=-10)
-
-    def update_weight(self, value: float) -> None:
-        self.weight_lbl.config(text=f"{value:.1f}{self.unit}")
-
-    def _toggle_unit(self) -> None:
-        self.unit = 'ml' if self.unit == 'g' else 'g'
-        self.update_weight(0.0)
+        btn("Báscula", app.show_scale, 0, 0)
+        btn("Escáner", app.show_scanner, 0, 1)
+        btn("Ajustes", app.show_settings, 0, 2)
 
 
-class ScannerScreen(tk.Frame):
-    """Screen used for barcode scanning."""
-
-    def __init__(self, parent: tk.Misc, app) -> None:
+class ScaleScreen(BaseScreen):
+    name = "scale"
+    def __init__(self, parent, app):
+        super().__init__(parent, app)
         pal = get_current_colors()
-        super().__init__(parent, bg=pal['COL_BG'])
-        self.app = app
+        tk.Label(self, text="Báscula", fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 28, "bold")).pack(pady=16)
+        self.weight_var = tk.StringVar(value="0 g")
+        self.unit = "g"
+        self.decimals = 0
+        tk.Label(self, textvariable=self.weight_var, fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 48, "bold")).pack(pady=8)
 
-        ProButton(self, '← Volver', self.app.show_main, small=True).pack(anchor='nw', padx=10, pady=10)
+        row = tk.Frame(self, bg=pal['COL_BG']); row.pack(pady=10)
+        tk.Button(row, text="Tara", command=app.tare_scale).pack(side="left", padx=8)
+        tk.Button(row, text="Cero", command=app.zero_scale).pack(side="left", padx=8)
+        tk.Button(row, text="Unidad", command=self._toggle_unit).pack(side="left", padx=8)
+        tk.Button(self, text="Volver", command=app.show_main).pack(pady=12)
 
-        tk.Label(self, text='Escanea un código...',
-                 bg=pal['COL_BG'], fg=pal['COL_TEXT'],
-                 font=("DejaVu Sans", 32, 'bold')).pack(expand=True)
+        # refresco simple del valor (si hay lector real, app.on_bg_update no afecta aquí)
+        self.after(500, self._refresh_weight)
 
-        self.mascot = Mascot(self, width=120, height=120, bg=pal['COL_BG'])
-        self.mascot.place(relx=1.0, rely=1.0, anchor='se', x=-10, y=-10)
-
-
-class SettingsScreen(tk.Frame):
-    """Tabbed settings screen with contextual help."""
-
-    def __init__(self, parent: tk.Misc, app, get_state, set_state, on_theme_change, back) -> None:
-        super().__init__(parent, bg=get_current_colors()['COL_BG'])
-        self.app = app
-        self.get_state = get_state
-        self.set_state = set_state
-        self.on_theme_change = on_theme_change
-        self.back = back
-
-        pal = get_current_colors()
-        self._theme_display = {name: theme.display_name for name, theme in THEMES.items()}
-        setup_ttk_styles()
-
-        self._default_help = "Pulsa una opción para ver su descripción"
-        self.help_texts: dict[str, str] = {}
-
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_columnconfigure(1, weight=0)
-        self.grid_rowconfigure(0, weight=1)
-
-
-        nb = ttk.Notebook(self, style='TNotebook')
-
-        nb.grid(row=0, column=0, sticky='nsew', padx=20, pady=20)
-
-        side = tk.Frame(self, bg=pal['COL_BG'])
-        side.grid(row=0, column=1, sticky='ne', padx=(0,20), pady=20)
-        self.mascot = Mascot(side, width=140, height=140, bg=pal['COL_BG'], with_legs=True)
-        self.mascot.pack()
-        self.help_lbl = tk.Label(side, text=self._default_help, wraplength=180,
-                                 bg=pal['COL_BG'], fg=pal['COL_TEXT'],
-                                 font=("DejaVu Sans", 18))
-        self.help_lbl.pack(pady=10)
-
-        # --- General tab -------------------------------------------------
-        general = tk.Frame(nb, bg=pal['COL_BG'])
-        nb.add(general, text='General')
-        tk.Label(general, text='General', bg=pal['COL_BG'], fg=pal['COL_ACCENT'],
-                 font=("DejaVu Sans", 24, 'bold')).pack(anchor='w', padx=10, pady=(0,10))
-
-        state = self.get_state()
-        self.diab_var = tk.BooleanVar(value=state.get('diabetic_mode', False))
-        cb = ttk.Checkbutton(general, text='Modo diabético', variable=self.diab_var,
-                             command=self._toggle_diabetic)
-        cb.pack(anchor='w', padx=20, pady=10, ipady=10)
-        self._bind_help(cb, 'Muestra glucemia y flecha en la barra superior.')
-
-        self.auto_cap_var = tk.BooleanVar(value=state.get('auto_capture_enabled', True))
-        cb2 = ttk.Checkbutton(general, text='Autocaptura', variable=self.auto_cap_var,
-                              command=self._on_auto_capture_toggle)
-        cb2.pack(anchor='w', padx=20, pady=10, ipady=10)
-        self._bind_help(cb2, 'Activa la captura automática al estabilizarse el peso.')
-
-        tk.Label(general, text='Umbral autocaptura (g):', bg=pal['COL_BG'],
-                 fg=pal['COL_TEXT']).pack(anchor='w', padx=20)
-        self.min_delta_var = tk.DoubleVar(value=state.get('auto_capture_min_delta_g', 8))
-        spin = ttk.Spinbox(general, from_=1, to=100, increment=1, textvariable=self.min_delta_var,
-                            width=5)
-        spin.pack(anchor='w', padx=20, pady=(0,10))
-        spin.configure(command=lambda: self._on_min_delta_change())
-        self.min_delta_var.trace_add('write', self._on_min_delta_change)
-        self._bind_help(spin, 'Peso mínimo adicional para disparar la autocaptura.')
-
-        # --- Tema tab ----------------------------------------------------
-        theme_tab = tk.Frame(nb, bg=pal['COL_BG'])
-        nb.add(theme_tab, text='Tema')
-        tk.Label(theme_tab, text='Tema', bg=pal['COL_BG'], fg=pal['COL_ACCENT'],
-                 font=("DejaVu Sans", 24, 'bold')).pack(anchor='w', padx=10, pady=(0,10))
-
-
-        current_theme = state.get('theme', 'modern')
-        if current_theme not in THEMES:
-            current_theme = 'modern'
-        self.theme_var = tk.StringVar(value=current_theme)
-        for name, theme in self._theme_display.items():
-            rb = ttk.Radiobutton(
-                theme_tab,
-                text=theme,
-                value=name,
-                variable=self.theme_var,
-                command=self._change_theme,
-            )
-            rb.pack(anchor='w', padx=20, pady=10, ipady=10)
-            self._bind_help(rb, f'Cambia el aspecto a "{theme}".')
-
-
-        ProButton(self, '← Volver', self.back, small=True).grid(row=1, column=0, columnspan=2,
-                                                                sticky='w', padx=20, pady=(0,20))
-
-    # -- help system -----------------------------------------------------
-    def _bind_help(self, widget, text: str) -> None:
-        self.help_texts[str(widget)] = text
-        widget.bind('<FocusIn>', lambda e, t=text: self._show_help(t, True))
-        widget.bind('<FocusOut>', lambda e: self._show_help(self._default_help, False))
-
-    def _show_help(self, text: str, push: bool = False) -> None:
-        self.help_lbl.config(text=text)
-        self.mascot.set_state('idle' if text == self._default_help else 'talk')
-        if push:
-            try:
-                self.app.messenger.show(MSGS["settings_focus"](text), kind="info", priority=2, icon="💡")
-            except Exception:
-                pass
-
-    # -- callbacks -------------------------------------------------------
-    def _change_theme(self) -> None:
-
-        name = self.theme_var.get()
-        if name not in THEMES:
-            return
-        root = self.winfo_toplevel()
+    def _refresh_weight(self):
         try:
-            apply_theme(root, name)
+            w = self.app.get_latest_weight()
+            if self.unit == "g":
+                txt = f"{round(w, self.decimals)} g"
+            else:
+                # ejemplo: convertir a oz
+                txt = f"{round(w / 28.3495, max(0, self.decimals))} oz"
+            self.weight_var.set(txt)
         except Exception:
-            set_theme(name)
-        setup_ttk_styles()
-        self.set_state({'theme': name, 'ui_theme': name})
-        if self.on_theme_change:
-            self.on_theme_change(name)
+            pass
+        self.after(500, self._refresh_weight)
+
+    def _toggle_unit(self):
+        self.unit = "oz" if self.unit == "g" else "g"
 
 
-    def _toggle_diabetic(self) -> None:
-        self.set_state({'diabetic_mode': self.diab_var.get()})
+class ScannerScreen(BaseScreen):
+    name = "scanner"
+    def __init__(self, parent, app):
+        super().__init__(parent, app)
+        pal = get_current_colors()
+        tk.Label(self, text="Escáner", fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 28, "bold")).pack(pady=16)
+        tk.Label(self, text="Acerca un código al lector…", fg=pal['COL_TEXT'], bg=pal['COL_BG']).pack(pady=8)
+        tk.Button(self, text="Volver", command=app.show_main).pack(pady=12)
 
-    def _on_auto_capture_toggle(self) -> None:
-        self.set_state({'auto_capture_enabled': self.auto_cap_var.get()})
 
-    def _on_min_delta_change(self, *_):
-        try:
-            val = float(self.min_delta_var.get())
-        except Exception:
-            val = 8.0
-        if val < 1.0:
-            val = 1.0
-        if val > 100.0:
-            val = 100.0
-        self.min_delta_var.set(val)
-        self.set_state({'auto_capture_min_delta_g': val})
+class SettingsScreen(BaseScreen):
+    name = "settings"
+    def __init__(self, parent, app, get_state=None, set_state=None, change_theme=None, back=None):
+        super().__init__(parent, app)
+        pal = get_current_colors()
+        tk.Label(self, text="Ajustes", fg=pal['COL_TEXT'], bg=pal['COL_BG'],
+                 font=("DejaVu Sans", 28, "bold")).pack(pady=16)
+        row = tk.Frame(self, bg=pal['COL_BG']); row.pack(pady=10)
+        tk.Button(row, text="Tema claro", command=(lambda: change_theme("modern") if change_theme else None)).pack(side="left", padx=8)
+        tk.Button(row, text="Tema oscuro", command=(lambda: change_theme("dark") if change_theme else None)).pack(side="left", padx=8)
+        tk.Button(self, text="Volver", command=(back or app.show_main)).pack(pady=12)
+
 
 class TimerPopup(tk.Toplevel):
-    """Popup with presets and manual entry for countdown timer."""
-
-    def __init__(self, app) -> None:
+    def __init__(self, app):
         super().__init__(app.root)
-        self.app = app
-        self.title('Temporizador')
+        self.title("Temporizador")
+        self.geometry("300x160+50+50")
         pal = get_current_colors()
-        self.configure(bg=pal['COL_CARD'])
-        self.grab_set()
+        self.configure(bg=pal['COL_BG'])
+        tk.Label(self, text="Minutos:", fg=pal['COL_TEXT'], bg=pal['COL_BG']).pack(pady=6)
+        self.e = tk.Entry(self); self.e.insert(0, "1"); self.e.pack(pady=6)
+        tk.Button(self, text="Iniciar", command=self._start).pack(pady=8)
+        tk.Button(self, text="Cerrar", command=self.destroy).pack()
+        self.app = app
 
-        presets = (1, 5, 10, 15)
-        for i, p in enumerate(presets):
-            ProButton(self, f"{p} min", lambda d=p: self._start(d*60), small=True,
-                      bg=pal['COL_ACCENT']).grid(row=i, column=0, padx=10, pady=5)
-
-        tk.Label(self, text='Minutos:', bg=pal['COL_CARD'], fg=pal['COL_TEXT']).grid(row=0, column=1, padx=10)
-        self.entry = tk.Entry(self)
-        self.entry.grid(row=1, column=1, padx=10)
-        ProButton(self, 'Iniciar', self._start_manual, small=True).grid(row=2, column=1, pady=5)
-
-    def _start(self, secs: int) -> None:
-        self.destroy()
-        self.app.start_timer(secs)
-
-    def _start_manual(self) -> None:
+    def _start(self):
         try:
-            m = int(self.entry.get())
+            m = int(self.e.get().strip() or "1")
         except Exception:
-            m = 0
-        self._start(m*60)
+            m = 1
+        self.app.start_timer(m * 60)
+        self.destroy()


### PR DESCRIPTION
## Summary
- replace the Tkinter screen implementations with explicit home, scale, scanner, settings, and timer popup widgets
- rebuild the main BasculaApp orchestration to include tolerant service startup, navigation helpers, and configuration-aware behavior
- refresh utility helpers with config defaults, persistence helpers, and a moving average helper

## Testing
- python -m compileall bascula/ui/screens.py bascula/ui/app.py bascula/main.py bascula/utils.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d95cf3688326bfd4ffa7e485c760