### PR TITLE
Fix main entrypoint to launch BasculaApp

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,63 +1,62 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-main.py - Punto de entrada principal simplificado
-"""
+"""Punto de entrada principal para la interfaz de Báscula Cam."""
+
+from __future__ import annotations
+
+import logging
 import os
 import sys
-import logging
 from pathlib import Path
 
-# Añadir la raíz del proyecto al path (por si se ejecuta fuera del repo)
+# Asegurar que la raíz del repositorio esté en sys.path
 REPO_ROOT = Path(__file__).parent.absolute()
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-# Logging básico (safe_run.sh redirige a /var/log/bascula/app.log)
+# Configuración básica de logging a stdout
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-    handlers=[logging.StreamHandler(sys.stdout)]
+    handlers=[logging.StreamHandler(sys.stdout)],
 )
-log = logging.getLogger("main")
+logger = logging.getLogger("bascula.main")
+
 
 def main() -> int:
-    log.info("=== BÁSCULA DIGITAL PRO - INICIO ===")
+    """Ejecuta la aplicación BasculaApp."""
+    logger.info("=== BÁSCULA DIGITAL PRO - INICIO ===")
 
-    # Entorno gráfico disponible
-    if not os.environ.get("DISPLAY") and sys.platform != "win32":
-        log.error("Entorno sin DISPLAY, no se puede iniciar la interfaz gráfica")
-        return 1
-
-    # Configurar entorno para Tkinter en kiosk
-    if sys.platform != "win32":
-        os.environ.setdefault("DISPLAY", ":0")
-        os.environ.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
-        
     try:
-        # Import y arranque de la app
+        if sys.platform != "win32" and not os.environ.get("DISPLAY"):
+            logger.error("Entorno sin servidor gráfico (DISPLAY). No se puede iniciar la UI.")
+            return 1
+
         from bascula.ui.app import BasculaApp
-        log.info("Inicializando aplicación...")
+
+        logger.info("Inicializando BasculaApp...")
         app = BasculaApp()
-        log.info("UI inicializada. Entrando en mainloop()")
-        app.run()  # Usar el método run() mejorado
+        logger.info("Aplicación inicializada. Iniciando loop principal de Tkinter.")
+        app.root.mainloop()
+        logger.info("Loop principal finalizado correctamente.")
         return 0
 
-    except ImportError as e:
-        log.error(f"Error de importación: {e}")
-        log.error("Verifica módulos y paquetes instalados (requirements.txt)")
+    except ImportError as exc:
+        logger.error("No se pudo importar BasculaApp u otros módulos requeridos: %s", exc)
+        logger.debug("Detalles de ImportError", exc_info=True)
         return 1
 
     except KeyboardInterrupt:
-        log.info("Aplicación interrumpida por el usuario (Ctrl+C)")
+        logger.info("Ejecución interrumpida por el usuario.")
         return 0
 
-    except Exception as e:
-        log.error(f"Error fatal: {e}", exc_info=True)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Error inesperado en la aplicación: %s", exc, exc_info=True)
         return 2
 
     finally:
-        log.info("=== BÁSCULA DIGITAL PRO - FIN ===")
+        logger.info("=== BÁSCULA DIGITAL PRO - FIN ===")
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
## Summary
- ensure the repository root is added to sys.path and configure stdout logging
- update main entrypoint to load BasculaApp, validate DISPLAY, and start Tkinter mainloop
- add robust exception handling with clear exit codes

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68ca25a2afa48326a06c89b0f38e958a