### PR TITLE
Add systemd units and safe run script for kiosk

### DIFF
--- a/etc/systemd/system/bascula-miniweb.service
+++ b/etc/systemd/system/bascula-miniweb.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bascula Mini Web
+After=network-online.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/bascula-cam
+ExecStart=/home/pi/bascula-cam/.venv/bin/uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port 8080
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/bascula-recovery.service
+++ b/etc/systemd/system/bascula-recovery.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Bascula Recovery UI
+After=graphical.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/bascula-cam
+ExecStartPre=/usr/bin/python3 -m py_compile /home/pi/bascula-cam/main.py
+ExecStart=/usr/bin/python3 /home/pi/bascula-cam/bascula/ui/recovery_ui.py
+Restart=on-failure
+
+[Install]
+WantedBy=graphical.target

--- a/etc/systemd/system/bascula-ui.service
+++ b/etc/systemd/system/bascula-ui.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Bascula UI (Tkinter Kiosk)
+After=graphical.target
+OnFailure=bascula-recovery.service
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/bascula-cam
+ExecStart=/home/pi/bascula-cam/scripts/safe_run.sh
+Restart=on-failure
+Environment=BASCULA_THEME=retro
+
+[Install]
+WantedBy=graphical.target

--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -1,202 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# --- Debug info
-echo "[safe_run] Starting with UID: $(id -u), GID: $(id -g)" >&2
-echo "[safe_run] Current directory: $(pwd)" >&2
-echo "[safe_run] Environment:" >&2
-env | sort >&2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOG_DIR="${REPO_ROOT}/logs"
+LOG_FILE="${LOG_DIR}/safe_run.log"
 
-# --- Paths
-APP_DIR=""
-APP_CANDIDATES=(
-  "/home/pi/bascula-cam"  # Primary location
-  "$HOME/bascula-cam"
-  "/opt/bascula/current"
-  "$HOME/bascula-cam-main"
-)
+mkdir -p "${LOG_DIR}"
 
-for candidate in "${APP_CANDIDATES[@]}"; do
-  if [ -d "$candidate" ]; then
-    APP_DIR="$candidate"
-    echo "[safe_run] Found app directory: $APP_DIR" >&2
-    break
-  else
-    echo "[safe_run] Directory not found: $candidate" >&2
-  fi
-done
+cd "${REPO_ROOT}"
 
-if [ -z "$APP_DIR" ]; then
-  echo "[safe_run] ERROR: Application directory not found in any of: ${APP_CANDIDATES[*]}" >&2
-  exit 1
+if [ -f ".venv/bin/activate" ]; then
+  # shellcheck disable=SC1091
+  source ".venv/bin/activate"
 fi
 
-# Ensure we can access the directory
-if [ ! -r "$APP_DIR" ] || [ ! -x "$APP_DIR" ]; then
-  echo "[safe_run] ERROR: Cannot access directory $APP_DIR (permission denied)" >&2
-  ls -ld "$APP_DIR" >&2
-  exit 1
-fi
-
-cd "$APP_DIR" || {
-  echo "[safe_run] ERROR: Failed to change to directory: $APP_DIR" >&2
-  exit 1
-}
-
-echo "[safe_run] Changed to directory: $(pwd)" >&2
-
-# Create log directory with proper permissions
-LOG_DIR="$HOME/.bascula/logs"
-mkdir -p "$LOG_DIR" 2>/dev/null || {
-  echo "[safe_run] WARNING: Failed to create log directory: $LOG_DIR" >&2
-  LOG_DIR="/tmp/bascula-logs"
-  mkdir -p "$LOG_DIR" 2>/dev/null || {
-    echo "[safe_run] ERROR: Cannot create any log directory" >&2
-    exit 1
-  }
-}
-
-# Ensure the log directory is writable
-if [ ! -w "$LOG_DIR" ]; then
-  echo "[safe_run] WARNING: Log directory is not writable: $LOG_DIR" >&2
-  LOG_DIR="/tmp/bascula-logs"
-  mkdir -p "$LOG_DIR" && chmod 777 "$LOG_DIR" || {
-    echo "[safe_run] ERROR: Cannot write to any log directory" >&2
-    exit 1
-  }
-fi
-
-LOG="$LOG_DIR/app.log"
-if ! touch "$LOG" 2>/dev/null; then
-  LOG="$HOME/app.log"
-  if ! touch "$LOG" 2>/dev/null; then
-    LOG="/tmp/bascula-app.log"
-    touch "$LOG" 2>/dev/null || true
-  fi
-fi
-
-echo "[safe_run] Directorio de la app: $APP_DIR" | tee -a "$LOG"
-echo "[safe_run] Registro en: $LOG" | tee -a "$LOG"
-
-# --- Entorno Xorg mejorado
-export DISPLAY=${DISPLAY:-:0}
-export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
-
-# Variables adicionales para Tkinter en kiosk
-export XAUTHORITY=${XAUTHORITY:-$HOME/.Xauthority}
-export XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-x11}
-
-# --- Verificar y configurar display
-echo "[safe_run] Verificando display ${DISPLAY:-:0}…" | tee -a "$LOG"
-
-# Asegurar que DISPLAY esté configurado
-if [ -z "${DISPLAY:-}" ]; then
-  export DISPLAY=":0"
-  echo "[safe_run] DISPLAY no configurado, usando :0" | tee -a "$LOG"
-fi
-
-# Esperar hasta 30 segundos para que X11 esté disponible
-echo "[safe_run] Esperando X11…" | tee -a "$LOG"
-for i in {1..30}; do
-  if xset -q >/dev/null 2>&1; then
-    echo "[safe_run] Display ${DISPLAY} funcionando después de ${i}s" | tee -a "$LOG"
-    break
-  fi
-  sleep 1
-done
-
-# Verificación final
-if ! xset -q >/dev/null 2>&1; then
-  echo "[safe_run] ERROR: No se pudo establecer conexión X11 después de 30s" | tee -a "$LOG"
-  echo "[safe_run] Saliendo con error" | tee -a "$LOG"
-  exit 1
-fi
-
-# --- Recovery flag
-REC_FLAG="/var/lib/bascula-updater/force_recovery"
-if [ -f "$REC_FLAG" ]; then
-  echo "[safe_run] Recovery flag encontrado, lanzando Recovery UI" | tee -a "$LOG"
-  if [ -x ".venv/bin/python" ]; then
-    exec .venv/bin/python -m bascula.ui.recovery_ui 2>>"$LOG"
-  else
-    exec python3 -m bascula.ui.recovery_ui 2>>"$LOG"
-  fi
-fi
-
-# --- Venv opcional
-PY=".venv/bin/python"
-if [ -x "$PY" ]; then
-  echo "[safe_run] Usando venv local" | tee -a "$LOG"
+if output=$(python3 main.py "$@" 2>&1); then
+  printf '%s\n' "$output"
+  exit 0
 else
