### PR TITLE
Implement meal workflow and diabetes hub

### DIFF
--- a/bascula/services/bg_monitor.py
+++ b/bascula/services/bg_monitor.py
@@ -1,26 +1,37 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import json, os
+import json
+import os
+import time
+from collections import deque
 from pathlib import Path
+from typing import Deque, Dict, List, Optional, Tuple
 
 try:
     import requests  # type: ignore
-except Exception:  # pragma: no cover - graceful fallback
+except Exception:  # pragma: no cover - optional dependency
     requests = None
 
 
 class BgMonitor:
-    """Polls Nightscout for the latest BG value using Tk's ``after``."""
+    """Nightscout polling helper with basic trend prediction."""
 
-    def __init__(self, app, interval_s: int = 60):
+    def __init__(self, app, interval_s: int = 60) -> None:
         self.app = app
-        self.interval_s = interval_s
-        self._job = None
-        self._last_bg: tuple[int, str] | None = None
+        self.interval_s = max(30, int(interval_s))
+        self._job: Optional[str] = None
+        self._last_entry_ts: float = 0.0
+        self._history: Deque[Tuple[float, float]] = deque(maxlen=8)
+        self.bg: Optional[int] = None
+        self.trend: str = ""
+        self.timestamp: Optional[float] = None
+        self.delta: Optional[float] = None
+        self.bg_pred_15: Optional[int] = None
+        self.bg_pred_30: Optional[int] = None
 
+    # ------------------------------------------------------------------ lifecycle
     def start(self) -> None:
-        self._tick()
+        self._schedule_tick(0)
 
     def stop(self) -> None:
         if self._job is not None:
@@ -30,55 +41,161 @@ class BgMonitor:
                 pass
             self._job = None
 
-    # ---- internal helpers -----------------------------------------
-    def _read_ns_cfg(self) -> tuple[str, str]:
+    # ------------------------------------------------------------------ helpers
+    def _schedule_tick(self, delay_ms: int) -> None:
+        try:
+            self._job = self.app.root.after(delay_ms, self._tick)
+        except Exception:
+            self._job = None
+
+    def _read_ns_cfg(self) -> Tuple[str, str]:
         cfg_dir_env = os.environ.get("BASCULA_CFG_DIR", "").strip()
         cfg_dir = Path(cfg_dir_env) if cfg_dir_env else (Path.home() / ".config" / "bascula")
+        path = cfg_dir / "nightscout.json"
         try:
-            data = json.loads((cfg_dir / "nightscout.json").read_text(encoding="utf-8"))
+            data = json.loads(path.read_text(encoding="utf-8"))
             return data.get("url", "").strip().rstrip("/"), data.get("token", "").strip()
         except Exception:
             return "", ""
 
