### PR TITLE
Restore voice listening API compatibility

### DIFF
--- a/tools/smoke_voice.py
+++ b/tools/smoke_voice.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from bascula.services.voice import VoiceService
+
+v = VoiceService()
+print("say: hola")
+v.say("Hola, probando voz.")
+
+got = []
+
+def cb(text: str) -> None:
+    print("heard:", text)
+    got.append(text)
+
+print("listen start")
+v.start_listening(cb, duration=3)
+
+import time
+
+time.sleep(1.0)
+print("is_listening:", v.is_listening())
+v.stop_listening()
+print("done")


### PR DESCRIPTION
## Summary
- restore the listening APIs in `VoiceService`, wiring optional backends or a stub callback
- update Focus mode and recipe overlay UI controls to respect the new `is_listening`/`stop_listening` flow and button states
- add a minimal smoke script that exercises speech synthesis and the listening stub

## Testing
- python tools/smoke_voice.py
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cad9d0ce34832695b920be3a90cbc4