-  PY="python3"
+  status=$?
+  printf '%s\n' "$output" >&2
+  {
+    printf '[%s] bascula main.py failed with exit code %s\n' "$(date --iso-8601=seconds)" "$status"
+    printf '%s\n' "$output"
+    printf '\n'
+  } >>"${LOG_FILE}"
+  exit "$status"
 fi
-
-# --- Configuración de pantalla para kiosk
-echo "[safe_run] Configurando pantalla para kiosk…" | tee -a "$LOG"
-
-# Desactivar ahorro de energía y protector de pantalla
-if which xset >/dev/null 2>&1; then
-  xset s off          # Desactivar screensaver
-  xset -dpms          # Desactivar power management
-  xset s noblank      # No blanquear pantalla
-  echo "[safe_run] Configuración xset aplicada" | tee -a "$LOG"
-fi
-
-# Ocultar cursor del mouse
-if which unclutter >/dev/null 2>&1; then
-  unclutter -idle 0.1 -root &
-  echo "[safe_run] Cursor oculto con unclutter" | tee -a "$LOG"
-fi
-
-# Configurar resolución si es necesario
-if which xrandr >/dev/null 2>&1; then
-  # Intentar configurar resolución óptima
-  xrandr --output HDMI-1 --mode 1024x600 2>/dev/null || true
-  echo "[safe_run] Configuración xrandr aplicada" | tee -a "$LOG"
-fi
-
-# --- Lanzar app con reintentos
-echo "[safe_run] Lanzando app…" | tee -a "$LOG"
-
-# Función para lanzar la app con reintentos
-launch_app() {
-  local attempt=1
-  local max_attempts=3
-  
-  while [ $attempt -le $max_attempts ]; do
-    echo "[safe_run] Intento $attempt de $max_attempts" | tee -a "$LOG"
-    
-    # Verificar display antes de cada intento
-    if ! xset q >/dev/null 2>&1; then
-      echo "[safe_run] Display no disponible en intento $attempt" | tee -a "$LOG"
-      sleep 2
-      attempt=$((attempt + 1))
-      continue
-    fi
-    
-    # Lanzar aplicación
-    "$PY" main.py >>"$LOG" 2>&1
-    exit_code=$?
-    
-    if [ $exit_code -eq 0 ]; then
-      echo "[safe_run] App terminó normalmente" | tee -a "$LOG"
-      exit 0
-    elif [ $exit_code -eq 1 ]; then
-      echo "[safe_run] Error de importación o display, reintentando…" | tee -a "$LOG"
-      sleep 3
-    else
-      echo "[safe_run] Error crítico (código $exit_code), terminando" | tee -a "$LOG"
-      exit $exit_code
-    fi
-    
-    attempt=$((attempt + 1))
-  done
-  
-  echo "[safe_run] Máximo de intentos alcanzado, terminando" | tee -a "$LOG"
-  exit 1
-}
-
-# Ejecutar función de lanzamiento
-launch_app


### PR DESCRIPTION
## Summary
- replace the kiosk launcher safe_run.sh with a minimal wrapper that activates the venv, runs main.py, and logs failures to logs/safe_run.log
- add bascula-ui.service and bascula-miniweb.service definitions for Raspberry Pi OS kiosk deployments
- provide a bascula-recovery.service unit so recovery_ui.py can be launched automatically if the main UI service fails

## Testing
- bash -n scripts/safe_run.sh

------
https://chatgpt.com/codex/tasks/task_e_68cade1f21a083268f4cb34a6df53154