### PR TITLE
Ensure Xorg wrapper config installed

### DIFF
--- a/etc/X11/Xwrapper.config
+++ b/etc/X11/Xwrapper.config
@@ -1,0 +1,2 @@
+allowed_users=anybody
+needs_root_rights=yes

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -528,6 +528,10 @@ log INFO "Configurando X11 para ${TARGET_USER}"
 log INFO "Instalando servicio kiosk-xorg"
 install -m 0644 "${REPO_ROOT}/systemd/kiosk-xorg.service" "/etc/systemd/system/"
 
+# Configurar Xwrapper para permitir arranque de Xorg desde systemd
+install -d -m 0755 /etc/X11
+install -m 0644 "${REPO_ROOT}/etc/X11/Xwrapper.config" "/etc/X11/Xwrapper.config"
+
 # Instalar xinitrc personalizado
 install -d -m 0755 /etc/X11/xinit
 install -m 0755 "${REPO_ROOT}/etc/X11/xinit/xinitrc" "/etc/X11/xinit/xinitrc"

--- a/scripts/install-all.sh.zero2w
+++ b/scripts/install-all.sh.zero2w
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
 #
 # install-all_complete_autodetect_fixed.sh
 # - Instalador completo para Bascula (OTA) con manejo mejorado de dependencias de cámara
@@ -69,10 +72,7 @@ fi
 # Xwrapper para permitir X desde servicio
 log "Configurando ${XWRAPPER}…"
 install -d -m 0755 /etc/X11
-cat > "${XWRAPPER}" <<'EOF'
-allowed_users=anybody
-needs_root_rights=yes
-EOF
+install -m 0644 "${SOURCE_REPO}/etc/X11/Xwrapper.config" "${XWRAPPER}"
 
 # OTA: clonar repo si no existe enlace current
 log "Configurando estructura OTA en ${BASCULA_ROOT}…"

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # scripts/install-all.sh — Bascula-Cam (Raspberry Pi 5, Bookworm Lite 64-bit)
 # - Installs reproducible environment with isolated venv, services, and OTA structure
 # - Configures HDMI (1024x600), KMS, I2S, PWM, UART, and NetworkManager AP fallback
@@ -189,10 +192,7 @@ fi
 
 # --- Xwrapper ---
 install -d -m 0755 /etc/X11
-cat > "${XWRAPPER}" <<'EOF'
-allowed_users=anybody
-needs_root_rights=yes
-EOF
+install -m 0644 "${SOURCE_REPO}/etc/X11/Xwrapper.config" "${XWRAPPER}"
 
 # --- Polkit rules ---
 install -d -m 0755 /etc/polkit-1/rules.d


### PR DESCRIPTION
## Summary
- add a tracked Xorg wrapper configuration that allows services to start the display server
- update all kiosk installation scripts to deploy the shared Xwrapper configuration template during setup

## Testing
- bash -n scripts/install-2-app.sh
- bash -n scripts/install_all.sh
- bash -n scripts/install-all.sh.zero2w

------
https://chatgpt.com/codex/tasks/task_e_68c994059c1083269db61c9cf745ac67