+    def _fetch_entries(self, url: str, token: str) -> List[Dict]:
+        if requests is None or not url:
+            return []
+        try:
+            resp = requests.get(
+                f"{url}/api/v1/entries.json",
+                params={"count": 6, "token": token},
+                timeout=8,
+            )
+            if resp.ok:
+                data = resp.json()
+                if isinstance(data, list):
+                    return data
+        except Exception:
+            self._publish_error("Nightscout sin datos")
+        return []
+
+    def _extract_timestamp(self, entry: Dict) -> Optional[float]:
+        if not isinstance(entry, dict):
+            return None
+        date_ms = entry.get("date")
+        if isinstance(date_ms, (int, float)):
+            return float(date_ms) / 1000.0
+        date_str = entry.get("dateString")
+        if isinstance(date_str, str):
+            try:
+                from datetime import datetime
+
+                return datetime.fromisoformat(date_str.replace("Z", "+00:00")).timestamp()
+            except Exception:
+                pass
+        return None
+
+    def _parse_bg(self, entry: Dict) -> Optional[int]:
+        for key in ("sgv", "glucose", "bg"):
+            value = entry.get(key)
+            try:
+                if value is not None:
+                    return int(float(value))
+            except Exception:
+                continue
+        return None
+
+    def _parse_trend(self, entry: Dict) -> str:
+        raw = str(entry.get("direction", "")).lower()
+        if "up" in raw:
+            return "up"
+        if "down" in raw:
+            return "down"
+        if "flat" in raw:
+            return "flat"
+        return ""
+
+    def _compute_predictions(self) -> None:
+        if len(self._history) < 2:
+            self.bg_pred_15 = None
+            self.bg_pred_30 = None
+            return
+        first_ts, first_val = self._history[0]
+        last_ts, last_val = self._history[-1]
+        span_min = (last_ts - first_ts) / 60.0
+        if span_min <= 0:
+            slope = 0.0
+        else:
+            slope = (last_val - first_val) / span_min
+        self.bg_pred_15 = int(round(last_val + slope * 15))
+        self.bg_pred_30 = int(round(last_val + slope * 30))
+
+    def _publish_error(self, message: str) -> None:
+        try:
+            self.app.on_bg_error(message)
+        except Exception:
+            pass
+        try:
+            self.app.event_bus.publish("bg_error", {"message": message})
+        except Exception:
+            pass
+
+    def _publish_update(self) -> None:
+        payload = {
+            "value": self.bg,
+            "trend": self.trend,
+            "timestamp": self.timestamp,
+            "delta": self.delta,
+            "pred_15": self.bg_pred_15,
+            "pred_30": self.bg_pred_30,
+        }
+        try:
+            self.app.event_bus.publish("bg_update", payload)
+            self.app.event_bus.publish("BG_UPDATE", payload)
+        except Exception:
+            pass
+        cfg = self.app.get_cfg()
+        low = int(cfg.get("bg_low_threshold", cfg.get("bg_low_mgdl", 70)))
+        high = int(cfg.get("bg_high_threshold", cfg.get("bg_high_mgdl", 180)))
+        value = self.bg or 0
+        if value and value <= low:
+            try:
+                self.app.event_bus.publish("bg_low", payload)
+                self.app.event_bus.publish("BG_HYPO", payload)
+            except Exception:
+                pass
+        elif value and value >= high:
+            try:
+                self.app.event_bus.publish("bg_high", payload)
+            except Exception:
+                pass
+        else:
+            try:
+                self.app.event_bus.publish("BG_NORMAL", payload)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------ polling loop
     def _tick(self) -> None:
         url, token = self._read_ns_cfg()
-        if requests is not None and url:
+        entries = self._fetch_entries(url, token)
+        updated = False
+        for entry in sorted(entries, key=lambda e: self._extract_timestamp(e) or 0.0):
+            ts = self._extract_timestamp(entry)
+            value = self._parse_bg(entry)
+            if ts is None or value is None:
+                continue
+            if ts <= self._last_entry_ts:
+                continue
+            prev_bg = self.bg
+            self.bg = value
+            self.trend = self._parse_trend(entry)
+            self.timestamp = ts
+            self.delta = value - prev_bg if prev_bg is not None else None
+            self._last_entry_ts = ts
+            self._history.append((ts, float(value)))
+            self._compute_predictions()
+            updated = True
+        if updated:
             try:
-                resp = requests.get(
-                    f"{url}/api/v1/entries.json",
-                    params={"count": 1, "token": token},
-                    timeout=8,
-                )
-                if resp.ok:
-                    arr = resp.json()
-                    if isinstance(arr, list) and arr:
-                        entry = arr[0]
-                        try:
-                            val = int(entry.get("sgv") or entry.get("glucose"))
-                        except Exception:
-                            val = None
-                        if val is not None:
-                            trend_raw = str(entry.get("direction", ""))
-                            trend = {
-                                "DoubleUp": "up",
-                                "SingleUp": "up",
-                                "FortyFiveUp": "up",
-                                "DoubleDown": "down",
-                                "SingleDown": "down",
-                                "FortyFiveDown": "down",
-                                "Flat": "flat",
-                            }.get(trend_raw, "")
-                            bg_tuple = (val, trend)
-                            if bg_tuple != self._last_bg:
-                                self._last_bg = bg_tuple
-                                try:
-                                    self.app.on_bg_update(val, trend)
-                                except Exception:
-                                    pass
+                self.app.on_bg_update(self.bg, self.trend)
             except Exception:
-                try:
-                    self.app.on_bg_error("Nightscout sin datos")
-                except Exception:
-                    pass
-
-        self._job = self.app.root.after(self.interval_s * 1000, self._tick)
+                pass
+            self._publish_update()
+        self._schedule_tick(self.interval_s * 1000)

