### PR TITLE
Ensure bascula-ui service can execute safe_run

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -281,6 +281,15 @@ chmod 755 /home "${TARGET_HOME}" "${APP_DIR}"
 # Ejecutables para scripts y binarios del proyecto
 chmod 755 "${APP_DIR}"/scripts/*.sh 2>/dev/null || true
 
+SAFE_RUN_PATH="${APP_DIR}/scripts/safe_run.sh"
+if [[ ! -f "${SAFE_RUN_PATH}" ]]; then
+  die "No se encontró ${SAFE_RUN_PATH}; verifica la sincronización del repositorio"
+fi
+if [[ ! -x "${SAFE_RUN_PATH}" ]]; then
+  chmod 755 "${SAFE_RUN_PATH}"
+  log INFO "Permisos de ejecución aplicados a safe_run.sh"
+fi
+
 # Crear el directorio de configuración con permisos correctos
 install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "${CFG_DIR}"
 

--- a/systemd/bascula-ui.service
+++ b/systemd/bascula-ui.service
@@ -14,7 +14,7 @@ Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=XAUTHORITY=%h/.Xauthority
 Environment=XDG_SESSION_TYPE=x11
-ExecStart=%h/bascula-cam/scripts/safe_run.sh
+ExecStart=/bin/bash %h/bascula-cam/scripts/safe_run.sh
 Restart=on-failure
 RestartSec=3
 # Permitir acceso a /dev/snd/*


### PR DESCRIPTION
## Summary
- ensure install-2-app checks for scripts/safe_run.sh, sets execute permission when missing, and errors early when the file is absent
- invoke safe_run.sh from bascula-ui.service through /bin/bash to avoid Exec format failures when the executable bit is not set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96f4e0f4083268f245c2ace2a338a