### PR TITLE
Ensure kiosk-xorg service starts on tty1

### DIFF
--- a/systemd/kiosk-xorg.service
+++ b/systemd/kiosk-xorg.service
@@ -11,11 +11,18 @@ Group=tty
 Environment=HOME=/home/pi
 Environment=XDG_SESSION_TYPE=x11
 Environment=XDG_SESSION_CLASS=user
+Environment=XDG_RUNTIME_DIR=/run/user/%U
 WorkingDirectory=/home/pi
 ExecStartPre=/bin/bash -c 'while fuser /tmp/.X0-lock 2>/dev/null; do sleep 1; done'
 ExecStart=/usr/bin/startx /etc/X11/xinit/xinitrc -- :0 vt1 -keeptty
 StandardOutput=journal
 StandardError=journal
+PAMName=login
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+StandardInput=tty
 Restart=on-failure
 RestartSec=3
 


### PR DESCRIPTION
## Summary
- configure the kiosk-xorg systemd service to create a proper login session on tty1
- ensure the service inherits the correct runtime directory and controlling TTY so startx may launch Xorg

## Testing
- not run (system-level change)

------
https://chatgpt.com/codex/tasks/task_e_68c99203651c8326ac677f72cca53036