--- a/bascula/ui/screens_diabetes.py
+++ b/bascula/ui/screens_diabetes.py
@@ -1,66 +1,259 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import time
 import tkinter as tk
 from tkinter import ttk
+from typing import Optional
 
 from bascula.ui.screens import BaseScreen
-from bascula.ui.widgets import Card, BigButton, GhostButton, Toast, COL_BG, COL_CARD, COL_CARD_HOVER, COL_TEXT, COL_MUTED, COL_ACCENT
+from bascula.ui.widgets import Card, BigButton, GhostButton, Toast, COL_CARD, COL_TEXT, COL_ACCENT, COL_MUTED
+
 
 class DiabetesSettingsScreen(BaseScreen):
+    """Realtime diabetes hub with BG status and 15/15 tools."""
+
+    name = "diabetes"
+    title = "Diabetes"
+
     def __init__(self, parent, app, **kwargs):
-        super().__init__(parent, app)
-        header = tk.Frame(self, bg=COL_BG); header.pack(side="top", fill="x", pady=10)
-        tk.Label(header, text="Ajustes de Diabetes", bg=COL_BG, fg=COL_TEXT, font=("DejaVu Sans", 18, "bold")).pack(side="left", padx=14)
-        GhostButton(header, text="< Atrás", command=lambda: self.app.show_screen('settingsmenu'), micro=True).pack(side="right", padx=14)
-        body = Card(self); body.pack(fill="both", expand=True, padx=14, pady=10)
+        super().__init__(parent, app, **kwargs)
 
-        # Modo diabético + aviso
-        top = tk.Frame(body, bg=COL_CARD); top.pack(fill="x", padx=10, pady=(6,6))
-        self.var_dm = tk.BooleanVar(value=bool(self.app.get_cfg().get('diabetic_mode', False)))
-        ttk.Checkbutton(top, text="Modo diabético (experimental)", variable=self.var_dm, command=self._toggle_dm).pack(side="left")
-        tk.Label(top, text="No es consejo médico.", bg=COL_CARD, fg=COL_MUTED).pack(side="left", padx=10)
+        self.bg_var = tk.StringVar(value="—")
+        self.trend_var = tk.StringVar(value="—")
+        self.pred_var = tk.StringVar(value="—")
+        self.timer_var = tk.StringVar(value="Temporizador detenido")
+        self.mode_var = tk.BooleanVar(value=bool(self.app.diabetes_mode))
+        self.bolus_var = tk.StringVar(value="Sin recomendación")
+        self.bolus_window_var = tk.StringVar(value="")
+        self.threshold_low = tk.StringVar(value=str(self.app.get_cfg().get("bg_low_threshold", 70)))
+        self.threshold_high = tk.StringVar(value=str(self.app.get_cfg().get("bg_high_threshold", 180)))
+        self._bolus_job: Optional[str] = None
+        self._bolus_window_end: Optional[float] = None
 
-        nsrow = tk.Frame(body, bg=COL_CARD); nsrow.pack(fill="x", padx=10, pady=(0,6))
-        GhostButton(nsrow, text="Configurar Nightscout", command=lambda: self.app.show_screen('nightscout'), micro=True).pack(side="left", padx=4)
+        top = Card(self.content)
+        top.pack(fill="x", pady=(0, 12))
 
