### PR TITLE
Restore full featured Tk UI

### DIFF
--- a/bascula/config/theme.py
+++ b/bascula/config/theme.py
@@ -1,30 +1,89 @@
 """Simple theme helpers for the kiosk UI."""
 from __future__ import annotations
 
+from copy import deepcopy
+import importlib
+import os
 from tkinter import ttk
 import tkinter as tk
 
-_THEMES = {
-    "retro": {
-        "BG": "#000000",
-        "TEXT": "#00FF66",
-        "ACCENT": "#00FF99",
-        "BORDER": "#00FF66",
-    },
+# Keys available for every theme.  ``BG/TEXT/ACCENT/BORDER`` are legacy names
+# kept for compatibility with older widgets.  The extended palette is consumed
+# by the modern UI components (cards, toasts, etc.).
+_THEMES: dict[str, dict[str, str]] = {
     "modern": {
-        "BG": "#0a0e1a",
-        "TEXT": "#f0f4f8",
-        "ACCENT": "#00d4aa",
-        "BORDER": "#2a3142",
+        "BG": "#0A0E1A",
+        "TEXT": "#F0F4F8",
+        "ACCENT": "#00D4AA",
+        "BORDER": "#1F2636",
+        "COL_BG": "#0A0E1A",
+        "COL_CARD": "#141B2D",
+        "COL_CARD_HOVER": "#1B2338",
+        "COL_BORDER": "#1F2636",
+        "COL_TEXT": "#F0F4F8",
+        "COL_MUTED": "#98A7C2",
+        "COL_ACCENT": "#00D4AA",
+        "COL_SUCCESS": "#35D07F",
+        "COL_WARN": "#F0AA3A",
+        "COL_DANGER": "#F05B4F",
+        "COL_SHADOW": "#00000040",
+    },
+    "retro": {
+        "BG": "#050A04",
+        "TEXT": "#8FFFA5",
+        "ACCENT": "#66FFCC",
+        "BORDER": "#0F3D1E",
+        "COL_BG": "#050A04",
+        "COL_CARD": "#0D1F11",
+        "COL_CARD_HOVER": "#132916",
+        "COL_BORDER": "#0F3D1E",
+        "COL_TEXT": "#8FFFA5",
+        "COL_MUTED": "#5A9B74",
+        "COL_ACCENT": "#66FFCC",
+        "COL_SUCCESS": "#6BE089",
+        "COL_WARN": "#E9D76F",
+        "COL_DANGER": "#F26C6C",
+        "COL_SHADOW": "#00000060",
     },
 }
 
-_current_theme = "retro"
+_current_theme = "modern"
+
+
+def list_themes() -> list[str]:
+    """Return the available theme identifiers."""
+
+    return sorted(_THEMES)
 
 
 def colors() -> dict[str, str]:
-    """Return a copy of the active palette."""
-    return dict(_THEMES[_current_theme])
+    """Return a legacy palette compatible with the original application."""
+
+    palette = get_current_colors()
+    return {
+        "BG": palette["COL_BG"],
+        "TEXT": palette["COL_TEXT"],
+        "ACCENT": palette["COL_ACCENT"],
+        "BORDER": palette["COL_BORDER"],
+    }
+
+
+def get_current_colors() -> dict[str, str]:
+    """Return a copy of the currently active extended palette."""
+
+    return deepcopy(_THEMES[_current_theme])
+
+
+def set_theme(name: str) -> str:
+    """Select *name* as current theme, returning the resolved value."""
+
+    global _current_theme
+    if name not in _THEMES:
+        name = os.environ.get("BASCULA_UI_THEME", _current_theme)
+    if name not in _THEMES:
+        name = "modern"
+    _current_theme = name
+    return name
 
 
 def _configure_styles(palette: dict[str, str]) -> None:
@@ -34,41 +93,56 @@ def _configure_styles(palette: dict[str, str]) -> None:
     except tk.TclError:
         pass
 
-    style.configure("TFrame", background=palette["BG"], bordercolor=palette["BORDER"])
-    style.configure(
-        "TLabel",
-        background=palette["BG"],
-        foreground=palette["TEXT"],
-    )
+    bg = palette["COL_BG"]
+    text = palette["COL_TEXT"]
+    accent = palette["COL_ACCENT"]
+    card = palette["COL_CARD"]
+    border = palette["COL_BORDER"]
+
+    style.configure("TFrame", background=bg, bordercolor=border)
+    style.configure("Card.TFrame", background=card, bordercolor=border)
+    style.configure("TLabel", background=bg, foreground=text)
+    style.configure("Heading.TLabel", background=bg, foreground=text, font=("DejaVu Sans", 22, "bold"))
     style.configure(
         "TButton",
-        background=palette["BORDER"],
-        foreground=palette["BG"],
-        bordercolor=palette["BORDER"],
+        background=accent,
+        foreground=bg,
+        bordercolor=accent,
         focusthickness=1,
+        padding=(12, 8),
+        font=("DejaVu Sans", 12, "bold"),
     )
     style.map(
         "TButton",
-        background=[("active", palette["ACCENT"])],
-        foreground=[("active", palette["BG"])],
+        background=[("active", palette["COL_CARD_HOVER"])],
+        foreground=[("active", palette["COL_TEXT"])],
     )
 
 
-def _apply_background(widget: tk.Misc, background: str) -> None:
+def _apply_background(widget: tk.Misc, palette: dict[str, str]) -> None:
+    bg = palette["COL_BG"]
     try:
-        widget.configure(bg=background)
+        widget.configure(bg=bg)
     except tk.TclError:
         pass
     for child in widget.winfo_children():
-        _apply_background(child, background)
+        _apply_background(child, palette)
 
 
-def apply_theme(root: tk.Misc, name: str = "retro") -> None:
-    """Apply one of the predefined color palettes to *root*."""
-    global _current_theme
-    if name not in _THEMES:
-        name = "retro"
-    _current_theme = name
-    palette = _THEMES[name]
-    _apply_background(root, palette["BG"])
+def apply_theme(root: tk.Misc, name: str = "modern") -> None:
+    """Apply the selected theme to *root* and refresh shared widgets."""
+
+    resolved = set_theme(name)
+    palette = _THEMES[resolved]
+    _apply_background(root, palette)
     _configure_styles(palette)
+
+    # Allow widgets to refresh cached constants without hard imports at module
+    # import time.
+    try:  # pragma: no cover - best effort only
+        widget_mod = importlib.import_module("bascula.ui.widgets")
+        if hasattr(widget_mod, "refresh_theme_cache"):
+            widget_mod.refresh_theme_cache()
+    except Exception:
+        pass
+

--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -1,59 +1,261 @@
-"""Minimal fullscreen application entry point."""
+"""High level Tkinter application used by the Báscula Cam kiosk."""
+
 from __future__ import annotations
 
+import logging
 import tkinter as tk
+from typing import Dict, Optional
 
-from bascula.config.theme import apply_theme, colors
+from bascula.config.theme import apply_theme
+from bascula.services.event_bus import EventBus
+from bascula.services.scale import ScaleService
+from bascula.services.tare_manager import TareManager
+from bascula.utils import MovingAverage, load_config, save_config
+from bascula.ui.widgets import TopBar, COL_BG
 from bascula.ui.screens import HomeScreen, ScaleScreen, SettingsScreen
-from bascula.ui.widgets import TopBar
+from bascula.ui.screens_wifi import WifiScreen
+from bascula.ui.screens_apikey import ApiKeyScreen
+from bascula.ui.screens_nightscout import NightscoutScreen
+
+try:  # Optional – audio is not critical during development/testing
+    from bascula.services.audio import AudioService
+except Exception:  # pragma: no cover - missing optional dependency
+    AudioService = None  # type: ignore
 
 
-class BasculaApp:
-    """Tkinter application configured for kiosk usage."""
+class _Messenger:
+    """Very small helper to route toast-style messages to the log."""
 
-    def __init__(self, theme: str = "retro") -> None:
-        self.root = tk.Tk()
+    def __init__(self, logger: logging.Logger) -> None:
+        self.logger = logger
+
+    def show(self, text: str, *, kind: str = "info", priority: int = 0, icon: str = "") -> None:
+        if not text:
+            return
+        msg = f"[{kind.upper()}] {text}"
+        if icon:
+            msg = f"{icon} {msg}"
+        self.logger.info(msg)
+
+
+class BasculaAppTk:
+    """Main application orchestrating services and Tk screens."""
+
+    def __init__(self, root: Optional[tk.Tk] = None, theme: str = "modern") -> None:
+        self.logger = logging.getLogger("bascula.ui.app")
+        self.cfg = load_config()
+        self.event_bus = EventBus()
+        self.messenger = _Messenger(self.logger)
+
+        self.root = root if root is not None else tk.Tk()
         self.root.title("Báscula Cam")
-        try:
-            self.root.attributes("-fullscreen", True)
-        except tk.TclError:
-            pass
-        self.root.geometry("1024x600")
-        apply_theme(self.root, theme)
-        palette = colors()
-        self.root.configure(bg=palette["BG"])
+        self.root.minsize(800, 480)
 
+        desired_theme = self.cfg.get("ui_theme", theme)
+        apply_theme(self.root, desired_theme)
+
+        self.root.configure(bg=COL_BG)
+        self.root.geometry("1024x600")
+        self.root.bind("<Escape>", lambda _evt: self.root.quit())
+
+        # Reactive variables shared by multiple screens
+        self.weight_text = tk.StringVar(value="0 g")
+        self.stability_text = tk.StringVar(value="Sin lectura")
+        self.weight_history: list[dict[str, object]] = []
+
+        # Build UI chrome
         self.topbar = TopBar(self.root, self)
         self.topbar.pack(fill=tk.X)
 
-        self.container = tk.Frame(self.root, bg=palette["BG"])
+        self.container = tk.Frame(self.root, bg=COL_BG)
         self.container.pack(fill=tk.BOTH, expand=True)
 
-        self.screens: dict[str, "BaseScreen"] = {}
-        for screen_cls in (HomeScreen, ScaleScreen, SettingsScreen):
-            screen = screen_cls(self.container, self)
-            self.screens[screen.name] = screen
+        # Screen registry
+        self.screens: Dict[str, tk.Frame] = {}
+        for screen_cls in (HomeScreen, ScaleScreen, SettingsScreen, WifiScreen, ApiKeyScreen, NightscoutScreen):
+            try:
+                screen = screen_cls(self.container, self)
+                self.screens[screen.name] = screen
+            except Exception as exc:  # pragma: no cover - failsafe for optional screens
+                self.logger.exception("No se pudo inicializar la pantalla %s", screen_cls.__name__, exc_info=exc)
 
-        self.current_screen: BaseScreen | None = None
+        self.current_screen = None
         self.show_screen("home")
 
-        self.root.bind("<Escape>", lambda _event: self.root.destroy())
+        # Services ------------------------------------------------------------------
+        self.reader: Optional[ScaleService] = None
+        self.tare = TareManager(calib_factor=float(self.cfg.get("calib_factor", 1.0)))
+        self._smoothing = MovingAverage(size=max(1, int(self.cfg.get("smoothing", 5))))
+        self._last_captured = 0.0
+        self._capture_min_delta = float(self.cfg.get("auto_capture_min_delta_g", 8))
 
-    def show_screen(self, name: str) -> None:
-        screen = self.screens.get(name)
-        if screen is None:
-            return
-        if self.current_screen is not None:
-            self.current_screen.pack_forget()
-        screen.pack(fill=tk.BOTH, expand=True)
-        screen.on_show()
-        self.current_screen = screen
+        try:
+            self.reader = ScaleService(
+                port=str(self.cfg.get("port", "/dev/serial0")),
+                baud=int(self.cfg.get("baud", 115200)),
+                logger=self.logger,
+                fail_fast=False,
+            )
+            self.reader.start()
+        except Exception:
+            self.logger.exception("No se pudo iniciar el lector de la báscula")
+            self.reader = None
 
+        self.audio = None
+        if AudioService is not None:
+            try:
+                self.audio = AudioService(self.cfg, logger=self.logger)
+            except Exception:  # pragma: no cover - optional feature
+                self.logger.exception("Fallo inicializando AudioService")
+                self.audio = None
+
+        self.root.after(300, self._update_weight_loop)
+        self.root.protocol("WM_DELETE_WINDOW", self.close)
+
+    # ------------------------------------------------------------------ Lifecycle
     def run(self) -> None:
         self.root.mainloop()
 
+    def close(self) -> None:
+        try:
+            if self.reader:
+                self.reader.stop()
+        finally:
+            self.root.destroy()
 
-# Late imports to avoid circular references in type checkers
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:  # pragma: no cover
-    from bascula.ui.screens import BaseScreen
+    # ------------------------------------------------------------------ Navigation
+    def show_screen(self, name: str) -> None:
+        screen = self.screens.get(name)
+        if screen is None:
+            self.logger.warning("Pantalla '%s' no encontrada", name)
+            return
+        if self.current_screen is screen:
+            return
+        if self.current_screen is not None:
+            try:
+                self.current_screen.on_hide()
+            except Exception:
+                pass
+            self.current_screen.pack_forget()
+        screen.pack(fill=tk.BOTH, expand=True)
+        try:
+            screen.on_show()
+        except Exception:
+            pass
+        self.current_screen = screen
+        try:
+            self.topbar.set_active(name)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ Services API
+    def get_cfg(self) -> dict:
+        return self.cfg
+
+    def save_cfg(self) -> None:
+        save_config(self.cfg)
+        try:
+            if "ui_theme" in self.cfg:
+                apply_theme(self.root, self.cfg.get("ui_theme", "modern"))
+        except Exception:
+            self.logger.exception("No se pudo aplicar el tema tras guardar la configuración")
+
+    def toggle_sound(self) -> None:
+        enabled = not bool(self.cfg.get("sound_enabled", True))
+        self.cfg["sound_enabled"] = enabled
+        self.save_cfg()
+        if self.audio:
+            try:
+                self.audio.set_enabled(enabled)  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+    def get_audio(self):  # pragma: no cover - convenience hook for settings modules
+        return self.audio
+
+    def get_reader(self) -> Optional[ScaleService]:
+        return self.reader
+
+    def get_tare(self) -> TareManager:
+        return self.tare
+
+    def get_latest_weight(self) -> float:
+        raw = self.reader.get_weight() if self.reader else 0.0
+        smooth = self._smoothing.add(raw)
+        return self.tare.compute_net(smooth)
+
+    # ------------------------------------------------------------------ Actions
+    def perform_tare(self) -> None:
+        raw = self.reader.get_weight() if self.reader else 0.0
+        self.tare.set_tare(raw)
+        self._last_captured = 0.0
+        self.messenger.show("Tara aplicada", icon="⚖️")
+
+    def perform_zero(self) -> None:
+        self.tare.clear_tare()
+        self._last_captured = 0.0
+        self.messenger.show("Tara reiniciada", icon="🧮")
+
+    def capture_weight(self) -> None:
+        weight = self.get_latest_weight()
+        if weight <= 0:
+            self.messenger.show("No hay peso estable para capturar", kind="warning", icon="ℹ️")
+            return
+        self._append_history(weight, manual=True)
+        self.event_bus.publish("WEIGHT_CAPTURED", weight)
+
+    def show_history(self) -> None:  # pragma: no cover - small popup
+        popup = tk.Toplevel(self.root)
+        popup.title("Historial de pesajes")
+        popup.geometry("360x400")
+        popup.configure(bg=COL_BG)
+        lb = tk.Listbox(popup, bg=COL_BG, fg="white", highlightthickness=0)
+        lb.pack(fill=tk.BOTH, expand=True, padx=12, pady=12)
+        for entry in self.weight_history:
+            lb.insert(tk.END, f"{entry['ts'].strftime('%d/%m %H:%M')} · {entry['value']}")
+
+    def set_focus_mode(self, enabled: bool) -> None:  # pragma: no cover - placeholder hook
+        self.cfg["focus_mode"] = bool(enabled)
+
+    # ------------------------------------------------------------------ Internal loops
+    def _update_weight_loop(self) -> None:
+        try:
+            weight = self.get_latest_weight()
+        except Exception:
+            weight = 0.0
+        decimals = max(0, int(self.cfg.get("decimals", 0)))
+        unit = str(self.cfg.get("unit", "g"))
+        formatted = f"{weight:.{decimals}f} {unit}"
+        stable = bool(self.reader.is_stable()) if self.reader else False
+
+        self.weight_text.set(formatted)
+        self.stability_text.set("Estable" if stable else "Midiendo…")
+        try:
+            self.topbar.update_weight(formatted, stable)
+        except Exception:
+            pass
+
+        if stable and weight > 0:
+            if abs(weight - self._last_captured) >= self._capture_min_delta:
+                self._append_history(weight)
+                self._last_captured = weight
+
+        self.root.after(250, self._update_weight_loop)
+
+    def _append_history(self, weight: float, manual: bool = False) -> None:
+        from datetime import datetime
+
+        formatted = f"{weight:.{max(0, int(self.cfg.get('decimals', 0)))}f} {self.cfg.get('unit', 'g')}"
+        entry = {"ts": datetime.now(), "value": formatted, "manual": manual}
+        self.weight_history.append(entry)
+        self.weight_history = self.weight_history[-20:]
+        if self.current_screen and hasattr(self.current_screen, "_refresh_history"):
+            try:
+                self.current_screen._refresh_history()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+
+# Backwards compatibility export -------------------------------------------------
+BasculaApp = BasculaAppTk
+

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -1,89 +1,195 @@
-"""Minimal screen set used by the simplified kiosk application."""
+"""Screen definitions used by :mod:`bascula.ui.app`.
+
+Historically this module exposed a rich set of widgets – home dashboard,
+interactive scale, multi-tabbed settings – but the pared down version bundled
+with the previous release only left skeletal placeholders.  The installation
+worked yet practically every navigation entry resulted in an empty panel,
+which is precisely the behaviour reported by the user.
+
+The classes below reinstate the expressive UI while keeping the code compact
+and well documented.  They rely exclusively on the widgets reintroduced in
+``bascula.ui.widgets`` so they remain testable without any special Tk extensions.
+"""
+
 from __future__ import annotations
 
 import tkinter as tk
-from tkinter import ttk
 
-from bascula.ui.widgets_mascota import MascotaCanvas
+from bascula.ui.widgets import (
+    Card,
+    Toast,
+    BigButton,
+    GhostButton,
+    WeightLabel,
+    COL_BG,
+    COL_CARD,
+    COL_TEXT,
+    COL_MUTED,
+)
 
 
-class BaseScreen(ttk.Frame):
-    """Base class for simple Tkinter screens."""
+class BaseScreen(tk.Frame):
+    """Common base with a title heading and themed background."""
 
     name = "base"
     title = "Pantalla"
 
-    def __init__(self, master: tk.Misc, app: "BasculaApp") -> None:
-        super().__init__(master, style="TFrame")
+    def __init__(self, parent: tk.Misc, app, **kwargs) -> None:
+        super().__init__(parent, bg=COL_BG, **kwargs)
         self.app = app
-        self.configure(padding=32)
 
-        self.heading = ttk.Label(self, text=self.title, style="TLabel", font=("DejaVu Sans", 28, "bold"))
-        self.heading.pack(anchor=tk.W, pady=(0, 24))
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(1, weight=1)
 
-    def on_show(self) -> None:  # pragma: no cover - hooks for future extension
-        """Called when the screen is shown."""
+        self.heading = tk.Label(
+            self,
+            text=self.title,
+            font=("DejaVu Sans", 26, "bold"),
+            bg=COL_BG,
+            fg=COL_TEXT,
+            anchor="w",
+        )
+        self.heading.grid(row=0, column=0, sticky="ew", padx=18, pady=(18, 8))
+
+        self.content = tk.Frame(self, bg=COL_BG)
+        self.content.grid(row=1, column=0, sticky="nsew", padx=18, pady=(0, 18))
+
+    def on_show(self) -> None:  # pragma: no cover - hooks for runtime behaviour
+        """Hook executed when the screen becomes visible."""
+
+    def on_hide(self) -> None:  # pragma: no cover
+        """Hook executed when the screen is hidden."""
 
 
 class HomeScreen(BaseScreen):
     name = "home"
     title = "Inicio"
 
-    def __init__(self, master: tk.Misc, app: "BasculaApp") -> None:
-        super().__init__(master, app)
-        container = ttk.Frame(self, style="TFrame")
-        container.pack(fill=tk.BOTH, expand=True)
+    def __init__(self, parent: tk.Misc, app, **kwargs) -> None:
+        super().__init__(parent, app, **kwargs)
 
-        left = ttk.Frame(container, style="TFrame")
-        left.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        hero = Card(self.content)
+        hero.pack(fill="both", expand=True)
 
-        welcome = ttk.Label(left, text="Bienvenido", style="TLabel", font=("DejaVu Sans", 18))
-        welcome.pack(anchor=tk.W, pady=(0, 12))
-
-        description = ttk.Label(
-            left,
-            text="Selecciona una opción en la barra superior para comenzar.",
-            style="TLabel",
-            wraplength=360,
-            justify=tk.LEFT,
+        title = tk.Label(
+            hero,
+            text="Báscula lista",
+            font=("DejaVu Sans", 22, "bold"),
+            bg=COL_CARD,
+            fg=COL_TEXT,
         )
-        description.pack(anchor=tk.W)
+        title.pack(anchor="w", pady=(0, 6))
 
-        right = ttk.Frame(container, style="TFrame")
-        right.pack(side=tk.RIGHT, fill=tk.BOTH)
+        subtitle = tk.Label(
+            hero,
+            text="Coloca un alimento sobre la bandeja o accede a Ajustes para personalizar tu experiencia.",
+            wraplength=520,
+            justify=tk.LEFT,
+            bg=COL_CARD,
+            fg=COL_MUTED,
+        )
+        subtitle.pack(anchor="w", pady=(0, 16))
 
-        mascot = MascotaCanvas(right)
-        mascot.pack(padx=12, pady=12)
-        self.mascota = mascot
+        weight_box = Card(hero)
+        weight_box.configure(padding=20)
+        weight_box.pack(fill="x", expand=False)
+
+        WeightLabel(weight_box, textvariable=app.weight_text).pack(fill="x")
+        tk.Label(
+            weight_box,
+            textvariable=app.stability_text,
+            bg=COL_CARD,
+            fg=COL_MUTED,
+            font=("DejaVu Sans", 14),
+        ).pack(anchor="w", pady=(6, 0))
+
+        actions = tk.Frame(hero, bg=COL_CARD)
+        actions.pack(fill="x", pady=(18, 4))
+
+        BigButton(actions, text="Pesar ahora", command=lambda: app.show_screen("scale")).pack(side="left", padx=6)
+        GhostButton(actions, text="Ver historial", command=app.show_history, micro=True).pack(side="left", padx=6)
+
+        self.history_card = Card(hero)
+        self.history_card.pack(fill="both", expand=True, pady=(16, 0))
+        self.history_list = tk.Listbox(
+            self.history_card,
+            bg=COL_CARD,
+            fg=COL_TEXT,
+            activestyle="none",
+            highlightthickness=0,
+            borderwidth=0,
+            font=("DejaVu Sans", 13),
+        )
+        self.history_list.pack(fill="both", expand=True)
+
+    def on_show(self) -> None:  # pragma: no cover - UI update
+        self._refresh_history()
+
+    def _refresh_history(self) -> None:
+        self.history_list.delete(0, tk.END)
+        for entry in self.app.weight_history:
+            ts = entry["ts"].strftime("%H:%M")
+            self.history_list.insert(tk.END, f"{ts} · {entry['value']}")
 
 
 class ScaleScreen(BaseScreen):
     name = "scale"
-    title = "Pesar"
+    title = "Báscula"
 
-    def __init__(self, master: tk.Misc, app: "BasculaApp") -> None:
-        super().__init__(master, app)
-        message = ttk.Label(
-            self,
-            text="Coloca el objeto en la báscula y sigue las instrucciones.",
-            style="TLabel",
-            wraplength=480,
-            justify=tk.LEFT,
+    def __init__(self, parent: tk.Misc, app, **kwargs) -> None:
+        super().__init__(parent, app, **kwargs)
+
+        card = Card(self.content)
+        card.pack(fill="both", expand=True)
+
+        self.weight_lbl = WeightLabel(card, textvariable=app.weight_text, bg=COL_CARD)
+        self.weight_lbl.pack(fill="x", padx=6, pady=(6, 12))
+
+        self.status_lbl = tk.Label(card, textvariable=app.stability_text, bg=COL_CARD, fg=COL_MUTED)
+        self.status_lbl.pack(anchor="w")
+
+        buttons = tk.Frame(card, bg=COL_CARD)
+        buttons.pack(fill="x", pady=18)
+
+        BigButton(buttons, text="Tara", command=app.perform_tare).pack(side="left", expand=True, fill="x", padx=4)
+        BigButton(buttons, text="Cero", command=app.perform_zero).pack(side="left", expand=True, fill="x", padx=4)
+        GhostButton(buttons, text="Capturar", command=app.capture_weight).pack(side="left", expand=True, fill="x", padx=4)
+
+        info = tk.Label(
+            card,
+            text="Los valores mostrados se actualizan en tiempo real desde el ESP32.",
+            bg=COL_CARD,
+            fg=COL_MUTED,
         )
-        message.pack(anchor=tk.W)
+        info.pack(anchor="w", pady=(12, 0))
+
+        self.toast = Toast(card)
+
+    def on_show(self) -> None:  # pragma: no cover - interactive behaviour
+        self.app.set_focus_mode(True)
+
+    def on_hide(self) -> None:  # pragma: no cover - interactive behaviour
+        self.app.set_focus_mode(False)
 
 
 class SettingsScreen(BaseScreen):
-    name = "settings"
+    name = "settingsmenu"
     title = "Ajustes"
 
-    def __init__(self, master: tk.Misc, app: "BasculaApp") -> None:
-        super().__init__(master, app)
-        info = ttk.Label(
-            self,
-            text="Configura la aplicación desde esta pantalla.",
-            style="TLabel",
-            wraplength=480,
-            justify=tk.LEFT,
-        )
-        info.pack(anchor=tk.W)
+    def __init__(self, parent: tk.Misc, app, **kwargs) -> None:
+        super().__init__(parent, app, **kwargs)
+        # Import lazily to avoid circular dependency during module import.
+        from bascula.ui.screens_tabs_ext import TabbedSettingsMenuScreen
+
+        notebook_screen = TabbedSettingsMenuScreen(self.content, app)
+        notebook_screen.pack(fill="both", expand=True)
+        self._proxied = notebook_screen
+
+    def on_show(self) -> None:  # pragma: no cover - delegated to proxy
+        if hasattr(self._proxied, "on_show"):
+            self._proxied.on_show()
+
+
+# Convenience alias kept for compatibility with older imports.
+SettingsMenuScreen = SettingsScreen
+

--- a/bascula/ui/screens_apikey.py
+++ b/bascula/ui/screens_apikey.py
@@ -23,6 +23,8 @@ BASE_URL = os.environ.get('BASCULA_WEB_URL', 'http://127.0.0.1:8080')
 
 
 class ApiKeyScreen(BaseScreen):
+    name = "apikey"
+
     _CFG_ENV = os.environ.get('BASCULA_CFG_DIR', '').strip()
     CFG_DIR = Path(_CFG_ENV) if _CFG_ENV else (Path.home() / ".config" / "bascula")
     API_FILE = CFG_DIR / "apikey.json"

--- a/bascula/ui/screens_nightscout.py
+++ b/bascula/ui/screens_nightscout.py
@@ -23,6 +23,8 @@ BASE_URL = os.environ.get('BASCULA_WEB_URL', 'http://127.0.0.1:8080')
 
 
 class NightscoutScreen(BaseScreen):
+    name = "nightscout"
+
     _CFG_ENV = os.environ.get('BASCULA_CFG_DIR', '').strip()
     CFG_DIR = Path(_CFG_ENV) if _CFG_ENV else (Path.home() / ".config" / "bascula")
     NS_FILE = CFG_DIR / "nightscout.json"

--- a/bascula/ui/screens_wifi.py
+++ b/bascula/ui/screens_wifi.py
@@ -28,6 +28,8 @@ BASE_URL = os.environ.get('BASCULA_WEB_URL', 'http://127.0.0.1:8080')
 
 
 class WifiScreen(BaseScreen):
+    name = "wifi"
+
     def __init__(self, parent, app, **kwargs):
         super().__init__(parent, app)
         header = tk.Frame(self, bg=COL_BG); header.pack(side="top", fill="x", pady=10)

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -1,35 +1,411 @@
-"""Reusable widgets for the simplified kiosk UI."""
+"""Core visual components used across the Tk interface.
+
+The original project evolved with a rather extensive widget toolkit that
+included themed buttons, cards, toast notifications and a handful of helper
+utilities tailored for touch devices.  During the simplification effort only a
+very small subset remained which made most of the advanced screens unusable –
+the modules still importing :mod:`bascula.ui.widgets` expected dozens of
+attributes (``COL_BG``, ``Card``, ``Toast`` …) that simply were not present.
+
+This module reintroduces those building blocks in a lightweight yet fully
+functional manner.  The goal is not to recreate every single pixel of the old
+design but to provide a consistent and modern look so that features such as the
+settings tabs, Wi-Fi configurator or the scale overlay can render correctly.
+
+The implementation deliberately favours clarity over extreme cleverness: most
+widgets are regular ``tk.Frame``/``tk.Button`` subclasses with a couple of
+convenience helpers.  Colours and font sizes are sourced from
+``bascula.config.theme`` so switching themes continues to work as expected.
+"""
+
 from __future__ import annotations
 
+import math
+import os
+import time
 import tkinter as tk
 from tkinter import ttk
+from typing import Callable, Iterable, Optional
 
-class TopBar(ttk.Frame):
-    """Navigation header with three fixed buttons."""
+from bascula.config.theme import get_current_colors
 
-    def __init__(self, master: tk.Misc, app: "BasculaApp") -> None:
-        super().__init__(master)
-        self.app = app
-        self.configure(padding=(16, 12), style="TFrame")
+# ---------------------------------------------------------------------------
+# Theme helpers
 
-        title = ttk.Label(self, text="Báscula Cam", style="TLabel", font=("DejaVu Sans", 20, "bold"))
-        title.pack(side=tk.LEFT)
+_UI_SCALE = float(os.environ.get("BASCULA_UI_SCALE", "1.0") or 1.0)
 
-        btn_container = ttk.Frame(self, style="TFrame")
-        btn_container.pack(side=tk.RIGHT)
 
-        buttons = [
-            ("Home", "home"),
-            ("Pesar", "scale"),
-            ("Ajustes", "settings"),
-        ]
-        for text, screen in buttons:
-            button = ttk.Button(
-                btn_container,
+def _round(n: float) -> int:
+    return int(round(n))
+
+
+def get_scaled_size(value: int) -> int:
+    """Return *value* scaled according to ``BASCULA_UI_SCALE``.
+
+    On small displays (e.g. 800x480) the default scale of ``1.0`` keeps the UI
+    sharp, while higher DPI panels can opt-in into slightly larger controls by
+    exporting ``BASCULA_UI_SCALE=1.15``.
+    """
+
+    return _round(max(1, value * _UI_SCALE))
+
+
+def refresh_theme_cache() -> None:
+    """Update module level colour constants from the active theme."""
+
+    global COLORS, COL_BG, COL_CARD, COL_CARD_HOVER, COL_BORDER, COL_TEXT
+    global COL_MUTED, COL_ACCENT, COL_SUCCESS, COL_WARN, COL_DANGER, COL_SHADOW
+    COLORS = get_current_colors()
+    COL_BG = COLORS["COL_BG"]
+    COL_CARD = COLORS["COL_CARD"]
+    COL_CARD_HOVER = COLORS["COL_CARD_HOVER"]
+    COL_BORDER = COLORS["COL_BORDER"]
+    COL_TEXT = COLORS["COL_TEXT"]
+    COL_MUTED = COLORS["COL_MUTED"]
+    COL_ACCENT = COLORS["COL_ACCENT"]
+    COL_SUCCESS = COLORS["COL_SUCCESS"]
+    COL_WARN = COLORS["COL_WARN"]
+    COL_DANGER = COLORS["COL_DANGER"]
+    COL_SHADOW = COLORS.get("COL_SHADOW", "#00000033")
+
+
+# Initialise constants at import time.
+refresh_theme_cache()
+
+# Touch friendly defaults
+TOUCH_MIN_SIZE = get_scaled_size(46)
+FS_TITLE = get_scaled_size(26)
+FS_TEXT = get_scaled_size(14)
+FS_BTN = get_scaled_size(16)
+FS_BTN_SMALL = get_scaled_size(13)
+FS_MONO = get_scaled_size(18)
+
+
+# ---------------------------------------------------------------------------
+# Basic containers & helpers
+
+class Card(ttk.Frame):
+    """Simple frame with the "card" background colour and rounded corners."""
+
+    def __init__(self, parent: tk.Misc, **kwargs) -> None:
+        style = kwargs.pop("style", "Card.TFrame")
+        super().__init__(parent, style=style, padding=get_scaled_size(14), **kwargs)
+        try:
+            self.configure(borderwidth=0)
+        except tk.TclError:
+            pass
+        self._apply_bg(self, COL_CARD)
+
+    def _apply_bg(self, widget: tk.Misc, color: str) -> None:
+        try:
+            widget.configure(bg=color)
+        except tk.TclError:
+            pass
+        for child in widget.winfo_children():
+            self._apply_bg(child, color)
+
+
+class WeightLabel(tk.Label):
+    """Large numeric label used to display the weight on several screens."""
+
+    def __init__(self, parent: tk.Misc, **kwargs) -> None:
+        kwargs.setdefault("font", ("DejaVu Sans", get_scaled_size(72), "bold"))
+        kwargs.setdefault("bg", COL_CARD)
+        kwargs.setdefault("fg", COL_ACCENT)
+        kwargs.setdefault("anchor", "e")
+        super().__init__(parent, **kwargs)
+
+
+class Mascot(tk.Canvas):
+    """Tiny decorative mascot drawn using vector primitives."""
+
+    def __init__(self, parent: tk.Misc, width: int = 60, height: int = 60, **kwargs) -> None:
+        super().__init__(parent, width=width, height=height, highlightthickness=0, **kwargs)
+        self.configure(bg=COL_CARD)
+        self._draw()
+
+    def _draw(self) -> None:
+        self.delete("all")
+        self.create_oval(6, 10, 54, 58, fill=COL_ACCENT, outline=COL_BORDER, width=2)
+        self.create_oval(14, 4, 46, 36, fill=COL_ACCENT, outline=COL_BORDER, width=2)
+        self.create_rectangle(22, 22, 38, 30, fill=COL_BG, outline=COL_BORDER, width=1)
+        self.create_oval(22, 16, 28, 22, fill=COL_BG, outline=COL_BORDER, width=1)
+        self.create_oval(36, 16, 42, 22, fill=COL_BG, outline=COL_BORDER, width=1)
+
+    def refresh(self) -> None:
+        self._draw()
+
+
+def bind_touch_scroll(widget: tk.Misc, *, units_divisor: int = 4, min_drag_px: int = 6) -> None:
+    """Enable drag-to-scroll behaviour on ``widget``.
+
+    Tkinter treeviews and canvases are notoriously difficult to use on touch
+    panels because the default scroll wheel bindings expect a mouse.  This
+    helper attaches a very small gesture recogniser so the user can drag the
+    content with a finger or stylus.
+    """
+
+    if not hasattr(widget, "yview"):
+        return
+
+    state = {"y": 0, "drag": False}
+
+    def _start(event):
+        state["y"] = event.y
+        state["drag"] = False
+
+    def _drag(event):
+        delta = event.y - state["y"]
+        if abs(delta) < min_drag_px:
+            return
+        state["drag"] = True
+        state["y"] = event.y
+        lines = int(delta / units_divisor)
+        if lines:
+            widget.yview_scroll(-lines, "units")
+
+    def _stop(_event):
+        state["drag"] = False
+
+    widget.bind("<ButtonPress-1>", _start, add=True)
+    widget.bind("<B1-Motion>", _drag, add=True)
+    widget.bind("<ButtonRelease-1>", _stop, add=True)
+
+
+def bind_text_entry(entry: tk.Entry) -> None:  # pragma: no cover - UI helper
+    entry.configure(insertbackground=COL_ACCENT, fg=COL_TEXT, bg=COL_CARD_HOVER, relief="flat")
+
+
+def bind_password_entry(entry: tk.Entry) -> None:  # pragma: no cover - UI helper
+    bind_text_entry(entry)
+
+
+# ---------------------------------------------------------------------------
+# Buttons
+
+class _BaseButton(tk.Button):
+    def __init__(self, parent: tk.Misc, *, bg: str, fg: str, font, **kwargs) -> None:
+        kwargs.setdefault("activebackground", COL_CARD_HOVER)
+        kwargs.setdefault("activeforeground", fg)
+        kwargs.setdefault("bd", 0)
+        kwargs.setdefault("relief", "flat")
+        kwargs.setdefault("cursor", "hand2")
+        kwargs.setdefault("highlightthickness", 0)
+        kwargs.setdefault("font", font)
+        super().__init__(parent, bg=bg, fg=fg, **kwargs)
+        self.configure(padx=get_scaled_size(14), pady=get_scaled_size(8))
+
+
+class BigButton(_BaseButton):
+    """Primary action button used across the UI."""
+
+    def __init__(self, parent: tk.Misc, micro: bool = False, **kwargs) -> None:
+        font = ("DejaVu Sans", FS_BTN_SMALL if micro else FS_BTN, "bold")
+        super().__init__(parent, bg=COL_ACCENT, fg=COL_BG, font=font, **kwargs)
+
+
+class GhostButton(_BaseButton):
+    """Secondary button with transparent background."""
+
+    def __init__(self, parent: tk.Misc, micro: bool = False, **kwargs) -> None:
+        font = ("DejaVu Sans", FS_BTN_SMALL if micro else FS_BTN)
+        super().__init__(parent, bg=COL_CARD, fg=COL_TEXT, font=font, **kwargs)
+        self.configure(padx=get_scaled_size(10), pady=get_scaled_size(6))
+
+
+# ---------------------------------------------------------------------------
+# Toast notifications
+
+class Toast:
+    """Small transient message displayed on top of a widget."""
+
+    def __init__(self, parent: tk.Misc) -> None:
+        self.parent = parent
+        self._label: Optional[tk.Label] = None
+        self._hide_after: Optional[str] = None
+
+    def show(self, text: str, timeout_ms: int = 1400, color: str = COL_ACCENT) -> None:
+        if not text:
+            return
+        if self._label is None:
+            self._label = tk.Label(
+                self.parent,
                 text=text,
-                command=lambda name=screen: self.app.show_screen(name),
+                bg=color,
+                fg=COL_BG,
+                font=("DejaVu Sans", FS_TEXT, "bold"),
+                padx=get_scaled_size(12),
+                pady=get_scaled_size(8),
             )
-            button.pack(side=tk.LEFT, padx=6)
+        else:
+            self._label.configure(text=text, bg=color)
 
-        separator = ttk.Separator(self, orient=tk.HORIZONTAL)
-        separator.pack(fill=tk.X, side=tk.BOTTOM, pady=(12, 0))
+        # Position near the bottom-right corner of the parent
+        try:
+            self._label.lift()
+            self._label.place(relx=0.98, rely=0.98, anchor="se")
+        except Exception:
+            self._label.pack()  # fallback
+
+        if self._hide_after:
+            try:
+                self.parent.after_cancel(self._hide_after)
+            except Exception:
+                pass
+
+        def _hide() -> None:
+            if self._label is not None:
+                self._label.place_forget()
+
+        self._hide_after = self.parent.after(timeout_ms, _hide)
+
+
+# ---------------------------------------------------------------------------
+# Keyboard popup (simplified)
+
+class TextKeyPopup(tk.Toplevel):  # pragma: no cover - interactive widget
+    """Very small on-screen keyboard for touch setups."""
+
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        title: str = "Introducir texto",
+        initial: str = "",
+        on_accept: Optional[Callable[[str], None]] = None,
+        password: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        self.title(title)
+        self.configure(bg=COL_BG)
+        self.geometry("420x320")
+        self.resizable(False, False)
+        self.on_accept = on_accept
+
+        self.var = tk.StringVar(value=initial)
+        entry = tk.Entry(self, textvariable=self.var, show="*" if password else "")
+        bind_text_entry(entry)
+        entry.pack(fill="x", padx=16, pady=16)
+        entry.focus_set()
+
+        grid = tk.Frame(self, bg=COL_BG)
+        grid.pack(fill="both", expand=True, padx=12)
+
+        layout = [
+            "1234567890",
+            "qwertyuiop",
+            "asdfghjkl",
+            "zxcvbnm",
+        ]
+
+        def add_char(ch: str) -> None:
+            entry.insert(tk.END, ch)
+
+        for row, chars in enumerate(layout):
+            row_frame = tk.Frame(grid, bg=COL_BG)
+            row_frame.pack(pady=4)
+            for ch in chars:
+                BigButton(row_frame, text=ch, width=3, command=lambda c=ch: add_char(c), micro=True).pack(
+                    side="left", padx=2
+                )
+
+        bottom = tk.Frame(self, bg=COL_BG)
+        bottom.pack(fill="x", pady=12)
+        GhostButton(bottom, text="Espacio", command=lambda: add_char(" "), micro=True).pack(side="left", padx=6)
+        GhostButton(bottom, text="Borrar", command=lambda: entry.delete(len(entry.get()) - 1, tk.END), micro=True).pack(
+            side="left", padx=6
+        )
+        BigButton(bottom, text="Aceptar", command=self._accept, micro=True).pack(side="right", padx=6)
+        GhostButton(bottom, text="Cancelar", command=self.destroy, micro=True).pack(side="right", padx=6)
+
+    def _accept(self) -> None:
+        if callable(self.on_accept):
+            self.on_accept(self.var.get())
+        self.destroy()
+
+
+# ---------------------------------------------------------------------------
+# Top navigation bar
+
+class TopBar(tk.Frame):
+    """Navigation header with contextual information and quick actions."""
+
+    def __init__(self, parent: tk.Misc, app) -> None:
+        super().__init__(parent, bg=COL_CARD)
+        self.app = app
+        self._buttons: dict[str, tk.Button] = {}
+
+        self.configure(padx=get_scaled_size(18), pady=get_scaled_size(10))
+
+        left = tk.Frame(self, bg=COL_CARD)
+        left.pack(side="left", fill="y")
+
+        self.mascot = Mascot(left)
+        self.mascot.pack(side="left", padx=(0, get_scaled_size(12)))
+
+        self.title_lbl = tk.Label(left, text="Báscula Cam", bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", FS_TITLE, "bold"))
+        self.title_lbl.pack(side="left")
+
+        center = tk.Frame(self, bg=COL_CARD)
+        center.pack(side="left", fill="both", expand=True)
+
+        self.weight_lbl = tk.Label(center, text="0 g", bg=COL_CARD, fg=COL_ACCENT, font=("DejaVu Sans", FS_TITLE, "bold"))
+        self.weight_lbl.pack(anchor="center")
+
+        right = tk.Frame(self, bg=COL_CARD)
+        right.pack(side="right")
+
+        nav_items = [
+            ("home", "Inicio"),
+            ("scale", "Báscula"),
+            ("settingsmenu", "Ajustes"),
+        ]
+        for name, label in nav_items:
+            btn = GhostButton(right, text=label, command=lambda s=name: app.show_screen(s))
+            btn.pack(side="right", padx=4)
+            self._buttons[name] = btn
+
+    def set_active(self, name: str) -> None:
+        for key, btn in self._buttons.items():
+            if key == name:
+                btn.configure(bg=COL_ACCENT, fg=COL_BG)
+            else:
+                btn.configure(bg=COL_CARD, fg=COL_TEXT)
+
+    def update_weight(self, text: str, stable: bool) -> None:
+        suffix = "✔" if stable else "…"
+        self.weight_lbl.configure(text=f"{text} {suffix}")
+
+
+__all__ = [
+    "Card",
+    "Toast",
+    "BigButton",
+    "GhostButton",
+    "WeightLabel",
+    "TopBar",
+    "Mascot",
+    "TextKeyPopup",
+    "bind_touch_scroll",
+    "bind_text_entry",
+    "bind_password_entry",
+    "get_scaled_size",
+    "TOUCH_MIN_SIZE",
+    "FS_TITLE",
+    "FS_TEXT",
+    "FS_BTN",
+    "FS_BTN_SMALL",
+    "FS_MONO",
+    "COL_BG",
+    "COL_CARD",
+    "COL_CARD_HOVER",
+    "COL_BORDER",
+    "COL_TEXT",
+    "COL_MUTED",
+    "COL_ACCENT",
+    "COL_SUCCESS",
+    "COL_WARN",
+    "COL_DANGER",
+    "COL_SHADOW",
+]
+


### PR DESCRIPTION
## Summary
- rebuild the Tk-based application shell with service orchestration, weight polling, history tracking and navigation between all UI screens
- restore the modern home, scale and settings screens plus hook in Wi-Fi, API key and Nightscout configuration panels
- reintroduce themed widgets, toast notifications and extended theme palettes so advanced tabs and overlays render correctly

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68caab3c3c288326b80c85820317ecb8