### PR TITLE
Fix kiosk-xorg service startup type

### DIFF
--- a/systemd/kiosk-xorg.service
+++ b/systemd/kiosk-xorg.service
@@ -5,7 +5,11 @@ Before=graphical.target
 Wants=graphical.target
 
 [Service]
-Type=forking
+# startx/xinit run in the foreground until the X server exits, so using
+# Type=simple prevents systemd from waiting for a non-existent daemonizing
+# fork which previously made the unit time out and caused dependent units
+# such as bascula-ui.service to fail to start.
+Type=simple
 User=pi
 Group=tty
 Environment=HOME=/home/pi


### PR DESCRIPTION
## Summary
- switch kiosk-xorg.service to Type=simple because startx/xinit stay in the foreground
- add context in the unit explaining the change to avoid timeout failures that blocked bascula-ui.service

## Testing
- not run (systemd unit change)


------
https://chatgpt.com/codex/tasks/task_e_68c9977f42108326b780bbd2169d50a2