-        # Parámetros de bolo
-        frm = tk.Frame(body, bg=COL_CARD); frm.pack(fill="x", padx=10, pady=(6,10))
-        tk.Label(frm, text="Objetivo (mg/dL)", bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=0, sticky='w')
-        tk.Label(frm, text="ISF (mg/dL/U)", bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=1, sticky='w', padx=(10,0))
-        tk.Label(frm, text="Ratio HC (g/U)", bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=2, sticky='w', padx=(10,0))
-        tk.Label(frm, text="DIA (h)", bg=COL_CARD, fg=COL_TEXT).grid(row=0, column=3, sticky='w', padx=(10,0))
-        self.var_tbg = tk.StringVar(value=str(self.app.get_cfg().get('target_bg_mgdl', 110)))
-        self.var_isf = tk.StringVar(value=str(self.app.get_cfg().get('isf_mgdl_per_u', 50)))
-        self.var_carb = tk.StringVar(value=str(self.app.get_cfg().get('carb_ratio_g_per_u', 10)))
-        self.var_dia = tk.StringVar(value=str(self.app.get_cfg().get('dia_hours', 4)))
-        tk.Entry(frm, textvariable=self.var_tbg, width=8, bg=COL_CARD_HOVER, fg=COL_TEXT, relief='flat').grid(row=1, column=0)
-        tk.Entry(frm, textvariable=self.var_isf, width=8, bg=COL_CARD_HOVER, fg=COL_TEXT, relief='flat').grid(row=1, column=1, padx=(10,0))
-        tk.Entry(frm, textvariable=self.var_carb, width=8, bg=COL_CARD_HOVER, fg=COL_TEXT, relief='flat').grid(row=1, column=2, padx=(10,0))
-        tk.Entry(frm, textvariable=self.var_dia, width=6, bg=COL_CARD_HOVER, fg=COL_TEXT, relief='flat').grid(row=1, column=3, padx=(10,0))
+        header = tk.Frame(top, bg=COL_CARD)
+        header.pack(fill="x")
+        style_name = "Diabetes.TCheckbutton"
+        try:
+            style = ttk.Style(self)
+            style.configure(style_name, background=COL_CARD, foreground=COL_TEXT)
+        except Exception:
+            style_name = ""
+        tk.Label(
+            header,
+            text="Modo diabético",
+            bg=COL_CARD,
+            fg=COL_ACCENT,
+            font=("DejaVu Sans", 18, "bold"),
+        ).pack(side="left", padx=8, pady=6)
+        ttk.Checkbutton(
+            header,
+            text="Activado",
+            variable=self.mode_var,
+            command=self._toggle_mode,
+            style=style_name or None,
+        ).pack(side="left", padx=8)
+        GhostButton(header, text="Nightscout", command=lambda: self.app.show_screen("nightscout"), micro=True).pack(
+            side="right", padx=6
+        )
 
-        ctr = tk.Frame(body, bg=COL_CARD); ctr.pack(fill='x', padx=10, pady=(6,6))
-        BigButton(ctr, text="Guardar", command=self._apply, micro=True).pack(side='left', padx=4)
+        status = tk.Frame(top, bg=COL_CARD)
+        status.pack(fill="x", padx=6, pady=(4, 8))
+        self._add_status_label(status, "Glucosa", self.bg_var)
+        self._add_status_label(status, "Tendencia", self.trend_var)
+        self._add_status_label(status, "Pred. 15/30", self.pred_var)
+
+        thresholds = tk.Frame(top, bg=COL_CARD)
+        thresholds.pack(fill="x", padx=6, pady=(0, 6))
+        tk.Label(thresholds, text="Hipo <", bg=COL_CARD, fg=COL_TEXT).pack(side="left")
+        tk.Entry(thresholds, textvariable=self.threshold_low, width=5, justify="center").pack(side="left", padx=(4, 12))
+        tk.Label(thresholds, text="Hiper >", bg=COL_CARD, fg=COL_TEXT).pack(side="left")
+        tk.Entry(thresholds, textvariable=self.threshold_high, width=5, justify="center").pack(side="left", padx=4)
+        GhostButton(thresholds, text="Guardar", micro=True, command=self._save_thresholds).pack(side="left", padx=12)
+
+        hypo = Card(self.content)
+        hypo.pack(fill="x", pady=(0, 12))
+        tk.Label(
+            hypo,
+            text="Regla 15/15",
+            bg=COL_CARD,
+            fg=COL_ACCENT,
+            font=("DejaVu Sans", 16, "bold"),
+        ).pack(anchor="w", padx=8, pady=(6, 0))
+        tk.Label(
+            hypo,
+            text="Toma 15 g de hidratos, espera 15 minutos y vuelve a medir.",
+            bg=COL_CARD,
+            fg=COL_MUTED,
+        ).pack(anchor="w", padx=8, pady=(0, 8))
+        tk.Label(hypo, textvariable=self.timer_var, bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 14, "bold")).pack(
+            anchor="w", padx=8
+        )
+        btns = tk.Frame(hypo, bg=COL_CARD)
+        btns.pack(fill="x", padx=8, pady=(8, 6))
+        BigButton(btns, text="Iniciar 15:00", command=self._start_timer, micro=True).pack(side="left", padx=4)
+        GhostButton(btns, text="Cancelar", command=self._cancel_timer, micro=True).pack(side="left", padx=4)
+
+        bolus = Card(self.content)
+        bolus.pack(fill="x", pady=(0, 12))
+        tk.Label(
+            bolus,
+            text="Ventana de inyección",
+            bg=COL_CARD,
+            fg=COL_ACCENT,
+            font=("DejaVu Sans", 16, "bold"),
+        ).pack(anchor="w", padx=8, pady=(6, 0))
+        tk.Label(bolus, textvariable=self.bolus_var, bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 14)).pack(
+            anchor="w", padx=8, pady=(0, 4)
+        )
+        tk.Label(bolus, textvariable=self.bolus_window_var, bg=COL_CARD, fg=COL_MUTED).pack(anchor="w", padx=8)
+
+        actions = tk.Frame(bolus, bg=COL_CARD)
+        actions.pack(fill="x", padx=8, pady=(8, 8))
+        GhostButton(actions, text="Reiniciar ventana", command=self._restart_window, micro=True).pack(side="left", padx=4)
+        GhostButton(actions, text="Detener", command=self._stop_window, micro=True).pack(side="left", padx=4)
 
         self.toast = Toast(self)
