### PR TITLE
Implement touch-first navigation, voice, and scanning

### DIFF
--- a/bascula/services/wakeword.py
+++ b/bascula/services/wakeword.py
@@ -7,8 +7,11 @@ Usage:
   if engine.is_triggered():
       manejar_evento()
 """
-import threading, time
-from typing import Protocol, Optional
+import os
+import random
+import threading
+import time
+from typing import Callable, Optional, Protocol
 
 
 class WakeWordEngine(Protocol):
@@ -71,3 +74,104 @@ class PorcupineWakeWord:
     # Optional method to simulate trigger in testing/development
     def _simulate_trigger(self) -> None:
         self._flag = True
+
+
+class WakewordService:
+    """High level wake word orchestrator with optional simulation."""
+
+    def __init__(
+        self,
+        keyword: str = "basculin",
+        *,
+        on_detect: Optional[Callable[[], None]] = None,
+        poll_interval: float = 0.12,
+        simulate: Optional[bool] = None,
+    ) -> None:
+        self._engine: Optional[WakeWordEngine] = PorcupineWakeWord(keyword)
+        self._thread: Optional[threading.Thread] = None
+        self._active = False
+        self._poll = max(0.05, float(poll_interval))
+        env_sim = os.getenv("BASCULA_WAKEWORD_SIMULATE")
+        if simulate is None:
+            self._simulate = False if env_sim in {"0", "false", "False"} else True
+        else:
+            self._simulate = bool(simulate)
+        self._on_detect = on_detect
+        self._next_fake = 0.0
+
+    # ------------------------------------------------------------------ lifecycle
+    def start(self) -> None:
+        if self._active:
+            return
+        self._active = True
+        if self._engine:
+            try:
+                self._engine.start()
+            except Exception:
+                pass
+        self._schedule_fake_trigger()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._active = False
+        if self._engine:
+            try:
+                self._engine.stop()
+            except Exception:
+                pass
+        if self._thread and self._thread.is_alive():
+            try:
+                self._thread.join(timeout=0.2)
+            except Exception:
+                pass
+        self._thread = None
+
+    def is_active(self) -> bool:
+        return self._active
+
+    # ------------------------------------------------------------------ callbacks
+    def set_on_detect(self, callback: Optional[Callable[[], None]]) -> None:
+        self._on_detect = callback
+
+    def trigger(self) -> None:
+        """Manually notify detection (useful for tests)."""
+
+        self._fire_callback()
+
+    # ------------------------------------------------------------------ internals
+    def _run_loop(self) -> None:
+        while self._active:
+            fired = False
+            if self._engine:
+                try:
+                    if self._engine.is_triggered():
+                        fired = True
+                except Exception:
+                    fired = False
+            now = time.time()
+            if fired:
+                self._fire_callback()
+                self._schedule_fake_trigger()
+            elif self._simulate and now >= self._next_fake:
+                self._fire_callback()
+                self._schedule_fake_trigger()
+            time.sleep(self._poll)
+
+    def _schedule_fake_trigger(self) -> None:
+        if not self._simulate:
+            self._next_fake = float("inf")
+            return
+        base = random.uniform(18.0, 32.0)
+        self._next_fake = time.time() + base
+
+    def _fire_callback(self) -> None:
+        cb = self._on_detect
+        if callable(cb):
+            try:
+                cb()
+            except Exception:
+                pass
+
+
+__all__ = ["PorcupineWakeWord", "WakewordService"]

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -26,6 +26,7 @@ from bascula.ui.widgets import (
     COL_TEXT,
     COL_MUTED,
 )
+from bascula.ui.widgets_mascota import MascotaCanvas
 
 
 class BaseScreen(tk.Frame):
@@ -71,24 +72,35 @@ class HomeScreen(BaseScreen):
         hero = Card(self.content)
         hero.pack(fill="both", expand=True)
 
+        header = tk.Frame(hero, bg=COL_CARD)
+        header.pack(fill="x", pady=(0, 12))
+
+        text_box = tk.Frame(header, bg=COL_CARD)
+        text_box.pack(side="left", fill="both", expand=True)
+
         title = tk.Label(
-            hero,
+            text_box,
             text="Báscula lista",
             font=("DejaVu Sans", 22, "bold"),
             bg=COL_CARD,
             fg=COL_TEXT,
+            anchor="w",
+            justify=tk.LEFT,
         )
         title.pack(anchor="w", pady=(0, 6))
 
         subtitle = tk.Label(
-            hero,
+            text_box,
             text="Coloca un alimento sobre la bandeja o accede a Ajustes para personalizar tu experiencia.",
             wraplength=520,
             justify=tk.LEFT,
             bg=COL_CARD,
             fg=COL_MUTED,
         )
-        subtitle.pack(anchor="w", pady=(0, 16))
+        subtitle.pack(anchor="w", pady=(0, 12))
+
+        self.mascota = MascotaCanvas(header, width=200, height=200, bg=COL_CARD)
+        self.mascota.pack(side="right", padx=(16, 0))
 
         weight_box = Card(hero)
         weight_box.configure(padding=20)
@@ -124,6 +136,18 @@ class HomeScreen(BaseScreen):
 
     def on_show(self) -> None:  # pragma: no cover - UI update
         self._refresh_history()
+        if hasattr(self.mascota, "start"):
+            try:
+                self.mascota.start()
+            except Exception:
+                pass
+
+    def on_hide(self) -> None:  # pragma: no cover - UI update
+        if hasattr(self.mascota, "stop"):
+            try:
+                self.mascota.stop()
+            except Exception:
+                pass
 
     def _refresh_history(self) -> None:
         self.history_list.delete(0, tk.END)
@@ -154,6 +178,7 @@ class ScaleScreen(BaseScreen):
         BigButton(buttons, text="Tara", command=app.perform_tare).pack(side="left", expand=True, fill="x", padx=4)
         BigButton(buttons, text="Cero", command=app.perform_zero).pack(side="left", expand=True, fill="x", padx=4)
         GhostButton(buttons, text="Capturar", command=app.capture_weight).pack(side="left", expand=True, fill="x", padx=4)
+        GhostButton(buttons, text="📷 Escanear", command=app.open_scanner).pack(side="left", expand=True, fill="x", padx=4)
 
         info = tk.Label(
             card,

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import math
 import os
-import sys
 import time
 import tkinter as tk
 from tkinter import ttk
@@ -410,6 +409,16 @@ class TopBar(tk.Frame):
         nav = tk.Frame(right, bg=COL_CARD)
         nav.pack(side="right")
 
+        self._mic_var = tk.StringVar(value="Mic: OFF")
+        self._mic_label = tk.Label(
+            right,
+            textvariable=self._mic_var,
+            bg=COL_CARD,
+            fg=COL_TEXT,
+            font=("DejaVu Sans", max(FS_TEXT, get_scaled_size(14)), "bold"),
+        )
+        self._mic_label.pack(side="right", padx=(0, get_scaled_size(12)))
+
         nav_items = [
             ("home", "Inicio"),
             ("scale", "Pesar"),
@@ -486,6 +495,7 @@ class TopBar(tk.Frame):
             self.app.show_screen(screen_name)
         except Exception:
             pass
+        self._after_navigation()
 
     def _show_more_menu(self, _event) -> None:
         if not self._extra_entries or str(self.more_btn.cget("state")) == tk.DISABLED:
@@ -510,25 +520,7 @@ class TopBar(tk.Frame):
         self.admin_menu.delete(0, tk.END)
         self.admin_menu.add_command(label="Inicio", command=lambda: self._on_nav_click("home"))
         self.admin_menu.add_separator()
-        self.admin_menu.add_command(label="Reiniciar UI", command=self._restart_ui)
-        self.admin_menu.add_separator()
         self.admin_menu.add_command(label="Salir", command=self._exit_app)
-
-    def _restart_ui(self) -> None:
-        try:
-            if hasattr(self.app, "logger"):
-                try:
-                    self.app.logger.info("Reiniciando interfaz gráfica…")
-                except Exception:
-                    pass
-            self.app.root.destroy()
-            os.execl(sys.executable, sys.executable, *sys.argv)
-        except Exception:
-            if hasattr(self.app, "logger"):
-                try:
-                    self.app.logger.exception("No se pudo reiniciar la interfaz")
-                except Exception:
-                    pass
 
     def _exit_app(self) -> None:
         try:
@@ -603,6 +595,23 @@ class TopBar(tk.Frame):
             except Exception:
                 pass
             self._message_after = None
+
+    def _after_navigation(self) -> None:
+        mascot = getattr(self.app, "mascot_react", None)
+        if callable(mascot):
+            try:
+                mascot("tap")
+            except Exception:
+                pass
+
+    def set_mic_status(self, active: bool) -> None:
+        text = "Mic: ON" if active else "Mic: OFF"
+        color = COL_ACCENT if active else COL_TEXT
+        self._mic_var.set(text)
+        try:
+            self._mic_label.configure(fg=color)
+        except Exception:
+            pass
 
     def filter_missing(self, screens: dict[str, tk.Frame]) -> None:
         self.more_menu.delete(0, tk.END)


### PR DESCRIPTION
## Summary
- redesign the top bar for touch with dynamic "Más" entries, admin menu cleanup, and a mic status indicator
- refresh the home screen mascot with idle animations and start/stop hooks, and wire the scale screen with a scanner shortcut
- extend the Tk app to auto-register optional screens, drive transitions via TransitionManager, and initialize voice, wakeword, camera, and vision services along with scanner/vision food logging
- provide Piper-backed voice synthesis and a simulated wakeword service to react to touch-free cues

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cac48569048326bc68fd9021fb25ea