### PR TITLE
Fix systemd environment for Tkinter UIs

### DIFF
--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -8,6 +8,20 @@ LOG_FILE="${LOG_DIR}/safe_run.log"
 
 mkdir -p "${LOG_DIR}"
 
+log_msg() {
+  printf '[%s] %s\n' "$(date --iso-8601=seconds)" "$1" >>"${LOG_FILE}"
+}
+
+if [[ -z "${DISPLAY:-}" && -S /tmp/.X11-unix/X0 ]]; then
+  export DISPLAY=:0
+  log_msg "DISPLAY no definido, usando DISPLAY=:0"
+fi
+
+if [[ -z "${XAUTHORITY:-}" ]]; then
+  export XAUTHORITY="${HOME}/.Xauthority"
+  log_msg "XAUTHORITY no definido, usando ${XAUTHORITY}"
+fi
+
 cd "${REPO_ROOT}"
 
 if [ -f ".venv/bin/activate" ]; then

--- a/scripts/verify-kiosk.sh
+++ b/scripts/verify-kiosk.sh
@@ -100,4 +100,60 @@ else
   warn "bascula-miniweb.service no existe"
 fi
 
+if systemctl list-units --type=service --all | grep -q '^bascula-ui.service'; then
+  env_output=$(systemctl show bascula-ui.service -p Environment 2>/dev/null || true)
+  if grep -q 'DISPLAY=:0' <<<"${env_output}"; then
+    ok "bascula-ui con DISPLAY=:0"
+  else
+    warn "bascula-ui sin DISPLAY=:0"
+  fi
+  if grep -q 'XAUTHORITY=' <<<"${env_output}"; then
+    ok "bascula-ui con XAUTHORITY"
+  else
+    warn "bascula-ui sin XAUTHORITY"
+  fi
+  if [[ -S /tmp/.X11-unix/X0 ]]; then
+    ok "Socket X0 disponible"
+  else
+    warn "Socket X0 no encontrado"
+  fi
+  if systemctl is-active bascula-ui.service >/dev/null 2>&1; then
+    ok "bascula-ui activo"
+  else
+    warn "bascula-ui no activo (revisar systemctl status bascula-ui)"
+  fi
+else
+  warn "bascula-ui.service no existe"
+fi
+
+if systemctl list-units --type=service --all | grep -q '^bascula-recovery.service'; then
+  if systemctl is-enabled bascula-recovery.service >/dev/null 2>&1; then
+    env_output=$(systemctl show bascula-recovery.service -p Environment 2>/dev/null || true)
+    if grep -q 'DISPLAY=:0' <<<"${env_output}"; then
+      ok "bascula-recovery con DISPLAY=:0"
+    else
+      warn "bascula-recovery sin DISPLAY=:0"
+    fi
+    if grep -q 'XAUTHORITY=' <<<"${env_output}"; then
+      ok "bascula-recovery con XAUTHORITY"
+    else
+      warn "bascula-recovery sin XAUTHORITY"
+    fi
+    if [[ -S /tmp/.X11-unix/X0 ]]; then
+      ok "Socket X0 disponible"
+    else
+      warn "Socket X0 no encontrado"
+    fi
+    if systemctl is-active bascula-recovery.service >/dev/null 2>&1; then
+      ok "bascula-recovery activo"
+    else
+      warn "bascula-recovery no activo (revisar systemctl status bascula-recovery)"
+    fi
+  else
+    warn "bascula-recovery.service existe pero no está habilitado"
+  fi
+else
+  log "bascula-recovery.service no existe"
+fi
+
 ok "Diagnóstico completado"


### PR DESCRIPTION
## Summary
- update the generated bascula-ui and bascula-recovery systemd units to export DISPLAY/XAUTHORITY, wait for the :0 socket and keep compatibility with startx before launching the kiosk scripts
- harden scripts/safe_run.sh with last-resort DISPLAY/XAUTHORITY fallbacks and logging when they are missing
- extend scripts/verify-kiosk.sh to validate the new service environments and X socket availability during kiosk checks

## Testing
- python -m py_compile $(git ls-files '*.py')

Tkinter necesita DISPLAY y XAUTHORITY definidos cuando arranca bajo systemd; sin estas variables las UIs de Tkinter no pueden abrir ventana.

------
https://chatgpt.com/codex/tasks/task_e_68cae3a40a4483268aa37e5f565b796c