-
-    def _toggle_dm(self):
         try:
-            cfg = self.app.get_cfg(); cfg['diabetic_mode'] = bool(self.var_dm.get()); self.app.save_cfg()
-            self.toast.show("Modo diabético: " + ("ON" if cfg['diabetic_mode'] else "OFF"), 900)
+            self.app.event_bus.subscribe("bg_update", self._on_bg_event)
+            self.app.event_bus.subscribe("bg_low", self._on_bg_low)
+            self.app.event_bus.subscribe("bolus_recommendation", self._on_bolus)
         except Exception:
             pass
 
-    def _apply(self):
-        try:
-            cfg = self.app.get_cfg()
-            cfg['target_bg_mgdl'] = max(60, int(float(self.var_tbg.get() or 110)))
-            cfg['isf_mgdl_per_u'] = max(5, int(float(self.var_isf.get() or 50)))
-            cfg['carb_ratio_g_per_u'] = max(2, int(float(self.var_carb.get() or 10)))
-            cfg['dia_hours'] = max(2, int(float(self.var_dia.get() or 4)))
-            self.app.save_cfg()
-            self.toast.show("Parámetros guardados", 1000, COL_SUCCESS)
-        except Exception as e:
-            self.toast.show(f"Error: {e}", 1300, COL_DANGER)
+    # ------------------------------------------------------------------ layout helpers
+    def _add_status_label(self, parent: tk.Misc, title: str, var: tk.StringVar) -> None:
+        box = tk.Frame(parent, bg=COL_CARD)
+        box.pack(side="left", expand=True, fill="x", padx=6)
+        tk.Label(box, text=title, bg=COL_CARD, fg=COL_MUTED).pack(anchor="w")
+        tk.Label(box, textvariable=var, bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 20, "bold")).pack(anchor="w")
 
