### PR TITLE
Revise Raspberry Pi Lite installer with kiosk flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,40 @@ source .venv/bin/activate
 python -m pip install -e .
 python -m pytest
 ```
+
+## Instalación en Raspberry Pi OS Lite (Pi 5 modo kiosko)
+
+1. Configura el arranque automático en consola:
+
+   ```bash
+   sudo raspi-config nonint do_boot_behaviour B2
+   ```
+
+2. Clona el repositorio y lanza el instalador orquestador:
+
+   ```bash
+   git clone https://github.com/DanielGTdiabetes/bascula-cam.git
+   cd bascula-cam
+   chmod +x scripts/install-all.sh
+   ./scripts/install-all.sh
+   ```
+
+   La Fase 1 prepara el sistema, instala dependencias y reinicia automáticamente. Tras el login de `pi`, se reanuda la Fase 2 sin intervención.
+
+### Ejecución manual de las fases
+
+```bash
+sudo bash scripts/install-1-system.sh   # reinicia automáticamente salvo que uses --skip-reboot
+sudo reboot                             # solo necesario si omitiste el reinicio automático
+sudo bash scripts/install-2-app.sh
+```
+
+### Notas de audio, voz y cámara
+
+- **Audio**: el servicio `bascula-ui` hereda `BASCULA_THEME=retro`. Si necesitas forzar una tarjeta ALSA concreta, exporta `BASCULA_APLAY_DEVICE` antes de lanzar `safe_run.sh` o ajusta el servicio con `Environment=BASCULA_APLAY_DEVICE=plughw:X,Y`.
+- **Piper**: los modelos descargados se guardan en `/opt/piper/models`. El fichero `.default-voice` selecciona el modelo usado por defecto.
+- **Cámara**: `libcamera-apps` y `python3-picamera2` quedan instalados durante la Fase 1. Usa `libcamera-hello --version` para verificar la pila de cámara.
+
+### Diagnóstico posterior
+
+Ejecuta `scripts/verify-kiosk.sh` (no bloqueante) para validar X11, Tkinter, Piper, audio, cámara, servicios `bascula-miniweb` y `x735-fan`.

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -4,520 +4,119 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 TARGET_USER="${TARGET_USER:-pi}"
-TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
-APP_DIR="${TARGET_HOME}/bascula-cam"
-CFG_DIR="${TARGET_HOME}/.config/bascula"
+PHASE_DIR="/var/lib/bascula"
 
-log(){ echo "[$1] ${2:-}"; }
-die(){ log ERR "${1}"; exit 1; }
+log() { printf '[inst] %s\n' "$*"; }
+ok() { printf '[ok] %s\n' "$*"; }
+warn() { printf '[warn] %s\n' "$*"; }
+err() { printf '[err] %s\n' "$*" >&2; }
 
-usage(){
+usage() {
   cat <<'USAGE'
-Uso: install-2-app.sh [--audio PERFIL]
+Uso: install-2-app.sh [--resume]
 
-  --audio PERFIL    Selecciona el perfil de audio (auto, max98357a, vc4hdmi, usb, none)
-  -h, --help        Muestra esta ayuda
+  --resume  Ejecutado automáticamente tras el reinicio de fase 1
 USAGE
   exit "${1:-0}"
 }
 
-AUDIO_PROFILE="auto"
+RESUME_MODE=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --audio=*)
-      AUDIO_PROFILE="${1#*=}"
-      ;;
-    --audio)
-      shift || die "Falta valor para --audio"
-      [[ $# -gt 0 ]] || die "Falta valor para --audio"
-      AUDIO_PROFILE="$1"
+    --resume)
+      RESUME_MODE=true
       ;;
     -h|--help)
       usage 0
       ;;
     *)
-      die "Opción no reconocida: $1"
+      err "Opción no reconocida: $1"
+      usage 1
       ;;
   esac
-  shift || true
+  shift
 done
-AUDIO_PROFILE="${AUDIO_PROFILE,,}"
-
-AUDIO_DEVICE_PCM=""
-AUDIO_CONTROL_CARD=""
-AUDIO_PROFILE_DESC=""
-AUDIO_PROFILE_RESOLVED="${AUDIO_PROFILE}"
 
 if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
-  die "Este script debe ejecutarse con sudo o como root"
+  err "Este script debe ejecutarse como root"
+  exit 1
 fi
 
-if ! id "${TARGET_USER}" >/dev/null 2>&1; then
-  die "El usuario objetivo '${TARGET_USER}' no existe"
-fi
-if [[ -z "${TARGET_HOME}" ]]; then
-  die "No se pudo determinar el directorio home de ${TARGET_USER}"
+if ! id -u "${TARGET_USER}" >/dev/null 2>&1; then
+  err "El usuario ${TARGET_USER} no existe"
+  exit 1
 fi
 
-# Verificar si necesitamos instalar X11 para modo kiosko
-install_minimal_x11_if_needed() {
-  if ! command -v startx >/dev/null 2>&1; then
-    log INFO "Raspberry Pi OS Lite detectado, instalando X11 mínimo para modo kiosko…"
-    
-    # Instalar X11 mínimo para modo kiosko
-    apt-get update
-    apt-get install -y \
-      xserver-xorg \
-      xserver-xorg-input-all \
-      xserver-xorg-video-fbdev \
-      xinit \
-      x11-xserver-utils \
-      unclutter \
-      unclutter-xfixes \
-      xterm
-    
-    log INFO "X11 mínimo instalado para modo kiosko"
-  else
-    log INFO "X11 ya está disponible"
-  fi
-}
+TARGET_HOME="$(getent passwd "${TARGET_USER}" | cut -d: -f6)"
+APP_DIR="${TARGET_HOME}/bascula-cam"
+VENV_DIR="${APP_DIR}/.venv"
+PYTHON="python3"
 
-install_minimal_x11_if_needed
-
-install_if_different(){
-  local src="$1" dest="$2" mode="$3"
-  if [[ -f "${dest}" ]] && cmp -s "${src}" "${dest}"; then
-    return 1
-  fi
-  install -m "${mode}" "${src}" "${dest}"
-  return 0
-}
-
-detect_card_index(){
-  local hint="${1:-}"
-  command -v aplay >/dev/null 2>&1 || return 1
-  local line idx id lower
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^card[[:space:]]+([0-9]+):[[:space:]]*([^ ,]+) ]]; then
-      idx="${BASH_REMATCH[1]}"
-      id="${BASH_REMATCH[2]}"
-      lower="$(printf '%s' "${id}" | tr '[:upper:]' '[:lower:]')"
-      if [[ -z "${hint}" || "${lower}" == *"${hint}"* ]]; then
-        printf '%s' "${idx}"
-        return 0
-      fi
-    fi
-  done < <(aplay -l 2>/dev/null || true)
-  return 1
-}
-
-ensure_asound_conf(){
-  local pcm_device="$1"
-  local control_card="$2"
-  local label="${3:-${pcm_device}}"
-  local asound_conf="/etc/asound.conf"
-  local tmp
-  tmp="$(mktemp)"
-  local ctl_card="${control_card}"
-  if [[ -z "${ctl_card}" ]]; then
-    ctl_card="0"
-  fi
-  if [[ ! "${ctl_card}" =~ ^[0-9]+$ ]]; then
-    ctl_card="\"${ctl_card}\""
-  fi
-  cat <<ASOUND > "${tmp}"
-pcm.!default {
-    type plug
-    slave.pcm "softvol"
-}
-
-pcm.softvol {
-    type softvol
-    slave {
-        pcm "${pcm_device}"
-    }
-    control {
-        name "SoftMaster"
-        card ${ctl_card}
-    }
-    min_dB -51.0
-    max_dB 0.0
-}
-
-ctl.!default {
-    type hw
-    card ${ctl_card}
-}
-ASOUND
-  if install_if_different "${tmp}" "${asound_conf}" 0644; then
-    log alsa "Configurado /etc/asound.conf para ${label}"
-  else
-    log alsa "/etc/asound.conf ya estaba configurado para ${label}"
-  fi
-  rm -f "${tmp}"
-}
-
-resolve_audio_profile(){
-  local profile="$1"
-  local idx=""
-  AUDIO_PROFILE_RESOLVED="$profile"
-  case "$profile" in
-    auto|"")
-      if idx=$(detect_card_index "hifiberry") || idx=$(detect_card_index "max98357") || idx=$(detect_card_index "i2s"); then
-        AUDIO_PROFILE_RESOLVED="max98357a"
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="MAX98357A (tarjeta ${idx})"
-      elif idx=$(detect_card_index "usb"); then
-        AUDIO_PROFILE_RESOLVED="usb"
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="USB Audio (tarjeta ${idx})"
-      elif idx=$(detect_card_index "vc4hdmi"); then
-        AUDIO_PROFILE_RESOLVED="vc4hdmi"
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="VC4 HDMI (tarjeta ${idx})"
-      else
-        AUDIO_DEVICE_PCM="plughw:0,0"
-        AUDIO_CONTROL_CARD="0"
-        AUDIO_PROFILE_DESC="Dispositivo ALSA predeterminado (tarjeta 0)"
-      fi
-      ;;
-    max98357a)
-      if idx=$(detect_card_index "hifiberry") || idx=$(detect_card_index "max98357") || idx=$(detect_card_index "i2s"); then
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="MAX98357A (tarjeta ${idx})"
-      else
-        AUDIO_DEVICE_PCM="plughw:1,0"
-        AUDIO_CONTROL_CARD="1"
-        AUDIO_PROFILE_DESC="MAX98357A (tarjeta 1 asumida)"
-        log WARN "No se detectó tarjeta MAX98357A; usando card 1"
-      fi
-      ;;
-    vc4hdmi|hdmi)
-      if idx=$(detect_card_index "vc4hdmi"); then
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="VC4 HDMI (tarjeta ${idx})"
-      else
-        AUDIO_DEVICE_PCM="plughw:0,0"
-        AUDIO_CONTROL_CARD="0"
-        AUDIO_PROFILE_DESC="VC4 HDMI (tarjeta 0 asumida)"
-        log WARN "No se detectó tarjeta VC4HDMI; usando card 0"
-      fi
-      ;;
-    usb)
-      if idx=$(detect_card_index "usb"); then
-        AUDIO_DEVICE_PCM="plughw:${idx},0"
-        AUDIO_CONTROL_CARD="${idx}"
-        AUDIO_PROFILE_DESC="USB Audio (tarjeta ${idx})"
-      else
-        AUDIO_DEVICE_PCM="plughw:0,0"
-        AUDIO_CONTROL_CARD="0"
-        AUDIO_PROFILE_DESC="USB Audio no encontrada (se usa tarjeta 0)"
-        log WARN "No se detectó tarjeta de audio USB; usando card 0"
-      fi
-      ;;
-    none)
-      AUDIO_DEVICE_PCM=""
-      AUDIO_CONTROL_CARD=""
-      AUDIO_PROFILE_DESC="Perfil de audio 'none' (sin cambios)"
-      ;;
-    *)
-      die "Perfil de audio no soportado: ${profile}"
-      ;;
-  esac
-}
-
-resolve_audio_profile "${AUDIO_PROFILE}"
-if [[ -n "${AUDIO_DEVICE_PCM}" ]]; then
-  log alsa "Perfil de audio: ${AUDIO_PROFILE_RESOLVED} → ${AUDIO_DEVICE_PCM}"
-else
-  log alsa "Perfil de audio: ${AUDIO_PROFILE_RESOLVED} (sin cambios en ALSA)"
+if [[ ! -d "${APP_DIR}" ]]; then
+  err "No se encuentra el repositorio en ${APP_DIR}"
+  exit 1
 fi
 
-ensure_ld_so_conf(){
-  local dir="$1"
-  local conf="/etc/ld.so.conf.d/piper.conf"
-  local tmp
-  tmp="$(mktemp)"
-  printf '%s\n' "${dir}" > "${tmp}"
-  if install_if_different "${tmp}" "${conf}" 0644; then
-    log piper "Registrado ${dir} en ${conf}"
-  else
-    log piper "${conf} ya contiene ${dir}"
-  fi
-  rm -f "${tmp}"
-}
+log "Creando entorno virtual"
+sudo -u "${TARGET_USER}" -- "${PYTHON}" -m venv "${VENV_DIR}" >/dev/null 2>&1 || \
+  sudo -u "${TARGET_USER}" -- "${PYTHON}" -m venv "${VENV_DIR}"
+sudo -u "${TARGET_USER}" -- "${VENV_DIR}/bin/python" -m pip install --upgrade pip setuptools wheel
+sudo -u "${TARGET_USER}" -- "${VENV_DIR}/bin/pip" install -r "${REPO_ROOT}/requirements.txt"
 
-run_as_target(){
-  local quoted_cmd
-  printf -v quoted_cmd ' %q' "$@"
-  su - "${TARGET_USER}" -s /bin/bash -c "${quoted_cmd}"
-}
+log "Creando servicios systemd"
+cat <<UI > /etc/systemd/system/bascula-ui.service
+[Unit]
+Description=Bascula UI (Tkinter Kiosk)
+After=graphical.target
 
-log INFO "Instalando aplicación para ${TARGET_USER}"
-mkdir -p "${APP_DIR}"
-if [[ "${REPO_ROOT}" != "${APP_DIR}" ]]; then
-  log INFO "Sincronizando aplicación en ${APP_DIR}"
-  rsync -a --delete --exclude '.venv' --exclude '.git' "${REPO_ROOT}/" "${APP_DIR}/"
-fi
-
-# Propietario correcto del repo completo
-chown -R "${TARGET_USER}:audio" "${APP_DIR}"
-
-# La cadena /home → /home/${TARGET_USER} → APP_DIR debe ser “ejecutable” (x) para poder hacer chdir
-chmod 755 /home "${TARGET_HOME}" "${APP_DIR}"
-
-# Permisos razonables dentro del repo
-{
-  find "${APP_DIR}" -type d -exec chmod 755 {} \;
-  find "${APP_DIR}" -type f -exec chmod 644 {} \;
-} || true
-# Ejecutables para scripts y binarios del proyecto
-chmod 755 "${APP_DIR}"/scripts/*.sh 2>/dev/null || true
-# Asegurar que safe_run.sh sea ejecutable específicamente
-chmod 755 "${APP_DIR}/scripts/safe_run.sh" 2>/dev/null || true
-
-SAFE_RUN_PATH="${APP_DIR}/scripts/safe_run.sh"
-if [[ ! -f "${SAFE_RUN_PATH}" ]]; then
-  die "No se encontró ${SAFE_RUN_PATH}; verifica la sincronización del repositorio"
-fi
-if [[ ! -x "${SAFE_RUN_PATH}" ]]; then
-  chmod 755 "${SAFE_RUN_PATH}"
-  log INFO "Permisos de ejecución aplicados a safe_run.sh"
-fi
-
-# Crear el directorio de configuración con permisos correctos
-install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "${CFG_DIR}"
-
-# Crear directorio de logs en el home del usuario para evitar problemas de permisos
-USER_LOG_DIR="${TARGET_HOME}/.bascula/logs"
-install -d -m 0755 -o "${TARGET_USER}" -g "audio" "${USER_LOG_DIR}"
-
-# También crear el directorio del sistema como fallback
-LOG_DIR="/var/log/bascula"
-install -d -m 0755 "${LOG_DIR}"
-if getent group audio >/dev/null 2>&1; then
-  chown "${TARGET_USER}:audio" "${LOG_DIR}"
-else
-  chown "${TARGET_USER}:${TARGET_USER}" "${LOG_DIR}" || true
-fi
-
-VENV="${APP_DIR}/.venv"
-if [[ ! -d "${VENV}" ]]; then
-  log INFO "Creando entorno virtual en ${VENV}"
-  run_as_target python3 -m venv "${VENV}"
-else
-  log INFO "Entorno virtual ya existente en ${VENV}"
-fi
-
-log INFO "Actualizando pip/setuptools/wheel"
-run_as_target "${VENV}/bin/python" -m pip install --upgrade pip setuptools wheel
-if [[ -f "${APP_DIR}/requirements.txt" ]]; then
-  log INFO "Instalando dependencias desde requirements.txt"
-  run_as_target "${VENV}/bin/python" -m pip install -r "${APP_DIR}/requirements.txt"
-else
-  log WARN "No se encontró requirements.txt; omitiendo instalación"
-fi
-
-log INFO "Instalando bascula-cam en modo editable"
-run_as_target "${VENV}/bin/python" -m pip install -e "${APP_DIR}"
-
-if [[ -f "${APP_DIR}/pyproject.toml" && -d "${APP_DIR}/tests" ]]; then
-  echo "[test] Ejecutando pytest…"
-  run_as_target "${VENV}/bin/python" -m pip install -U pytest
-  if ! run_as_target "${VENV}/bin/python" -m pytest -q "${APP_DIR}/tests"; then
-    echo "[warn] pytest falló (no bloquea la instalación)"
-  fi
-fi
-
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "${TMPDIR}"' EXIT
-ARCH="$(uname -m)"
-ASSET=""
-case "${ARCH}" in
-  aarch64|arm64)
-    ASSET="piper_linux_aarch64.tar.gz"
-    ;;
-  armv7l|arm)
-    ASSET="piper_armv7l.tar.gz"
-    ;;
-  x86_64)
-    ASSET="piper_linux_x86_64.tar.gz"
-    ;;
-  *)
-    log WARN "Arquitectura ${ARCH} no soportada para Piper"
-    ;;
-esac
-if [[ -n "${ASSET}" ]]; then
-  PIPER_URL="https://github.com/rhasspy/piper/releases/latest/download/${ASSET}"
-  log piper "Descargando Piper (${ASSET}) desde ${PIPER_URL}"
-  curl -fSL --retry 3 --retry-delay 2 -o "${TMPDIR}/piper.tgz" "${PIPER_URL}"
-  tar -xzf "${TMPDIR}/piper.tgz" -C "${TMPDIR}"
-  PIPER_BIN="$(find "${TMPDIR}" -type f -name piper -perm -111 | head -n1 || true)"
-  [[ -n "${PIPER_BIN}" ]] || die "No se encontró ejecutable 'piper' tras extraer"
-  PIPER_ROOT="$(dirname "${PIPER_BIN}")"
-  PIPER_INSTALL_DIR="/usr/local/lib/piper"
-  install -d -m 0755 "${PIPER_INSTALL_DIR}"
-  install -m 0755 "${PIPER_BIN}" "${PIPER_INSTALL_DIR}/piper"
-  log piper "Binario instalado en ${PIPER_INSTALL_DIR}/piper"
-  libs_copied=false
-  if [[ -d "${PIPER_ROOT}/lib" ]]; then
-    cp -a "${PIPER_ROOT}/lib/." "${PIPER_INSTALL_DIR}/"
-    libs_copied=true
-  else
-    while IFS= read -r -d '' libfile; do
-      cp -a "${libfile}" "${PIPER_INSTALL_DIR}/"
-      libs_copied=true
-    done < <(find "${TMPDIR}" \( -xtype f -o -xtype l \) -name 'lib*.so*' -print0)
-  fi
-  if [[ "${libs_copied}" == "true" ]]; then
-    log piper "Bibliotecas copiadas a ${PIPER_INSTALL_DIR}"
-  else
-    log piper "No se encontraron bibliotecas adicionales en el paquete"
-  fi
-  ensure_ld_so_conf "${PIPER_INSTALL_DIR}"
-  if command -v patchelf >/dev/null 2>&1; then
-    if patchelf --set-rpath "${PIPER_INSTALL_DIR}" "${PIPER_INSTALL_DIR}/piper"; then
-      log piper "RPATH fijado a ${PIPER_INSTALL_DIR}"
-    else
-      log piper "No se pudo fijar RPATH con patchelf"
-    fi
-  else
-    log piper "patchelf no disponible; se omite RPATH"
-  fi
-  cat <<'WRAPPER' > "${TMPDIR}/piper-wrapper"
-#!/usr/bin/env bash
-set -euo pipefail
-
-export ESPEAK_DATA_PATH="${ESPEAK_DATA_PATH:-/usr/share/espeak-ng-data}"
-exec "/usr/local/lib/piper/piper" "$@"
-WRAPPER
-  install -m 0755 "${TMPDIR}/piper-wrapper" /usr/local/bin/piper
-  log piper "Wrapper /usr/local/bin/piper actualizado"
-  ldconfig
-  log piper "ldconfig ejecutado"
-else
-  log WARN "No se determinó asset de Piper para ${ARCH}"
-fi
-
-# CONFIGURACIÓN DEL ARRANQUE KIOSCO (AUTOLOGIN + STARTX)
-if [[ -n "${AUDIO_DEVICE_PCM}" ]]; then
-  ensure_asound_conf "${AUDIO_DEVICE_PCM}" "${AUDIO_CONTROL_CARD}" "${AUDIO_PROFILE_DESC}"
-else
-  log alsa "Perfil de audio 'none': se mantiene /etc/asound.conf existente"
-fi
-
-log INFO "Configurando arranque en modo kiosco (autologin + startx)"
-
-override_dir="/etc/systemd/system/getty@tty1.service.d"
-override_conf="${override_dir}/override.conf"
-tmp_file="$(mktemp)"
-cat <<EOF > "${tmp_file}"
 [Service]
-ExecStart=
-ExecStart=-/sbin/agetty --autologin ${TARGET_USER} --noclear %I \$TERM
-Type=idle
-EOF
-install -d -m 0755 "${override_dir}"
-if install_if_different "${tmp_file}" "${override_conf}" 0644; then
-  log kiosk "Autologin configurado en tty1 para ${TARGET_USER}"
-else
-  log kiosk "Autologin en tty1 ya estaba configurado"
-fi
-rm -f "${tmp_file}"
+User=${TARGET_USER}
+WorkingDirectory=${TARGET_HOME}/bascula-cam
+ExecStart=${TARGET_HOME}/bascula-cam/.venv/bin/python ${TARGET_HOME}/bascula-cam/main.py
+Restart=on-failure
+Environment=BASCULA_THEME=retro
 
-bash_profile="${TARGET_HOME}/.bash_profile"
-tmp_file="$(mktemp)"
-cat <<'PROFILE' > "${tmp_file}"
-# Arranca Xorg automáticamente si estamos en tty1 y no hay sesión gráfica
-if [[ -z "$DISPLAY" ]] && [[ "$(tty)" == "/dev/tty1" ]]; then
-  exec startx
-fi
-PROFILE
-if install_if_different "${tmp_file}" "${bash_profile}" 0644; then
-  log kiosk "Actualizado ${bash_profile}"
-else
-  log kiosk "${bash_profile} ya estaba configurado"
-fi
-chown "${TARGET_USER}:${TARGET_USER}" "${bash_profile}" || true
-rm -f "${tmp_file}"
+[Install]
+WantedBy=graphical.target
+UI
 
-xinitrc="${TARGET_HOME}/.xinitrc"
-tmp_file="$(mktemp)"
-cat <<EOF > "${tmp_file}"
-#!/bin/sh
-# Desactivar salvapantallas y gestión de energía
-xset s off -dpms
+cat <<WEB > /etc/systemd/system/bascula-miniweb.service
+[Unit]
+Description=Bascula Mini Web
+After=network-online.target
 
-# Ocultar el cursor del ratón
-unclutter -idle 1 -root &
+[Service]
+User=${TARGET_USER}
+WorkingDirectory=${TARGET_HOME}/bascula-cam
+ExecStart=${TARGET_HOME}/bascula-cam/.venv/bin/uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port 8080
+Restart=always
 
-# Ejecutar el script de arranque seguro de la aplicación
-exec "${APP_DIR}/scripts/safe_run.sh" >> "${TARGET_HOME}/bascula_app.log" 2>&1
-EOF
-if install_if_different "${tmp_file}" "${xinitrc}" 0755; then
-  log kiosk "Actualizado ${xinitrc}"
-else
-  log kiosk "${xinitrc} ya estaba configurado"
-fi
-chown "${TARGET_USER}:${TARGET_USER}" "${xinitrc}" || true
-rm -f "${tmp_file}"
+[Install]
+WantedBy=multi-user.target
+WEB
 
 systemctl daemon-reload
-systemctl restart "getty@tty1.service" || true
+if systemctl enable bascula-ui.service bascula-miniweb.service; then
+  ok "Servicios bascula-ui y bascula-miniweb habilitados"
+else
+  warn "No se pudieron habilitar los servicios principales"
+fi
+if systemctl restart bascula-miniweb.service >/dev/null 2>&1; then
+  ok "bascula-miniweb reiniciado"
+else
+  warn "No se pudo iniciar bascula-miniweb (se activará tras reinicio)"
+fi
+if systemctl restart bascula-ui.service >/dev/null 2>&1; then
+  ok "bascula-ui reiniciado"
+else
+  warn "No se pudo iniciar bascula-ui (requiere entorno gráfico)"
+fi
 
-PIPER_VOICE="${PIPER_VOICE:-es_ES-sharvard-medium}"
-case "${PIPER_VOICE}" in
-  es_ES-sharvard-medium|es_ES-davefx-medium|es_ES-carlfm-x_low) ;;
-  *) die "Voz Piper no soportada: ${PIPER_VOICE}" ;;
-esac
-VOICES_BASE="https://github.com/DanielGTdiabetes/bascula-cam/releases/download/voices-v1"
-install -d -m 0755 /opt/piper/models
+install -d -m 0755 "${PHASE_DIR}"
+printf 'PHASE=2_DONE\n' > "${PHASE_DIR}/phase"
 
-fetch_voice_file(){
-  local url="$1" dest="$2" tmp size
-  if [[ -f "${dest}" && $(stat -c%s "${dest}" 2>/dev/null || echo 0) -ge 1024 ]]; then
-    log INFO "${dest} ya existe"
-    return
-  fi
-  tmp="$(mktemp)"
-  log INFO "Descargando ${url}"
-  if ! curl -fSL --retry 3 --retry-delay 2 -o "${tmp}" "${url}"; then
-    rm -f "${tmp}"
-    die "Fallo al descargar ${url}"
-  fi
-  size=$(stat -c%s "${tmp}" 2>/dev/null || echo 0)
-  if [[ "${size}" -lt 1024 ]]; then
-    rm -f "${tmp}"
-    die "Descarga corrupta (menos de 1KB) desde ${url}"
-  fi
-  install -m 0644 "${tmp}" "${dest}"
-  rm -f "${tmp}"
-}
+if ${RESUME_MODE}; then
+  rm -f /etc/profile.d/bascula-resume.sh
+fi
 
-fetch_voice_file "${VOICES_BASE}/${PIPER_VOICE}.onnx" "/opt/piper/models/${PIPER_VOICE}.onnx"
-fetch_voice_file "${VOICES_BASE}/${PIPER_VOICE}.onnx.json" "/opt/piper/models/${PIPER_VOICE}.onnx.json"
-log INFO "Voz ${PIPER_VOICE} instalada en /opt/piper/models"
-
-systemctl enable --now x735-fan.service || true
-
-set +e
-log INFO "== Post-install checks =="
-which piper || log WARN "piper no en PATH"
-ls -lh /opt/piper/models || true
-aplay -l || log WARN "aplay -l falló"
-
-echo "[diag] Comprobando cadena de permisos para ${APP_DIR}"
-ls -ld /home "${TARGET_HOME}" "${APP_DIR}" || true
-namei -om "${APP_DIR}" || true
-sudo -u "${TARGET_USER}" test -x "${APP_DIR}" \
-  && echo "[diag] ${TARGET_USER} puede hacer chdir a APP_DIR" \
-  || echo "[diag] ERROR: ${TARGET_USER} no puede chdir a APP_DIR"
-
-set -e
-
-log INFO "Fase 2 completada"
+ok "Fase 2 completada"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -2,10 +2,32 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-log(){ echo "[$1] ${2:-}"; }
-die(){ log ERR "${1}"; exit 1; }
+log() { printf '[inst] %s\n' "$*"; }
+err() { printf '[err] %s\n' "$*" >&2; }
 
-bash "${SCRIPT_DIR}/install-1-system.sh"
-bash "${SCRIPT_DIR}/install-2-app.sh" "$@"
+usage() {
+  cat <<'USAGE'
+Uso: scripts/install-all.sh [opciones fase1]
+
+Ejecuta la instalación completa en dos fases con reinicio intermedio.
+Las opciones proporcionadas se pasan a install-1-system.sh.
+USAGE
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+log "Iniciando fase 1 (sistema + hardware)"
+"${SCRIPT_DIR}/install-1-system.sh" --from-all "$@"
+# No se alcanza este punto porque fase 1 ejecuta reboot cuando finaliza

--- a/scripts/install-kiosk-xorg.sh
+++ b/scripts/install-kiosk-xorg.sh
@@ -1,25 +1,66 @@
 #!/usr/bin/env bash
 set -euo pipefail
-APP_DIR="/opt/bascula/current"
-[ -d "$APP_DIR" ] || APP_DIR="$HOME/bascula-cam-main"
 
-mkdir -p "$HOME/.config/lxsession/LXDE-pi"
-cat > "$HOME/.config/lxsession/LXDE-pi/autostart" <<'EOF'
-@/opt/bascula/current/scripts/safe_run.sh
-EOF
-[ -d "$APP_DIR" ] || sed -i "s|/opt/bascula/current|$APP_DIR|g" "$HOME/.config/lxsession/LXDE-pi/autostart"
+TARGET_USER="${1:-pi}"
+TARGET_HOME="${2:-/home/pi}"
 
-mkdir -p "$HOME/.config/autostart"
-cat > "$HOME/.config/autostart/bascula.desktop" <<'EOF'
-[Desktop Entry]
-Type=Application
-Name=Bascula
-Exec=/opt/bascula/current/scripts/safe_run.sh
-X-GNOME-Autostart-enabled=true
-EOF
-[ -d "$APP_DIR" ] || sed -i "s|/opt/bascula/current|$APP_DIR|g" "$HOME/.config/autostart/bascula.desktop"
+log() { printf '[inst] %s\n' "$*"; }
+warn() { printf '[warn] %s\n' "$*"; }
 
-chmod +x "$APP_DIR/scripts/safe_run.sh" 2>/dev/null || true
-sudo systemctl disable bascula 2>/dev/null || true
-echo "[kiosk-xorg] Instalación completada."
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  warn "Se requieren privilegios de root para configurar autologin"
+fi
 
+if [[ ! -d "${TARGET_HOME}" ]]; then
+  warn "Directorio home ${TARGET_HOME} inexistente"
+  exit 0
+fi
+
+GETTY_DIR="/etc/systemd/system/getty@tty1.service.d"
+install -d -m 0755 "${GETTY_DIR}"
+cat <<EOF_OVR > "${GETTY_DIR}/override.conf"
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin ${TARGET_USER} --noclear %I \$TERM
+EOF_OVR
+chmod 0644 "${GETTY_DIR}/override.conf"
+
+BASH_PROFILE="${TARGET_HOME}/.bash_profile"
+cat <<'EOF_PROFILE' > "${BASH_PROFILE}"
+if [[ -z "${DISPLAY:-}" && $(tty) == /dev/tty1 ]]; then
+  printf '[inst] Lanzando startx para modo kiosko\n'
+  exec startx -- -nocursor
+fi
+EOF_PROFILE
+chown "${TARGET_USER}:${TARGET_USER}" "${BASH_PROFILE}" || true
+chmod 0644 "${BASH_PROFILE}"
+
+XINITRC="${TARGET_HOME}/.xinitrc"
+cat <<'EOF_XINIT' > "${XINITRC}"
+#!/usr/bin/env bash
+set -euo pipefail
+
+xset s off
+xset -dpms
+xset s noblank
+
+matchbox-window-manager &
+WM_PID=$!
+
+cd "$HOME/bascula-cam"
+if [[ -x ./safe_run.sh ]]; then
+  exec ./safe_run.sh
+elif [[ -x ./.venv/bin/python ]]; then
+  exec ./.venv/bin/python main.py
+else
+  exec python3 main.py
+fi
+EOF_XINIT
+chown "${TARGET_USER}:${TARGET_USER}" "${XINITRC}" || true
+chmod 0755 "${XINITRC}"
+
+if [[ -x "${TARGET_HOME}/bascula-cam/safe_run.sh" ]]; then
+  chmod 0755 "${TARGET_HOME}/bascula-cam/safe_run.sh"
+fi
+
+log "Autologin y startx configurados para ${TARGET_USER}"

--- a/scripts/install-piper-voices.sh
+++ b/scripts/install-piper-voices.sh
@@ -1,96 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VOICE="${1:-es_ES-sharvard-medium}"
+MODELS_DIR="/opt/piper/models"
+BASE_URL="https://github.com/DanielGTdiabetes/bascula-cam/releases/download/voices-v1"
 
-VOICES_BASE="https://github.com/DanielGTdiabetes/bascula-cam/releases/download/voices-v1"
-PIPER_MODELS_DIR="/opt/piper/models"
+log() { printf '[inst] %s\n' "$*"; }
+warn() { printf '[warn] %s\n' "$*"; }
+err() { printf '[err] %s\n' "$*" >&2; }
 
-PIPER_VOICE="${PIPER_VOICE:-es_ES-sharvard-medium}"
-case "${PIPER_VOICE}" in
-  es_ES-sharvard-medium|es_ES-davefx-medium|es_ES-carlfm-x_low)
-    ;;
-  *)
-    echo "[err] Voz '${PIPER_VOICE}' no soportada. Usa: es_ES-sharvard-medium | es_ES-davefx-medium | es_ES-carlfm-x_low" >&2
-    exit 1
-    ;;
-esac
-
-install -d -m 0755 "${PIPER_MODELS_DIR}"
-
-TMP_WORK=""
-cleanup_tmp() {
-  if [[ -n "${TMP_WORK}" && -d "${TMP_WORK}" ]]; then
-    rm -rf "${TMP_WORK}"
-  fi
-  TMP_WORK=""
-}
-trap cleanup_tmp EXIT
-
-install_piper_bin() {
-  if command -v piper >/dev/null 2>&1; then
+download_voice() {
+  local file="$1"
+  local dest="${MODELS_DIR}/${file}"
+  if [[ -f "${dest}" ]]; then
+    log "${file} ya presente"
     return 0
   fi
-
-  local arch="$(uname -m)"
-  local url=""
-  case "${arch}" in
-    aarch64)
-      url="https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_aarch64.tar.gz"
-      ;;
-    armv7l|armv7hf|armv8l|armv6l|armv6)
-      url="https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_armv7l.tar.gz"
-      ;;
-    x86_64)
-      url="https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_x86_64.tar.gz"
-      ;;
-    *)
-      echo "[err] Arquitectura no soportada para Piper: ${arch}" >&2
-      exit 1
-      ;;
-  esac
-
-  TMP_WORK="$(mktemp -d)"
-  curl -fSL -o "${TMP_WORK}/piper.tgz" "${url}"
-  tar -xzf "${TMP_WORK}/piper.tgz" -C "${TMP_WORK}"
-  local PIPER_BIN
-  PIPER_BIN="$(find "${TMP_WORK}" -type f -name piper -perm -111 | head -n1 || true)"
-  test -n "${PIPER_BIN}" || { echo "[err] No se encontró ejecutable piper"; exit 1; }
-  install -m 0755 "${PIPER_BIN}" /usr/local/bin/piper
-  rm -rf "${TMP_WORK}"
-  TMP_WORK=""
-}
-
-download_asset() {
-  local asset="$1"
-  local dest="${PIPER_MODELS_DIR}/${asset}"
-  local url="${VOICES_BASE}/${asset}"
-  local tmp="${dest}.tmp.$$"
-
-  echo "[piper] Descargando ${asset} desde ${url}"
-  if ! curl -fSL --retry 3 --retry-delay 2 -o "${tmp}" "${url}"; then
-    rm -f "${tmp}"
-    echo "[err] No pude descargar ${PIPER_VOICE} (${asset}) desde ${url}" >&2
-    exit 1
+  local url="${BASE_URL}/${file}"
+  log "Descargando ${file}"
+  if ! curl -fSL --retry 3 --retry-delay 2 -o "${dest}.tmp" "${url}"; then
+    rm -f "${dest}.tmp"
+    err "No se pudo descargar ${url}"
+    return 1
   fi
-
-  local size
-  size="$(stat -c%s "${tmp}" 2>/dev/null || echo 0)"
-  if [[ "${size}" -lt 1024 ]]; then
-    rm -f "${tmp}"
-    echo "[err] No pude descargar ${PIPER_VOICE} (${asset}) desde ${url}" >&2
-    exit 1
+  if [[ ! -s "${dest}.tmp" ]]; then
+    rm -f "${dest}.tmp"
+    err "Descarga vacía de ${url}"
+    return 1
   fi
-
-  mv "${tmp}" "${dest}"
+  mv "${dest}.tmp" "${dest}"
   chmod 0644 "${dest}"
+  return 0
 }
 
-install_piper_bin
+install -d -m 0755 "${MODELS_DIR}"
 
-download_asset "${PIPER_VOICE}.onnx"
-download_asset "${PIPER_VOICE}.onnx.json"
+download_voice "${VOICE}.onnx" || warn "Fallo al obtener ${VOICE}.onnx"
+download_voice "${VOICE}.onnx.json" || warn "Fallo al obtener ${VOICE}.onnx.json"
 
-echo "${PIPER_VOICE}" > "${PIPER_MODELS_DIR}/.default-voice"
-echo "[ok] Voz ${PIPER_VOICE} instalada en /opt/piper/models"
+if command -v piper >/dev/null 2>&1; then
+  printf '%s\n' "${VOICE}" > "${MODELS_DIR}/.default-voice"
+  chmod 0644 "${MODELS_DIR}/.default-voice"
+  log "Modelo por defecto configurado en ${VOICE}"
+else
+  warn "piper no está disponible; se instaló solo el modelo"
+fi

--- a/scripts/x735-poweroff.sh
+++ b/scripts/x735-poweroff.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PIN="${X735_POWER_PIN:-4}"
+if command -v raspi-gpio >/dev/null 2>&1; then
+  raspi-gpio set "${PIN}" op dl
+  sleep 0.5
+  raspi-gpio set "${PIN}" op dh
+  sleep 0.5
+  raspi-gpio set "${PIN}" op dl
+fi

--- a/scripts/x735.sh
+++ b/scripts/x735.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG() { printf '[x735] %s\n' "$*"; }
+WARN() { printf '[warn] %s\n' "$*"; }
+
+FAN_PIN="${X735_FAN_PIN:-18}"
+BUTTON_PIN="${X735_BUTTON_PIN:-26}"
+POWER_PIN="${X735_POWER_PIN:-4}"
+FAN_ON_TEMP="${X735_FAN_ON:-60}"
+FAN_OFF_TEMP="${X735_FAN_OFF:-50}"
+BUTTON_HOLD_SEC="${X735_BUTTON_HOLD:-3}"
+
+command -v raspi-gpio >/dev/null 2>&1 || { WARN "raspi-gpio no disponible"; exit 0; }
+
+setup_pins() {
+  raspi-gpio set "${FAN_PIN}" op dl
+  raspi-gpio set "${POWER_PIN}" op dh
+  raspi-gpio set "${BUTTON_PIN}" ip pu
+}
+
+read_temp() {
+  if command -v vcgencmd >/dev/null 2>&1; then
+    vcgencmd measure_temp 2>/dev/null | sed -E 's/.*=([0-9]+\.?[0-9]*).*/\1/'
+  elif [[ -f /sys/class/thermal/thermal_zone0/temp ]]; then
+    awk '{ printf "%.1f", $1/1000 }' /sys/class/thermal/thermal_zone0/temp
+  else
+    echo "0"
+  fi
+}
+
+fan_state=0
+set_fan() {
+  local new_state="$1"
+  if [[ "${new_state}" -eq 1 && "${fan_state}" -ne 1 ]]; then
+    raspi-gpio set "${FAN_PIN}" op dh
+    fan_state=1
+    LOG "Ventilador encendido"
+  elif [[ "${new_state}" -eq 0 && "${fan_state}" -ne 0 ]]; then
+    raspi-gpio set "${FAN_PIN}" op dl
+    fan_state=0
+    LOG "Ventilador apagado"
+  fi
+}
+
+button_pressed() {
+  raspi-gpio get "${BUTTON_PIN}" 2>/dev/null | grep -q 'level=0'
+}
+
+setup_pins
+LOG "Controlador X735 iniciado (fan pin=${FAN_PIN})"
+
+hold_counter=0
+while true; do
+  temp="$(read_temp)"
+  if [[ "${temp%.*}" -ge "${FAN_ON_TEMP}" ]]; then
+    set_fan 1
+  elif [[ "${temp%.*}" -le "${FAN_OFF_TEMP}" ]]; then
+    set_fan 0
+  fi
+
+  if button_pressed; then
+    hold_counter=$((hold_counter + 1))
+    if [[ "${hold_counter}" -ge "${BUTTON_HOLD_SEC}" ]]; then
+      LOG "Botón de apagado mantenido; enviando poweroff"
+      systemctl poweroff
+    fi
+  else
+    hold_counter=0
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
## Summary
- rebuild the Raspberry Pi OS Lite installer into a two-phase flow with automatic resume after reboot
- prepare the base system in phase 1 by installing required packages, configuring kiosk autologin/startx, deploying Piper voice data, and wiring in x735 fan control
- configure the application stack in phase 2 by creating a dedicated venv, installing dependencies, registering systemd services, and updating diagnostics, kiosk scripts, and documentation

## Testing
- TARGET_USER=root TARGET_HOME=/root ./scripts/verify-kiosk.sh

------
https://chatgpt.com/codex/tasks/task_e_68cad5e9110c8326a3794e863bda5f8c