### PR TITLE
Fix bascula-ui systemd service for kiosk mode

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -111,6 +111,14 @@ chmod 755 "${APP_DIR}"/scripts/*.sh 2>/dev/null || true
 # Crear el directorio de configuración con permisos correctos
 install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "${CFG_DIR}"
 
+LOG_DIR="/var/log/bascula"
+install -d -m 0755 "${LOG_DIR}"
+if getent group audio >/dev/null 2>&1; then
+  chown "${TARGET_USER}:audio" "${LOG_DIR}"
+else
+  chown "${TARGET_USER}:${TARGET_USER}" "${LOG_DIR}" || true
+fi
+
 VENV="${APP_DIR}/.venv"
 if [[ ! -d "${VENV}" ]]; then
   log INFO "Creando entorno virtual en ${VENV}"

--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -2,13 +2,43 @@
 set -euo pipefail
 
 # --- Paths
-APP_DIR="/opt/bascula/current"
-[ -d "$APP_DIR" ] || APP_DIR="$HOME/bascula-cam-main"
+APP_DIR=""
+APP_CANDIDATES=(
+  "/opt/bascula/current"
+  "$HOME/bascula-cam"
+  "$HOME/bascula-cam-main"
+)
+for candidate in "${APP_CANDIDATES[@]}"; do
+  if [ -d "$candidate" ]; then
+    APP_DIR="$candidate"
+    break
+  fi
+done
+
+if [ -z "$APP_DIR" ]; then
+  echo "[safe_run] ERROR: Directorio de aplicación no encontrado" >&2
+  exit 1
+fi
+
 cd "$APP_DIR"
 
 LOG_DIR="/var/log/bascula"
-mkdir -p "$LOG_DIR" || true
+if ! mkdir -p "$LOG_DIR" 2>/dev/null; then
+  LOG_DIR="$HOME/.bascula/logs"
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+fi
+
 LOG="$LOG_DIR/app.log"
+if ! touch "$LOG" 2>/dev/null; then
+  LOG="$HOME/app.log"
+  if ! touch "$LOG" 2>/dev/null; then
+    LOG="/tmp/bascula-app.log"
+    touch "$LOG" 2>/dev/null || true
+  fi
+fi
+
+echo "[safe_run] Directorio de la app: $APP_DIR" | tee -a "$LOG"
+echo "[safe_run] Registro en: $LOG" | tee -a "$LOG"
 
 # --- Entorno Xorg mejorado
 export DISPLAY=${DISPLAY:-:0}

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -1,15 +1,20 @@
 [Unit]
 Description=Bascula UI (Tkinter)
 After=network-online.target sound.target
+Wants=network-online.target sound.target
 
 [Service]
 User=pi
 Group=audio
-WorkingDirectory=/home/pi/bascula-cam
+WorkingDirectory=%h/bascula-cam
 # Opcional: forzar tarjeta (comentado por defecto)
 # Environment=BASCULA_APLAY_DEVICE=plughw:1,0
 Environment=BASCULA_CFG_DIR=%h/.config/bascula
-ExecStart=/bin/bash -lc 'if [ -x %h/bascula-cam/.venv/bin/python ]; then %h/bascula-cam/.venv/bin/python %h/bascula-cam/main.py; else python3 %h/bascula-cam/main.py; fi'
+Environment=DISPLAY=:0
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+Environment=XAUTHORITY=%h/.Xauthority
+Environment=XDG_SESSION_TYPE=x11
+ExecStart=%h/bascula-cam/scripts/safe_run.sh
 Restart=on-failure
 RestartSec=3
 # Permitir acceso a /dev/snd/*


### PR DESCRIPTION
## Summary
- ensure the bascula UI systemd unit runs the resilient safe_run.sh launcher with the proper graphical environment variables
- make safe_run.sh locate the installed application in /home/<user>/bascula-cam and guarantee a writable log location
- provision /var/log/bascula with the right ownership during install-2-app so service logs can be created without failures

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c953f8c040832681695ced7a053e10