+    # ------------------------------------------------------------------ actions
+    def _toggle_mode(self) -> None:
+        cfg = self.app.get_cfg()
+        cfg["diabetic_mode"] = bool(self.mode_var.get())
+        self.app.save_cfg()
+        if self.mode_var.get():
+            self.toast.show("Modo diabético activado", 1200)
+        else:
+            self.toast.show("Modo diabético desactivado", 1200)
+
+    def _save_thresholds(self) -> None:
+        cfg = self.app.get_cfg()
+        try:
+            cfg["bg_low_threshold"] = max(50, int(float(self.threshold_low.get())))
+            cfg["bg_high_threshold"] = max(100, int(float(self.threshold_high.get())))
+            self.app.save_cfg()
+            self.toast.show("Umbrales guardados", 1000)
+        except Exception as exc:
+            self.toast.show(f"Error: {exc}", 1500)
+
+    def _start_timer(self) -> None:
+        try:
+            self.app.start_hypo_timer()
+        except Exception:
+            self.toast.show("No se pudo iniciar", 1500)
+
+    def _cancel_timer(self) -> None:
+        try:
+            self.app.hypo_timer.close()
+        except Exception:
+            pass
+        self.timer_var.set("Temporizador detenido")
+
+    def _restart_window(self) -> None:
+        if self._bolus_window_end is None:
+            return
+        remaining = self._bolus_window_end - time.time()
+        if remaining <= 0:
+            self._stop_window()
+        else:
+            self._schedule_window_update()
+
+    def _stop_window(self) -> None:
+        self._bolus_window_end = None
+        self.bolus_window_var.set("")
+        if self._bolus_job:
+            try:
+                self.after_cancel(self._bolus_job)
+            except Exception:
+                pass
+            self._bolus_job = None
+
+    # ------------------------------------------------------------------ events
+    def _on_bg_event(self, payload: Optional[dict]) -> None:
+        if not isinstance(payload, dict):
+            payload = {}
+        value = payload.get("value", self.app._last_bg)
+        trend = payload.get("trend", self.app._last_bg_direction)
+        pred15 = payload.get("pred_15", self.app._bg_pred_15)
+        pred30 = payload.get("pred_30", self.app._bg_pred_30)
+        if value is None:
+            self.bg_var.set("—")
+        else:
+            delta = payload.get("delta")
+            if delta is None:
+                self.bg_var.set(f"{value} mg/dL")
+            else:
+                sign = "+" if delta >= 0 else ""
+                self.bg_var.set(f"{value} mg/dL ({sign}{int(delta)})")
+        arrows = {"up": "↑", "down": "↓", "flat": "→"}
+        self.trend_var.set(arrows.get(str(trend), str(trend)) or "—")
+        if pred15 is not None and pred30 is not None:
+            self.pred_var.set(f"{pred15}/{pred30} mg/dL")
+        else:
+            self.pred_var.set("—")
+        remaining = 0
+        try:
+            if self.app.hypo_timer.is_running():
+                remaining = self.app.hypo_timer.remaining_seconds()
+        except Exception:
+            remaining = 0
+        if remaining > 0:
+            mins, secs = divmod(int(remaining), 60)
+            self.timer_var.set(f"Restan {mins:02d}:{secs:02d}")
+        else:
+            self.timer_var.set("Temporizador detenido")
+
+    def _on_bg_low(self, payload: Optional[dict]) -> None:
+        self.timer_var.set("BG baja detectada – inicia la regla 15/15")
+
+    def _on_bolus(self, payload: Optional[dict]) -> None:
+        if not isinstance(payload, dict):
+            return
+        units = payload.get("units")
+        carbs = payload.get("carbs")
+        current = payload.get("current_bg")
+        target = payload.get("target")
+        window = int(payload.get("window_min", 15))
+        text = f"Carbs {carbs:.1f} g → {units:.2f} U (BG {current}/{target})"
+        self.bolus_var.set(text)
+        self._bolus_window_end = time.time() + window * 60
+        self._schedule_window_update()
+
+    def _schedule_window_update(self) -> None:
+        if self._bolus_job:
+            try:
+                self.after_cancel(self._bolus_job)
+            except Exception:
+                pass
+        if self._bolus_window_end is None:
+            self.bolus_window_var.set("")
+            return
+        remaining = int(self._bolus_window_end - time.time())
+        if remaining <= 0:
+            self.bolus_window_var.set("Ventana finalizada")
+            self._bolus_window_end = None
+            return
+        mins, secs = divmod(remaining, 60)
+        self.bolus_window_var.set(f"Quedan {mins:02d}:{secs:02d}")
+        self._bolus_job = self.after(1000, self._schedule_window_update)
+
+    # ------------------------------------------------------------------ screen hooks
+    def on_show(self) -> None:  # pragma: no cover - UI updates
+        self._on_bg_event({})
+
+    def on_hide(self) -> None:  # pragma: no cover
+        self._stop_window()


### PR DESCRIPTION
## Summary
- extend the Nightscout monitor with trend-based predictions and bg_* event publication so downstream screens react in real time
- add a persistent meal workflow: capture detected foods, compute macros/IG sources, store meals, and issue informational bolus + injection-window guidance when parameters exist
- refresh the scale and diabetes screens with touch-friendly food tables, totals, 15/15 controls, and injection window countdowns while keeping prior navigation/mascot features intact

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68caca2ac4d88326a4cfb08989443b7c