### PR TITLE
Conectar overlays y pantallas ocultas

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -124,6 +124,8 @@ class HomeScreen(BaseScreen):
 
         BigButton(actions, text="Pesar ahora", command=lambda: app.show_screen("scale")).pack(side="left", padx=6)
         GhostButton(actions, text="Ver historial", command=app.show_history, micro=True).pack(side="left", padx=6)
+        GhostButton(actions, text="Recetas", command=app.open_recipes, micro=True).pack(side="left", padx=6)
+        GhostButton(actions, text="⏱ Timer", command=app.open_timer_overlay, micro=True).pack(side="left", padx=6)
 
         self.history_card = Card(hero)
         self.history_card.pack(fill="both", expand=True, pady=(16, 0))
@@ -183,6 +185,12 @@ class ScaleScreen(BaseScreen):
         BigButton(buttons, text="Cero", command=app.perform_zero).pack(side="left", expand=True, fill="x", padx=4)
         GhostButton(buttons, text="Capturar", command=app.capture_weight).pack(side="left", expand=True, fill="x", padx=4)
         GhostButton(buttons, text="📷 Escanear", command=app.open_scanner).pack(side="left", expand=True, fill="x", padx=4)
+
+        extras = tk.Frame(card, bg=COL_CARD)
+        extras.pack(fill="x", pady=(0, 12))
+        GhostButton(extras, text="⭐ Favoritos", command=app.open_favorites, micro=True).pack(side="left", expand=True, fill="x", padx=4)
+        GhostButton(extras, text="⏱ Timer", command=app.open_timer_overlay, micro=True).pack(side="left", expand=True, fill="x", padx=4)
+        GhostButton(extras, text="🍳 Recetas", command=app.open_recipes, micro=True).pack(side="left", expand=True, fill="x", padx=4)
 
         info = tk.Label(
             card,


### PR DESCRIPTION
## Summary
- Registrar los overlays de recetas, temporizador y favoritos dentro de `BasculaAppTk` con acciones públicas para abrirlos desde la interfaz
- Mejorar `RecipeOverlay` para que degrade el uso de voz cuando no hay backend y muestre feedback táctil/visual al avanzar pasos
- Añadir accesos visibles a Recetas, Temporizador y Favoritos en las pantallas Home/Pesar y en la barra superior, dinamizando además el menú "Más"
- Robustecer Focus Mode reutilizando un stub de voz cuando el servicio real no está disponible

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68cadfac68908326a5e3525fa6980c9d