### PR TITLE
Prepare kiosk install for Raspberry Pi

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from importlib import import_module
 import tkinter as tk
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional, Type
+from typing import Any, Dict, Iterable, Optional, Sequence, Type
 
 from bascula.config.theme import apply_theme
 from bascula.state import AppState
@@ -202,7 +202,7 @@ class BasculaAppTk:
         self._screen_labels: Dict[str, str] = {}
         self._advanced_screens: Dict[str, str] = {}
 
-        base_screens: Iterable[tuple[str, Type[tk.Frame], str, tuple[str, ...]]] = (
+        base_screens: Iterable[tuple[str, Type[tk.Frame], str, Sequence[str]]] = (
             ("home", HomeScreen, "Home", (getattr(HomeScreen, "name", "home"),)),
             ("scale", ScaleScreen, "Pesar", (getattr(ScaleScreen, "name", "scale"),)),
             (
@@ -569,7 +569,7 @@ class BasculaAppTk:
                 "El módulo %s no define %s; omitiendo pantalla opcional", module_name, class_name
             )
             return
-        aliases: tuple[str, ...] = ()
+        aliases: Sequence[str] = ()
         class_name = getattr(screen_cls, "name", None)
         if class_name and class_name != key:
             aliases = (class_name,)

--- a/etc/systemd/system/bascula-recovery.service
+++ b/etc/systemd/system/bascula-recovery.service
@@ -1,13 +1,19 @@
 [Unit]
 Description=Bascula Recovery UI
 After=graphical.target
+Wants=graphical.target
 
 [Service]
 User=pi
 WorkingDirectory=/home/pi/bascula-cam
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/pi/.Xauthority
+Environment=PYTHONUNBUFFERED=1
 ExecStartPre=/usr/bin/python3 -m py_compile /home/pi/bascula-cam/main.py
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do [ -S /tmp/.X11-unix/X0 ] && exit 0; sleep 0.5; done; exit 1'
 ExecStart=/usr/bin/python3 /home/pi/bascula-cam/bascula/ui/recovery_ui.py
 Restart=on-failure
+RestartSec=2
 
 [Install]
 WantedBy=graphical.target

--- a/etc/systemd/system/bascula-ui.service
+++ b/etc/systemd/system/bascula-ui.service
@@ -1,14 +1,18 @@
 [Unit]
 Description=Bascula UI (Tkinter Kiosk)
 After=graphical.target
-OnFailure=bascula-recovery.service
+Wants=graphical.target
 
 [Service]
 User=pi
 WorkingDirectory=/home/pi/bascula-cam
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/pi/.Xauthority
+Environment=PYTHONUNBUFFERED=1
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do [ -S /tmp/.X11-unix/X0 ] && exit 0; sleep 0.5; done; exit 1'
 ExecStart=/home/pi/bascula-cam/scripts/safe_run.sh
 Restart=on-failure
-Environment=BASCULA_THEME=retro
+RestartSec=2
 
 [Install]
 WantedBy=graphical.target

--- a/etc/systemd/system/x735-fan.service
+++ b/etc/systemd/system/x735-fan.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=X735 v3 Fan and Power Management
+After=multi-user.target
+
+[Service]
+ExecStart=/usr/local/bin/x735.sh
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 TARGET_USER="${TARGET_USER:-pi}"
 PHASE_DIR="/var/lib/bascula"
+RESUME_FILE="/etc/profile.d/bascula-resume.sh"
 
 log() { printf '[inst] %s\n' "$*"; }
 ok() { printf '[ok] %s\n' "$*"; }
@@ -57,99 +58,32 @@ if [[ ! -d "${APP_DIR}" ]]; then
   exit 1
 fi
 
-log "Creando entorno virtual"
-sudo -u "${TARGET_USER}" -- "${PYTHON}" -m venv "${VENV_DIR}" >/dev/null 2>&1 || \
+install -d -m 0755 "${PHASE_DIR}"
+
+log "Preparando entorno virtual"
+if [[ ! -d "${VENV_DIR}" ]]; then
   sudo -u "${TARGET_USER}" -- "${PYTHON}" -m venv "${VENV_DIR}"
+  ok "Entorno virtual creado"
+else
+  log "Entorno virtual existente reutilizado"
+fi
 sudo -u "${TARGET_USER}" -- "${VENV_DIR}/bin/python" -m pip install --upgrade pip setuptools wheel
 sudo -u "${TARGET_USER}" -- "${VENV_DIR}/bin/pip" install -r "${REPO_ROOT}/requirements.txt"
 
-log "Creando servicios systemd"
-cat <<UI > /etc/systemd/system/bascula-ui.service
-[Unit]
-Description=Bascula UI (Tkinter Kiosk)
-After=graphical.target
-Wants=graphical.target
+log "Instalando servicios systemd"
+install -m 0644 "${REPO_ROOT}/etc/systemd/system/bascula-ui.service" /etc/systemd/system/bascula-ui.service
+install -m 0644 "${REPO_ROOT}/etc/systemd/system/bascula-miniweb.service" /etc/systemd/system/bascula-miniweb.service
 
-[Service]
-User=${TARGET_USER}
-WorkingDirectory=${APP_DIR}
-Environment=DISPLAY=:0
-Environment=XAUTHORITY=${TARGET_HOME}/.Xauthority
-Environment=PYTHONUNBUFFERED=1
-# Espera activa a que exista el socket de X :0 (máx ~15s)
-ExecStartPre=/bin/sh -c 'for i in \$(seq 1 30); do [ -S /tmp/.X11-unix/X0 ] && exit 0; sleep 0.5; done; exit 1'
-ExecStart=${APP_DIR}/scripts/safe_run.sh
-Restart=on-failure
-RestartSec=2
-
-[Install]
-WantedBy=graphical.target
-UI
-
-RECOVERY_UI="${APP_DIR}/bascula/ui/recovery_ui.py"
+RECOVERY_UNIT="${REPO_ROOT}/etc/systemd/system/bascula-recovery.service"
 RECOVERY_AVAILABLE=false
-if [[ -f "${RECOVERY_UI}" ]]; then
-  cat <<REC > /etc/systemd/system/bascula-recovery.service
-[Unit]
-Description=Bascula Recovery UI (fallback Tkinter)
-After=graphical.target
-Wants=graphical.target
-
-[Service]
-User=${TARGET_USER}
-WorkingDirectory=${APP_DIR}
-Environment=DISPLAY=:0
-Environment=XAUTHORITY=${TARGET_HOME}/.Xauthority
-Environment=PYTHONUNBUFFERED=1
-ExecStartPre=/usr/bin/python3 -m py_compile ${APP_DIR}/main.py
-ExecStartPre=/bin/sh -c 'for i in \$(seq 1 30); do [ -S /tmp/.X11-unix/X0 ] && exit 0; sleep 0.5; done; exit 1'
-ExecStart=/usr/bin/python3 ${APP_DIR}/bascula/ui/recovery_ui.py
-Restart=on-failure
-RestartSec=2
-
-[Install]
-WantedBy=graphical.target
-REC
+if [[ -f "${APP_DIR}/bascula/ui/recovery_ui.py" && -f "${RECOVERY_UNIT}" ]]; then
+  install -m 0644 "${RECOVERY_UNIT}" /etc/systemd/system/bascula-recovery.service
   RECOVERY_AVAILABLE=true
 fi
 
-cat <<WEB > /etc/systemd/system/bascula-miniweb.service
-[Unit]
-Description=Bascula Mini Web
-After=network-online.target
-
-[Service]
-User=${TARGET_USER}
-WorkingDirectory=${APP_DIR}
-ExecStart=${APP_DIR}/.venv/bin/uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port 8080
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-WEB
-
 systemctl daemon-reload
-if systemctl enable bascula-ui.service; then
-  ok "Servicio bascula-ui habilitado"
-else
-  warn "No se pudo habilitar bascula-ui"
-fi
+systemctl enable bascula-ui.service bascula-miniweb.service
 
-if [[ ${RECOVERY_AVAILABLE} == true ]]; then
-  if systemctl enable bascula-recovery.service; then
-    ok "Servicio bascula-recovery habilitado"
-  else
-    warn "No se pudo habilitar bascula-recovery"
-  fi
-else
-  log "bascula-recovery no disponible (archivo ${RECOVERY_UI} no encontrado)"
-fi
-
-if systemctl enable bascula-miniweb.service; then
-  ok "Servicio bascula-miniweb habilitado"
-else
-  warn "No se pudo habilitar bascula-miniweb"
-fi
 if systemctl restart bascula-miniweb.service >/dev/null 2>&1; then
   ok "bascula-miniweb reiniciado"
 else
@@ -161,19 +95,22 @@ else
   warn "No se pudo iniciar bascula-ui (requiere entorno gráfico)"
 fi
 
-if [[ ${RECOVERY_AVAILABLE} == true ]]; then
+if ${RECOVERY_AVAILABLE}; then
+  systemctl enable bascula-recovery.service
   if systemctl restart bascula-recovery.service >/dev/null 2>&1; then
     ok "bascula-recovery reiniciado"
   else
     warn "No se pudo iniciar bascula-recovery (requiere entorno gráfico)"
   fi
+else
+  log "bascula-recovery no disponible"
 fi
 
-install -d -m 0755 "${PHASE_DIR}"
 printf 'PHASE=2_DONE\n' > "${PHASE_DIR}/phase"
 
-if ${RESUME_MODE}; then
-  rm -f /etc/profile.d/bascula-resume.sh
+if ${RESUME_MODE} && [[ -f "${RESUME_FILE}" ]]; then
+  rm -f "${RESUME_FILE}"
+  ok "Script de reanudación eliminado"
 fi
 
 ok "Fase 2 completada"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -2,32 +2,59 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PHASE_FILE="/var/lib/bascula/phase"
 
 log() { printf '[inst] %s\n' "$*"; }
 err() { printf '[err] %s\n' "$*" >&2; }
 
 usage() {
   cat <<'USAGE'
-Uso: scripts/install-all.sh [opciones fase1]
+Uso: scripts/install-all.sh
 
-Ejecuta la instalación completa en dos fases con reinicio intermedio.
-Las opciones proporcionadas se pasan a install-1-system.sh.
+Orquesta la instalación completa en dos fases con reinicio intermedio.
+Ejecuta install-1-system.sh en la primera invocación y, tras el reinicio,
+completa la configuración mediante install-2-app.sh.
 USAGE
   exit "${1:-0}"
 }
 
-while [[ $# -gt 0 ]]; do
+if [[ $# -gt 0 ]]; then
   case "$1" in
     -h|--help)
       usage 0
       ;;
     *)
-      break
+      err "Opción no reconocida: $1"
+      usage 1
       ;;
   esac
-  shift
-done
+fi
 
-log "Iniciando fase 1 (sistema + hardware)"
-"${SCRIPT_DIR}/install-1-system.sh" --from-all "$@"
-# No se alcanza este punto porque fase 1 ejecuta reboot cuando finaliza
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  err "Este script debe ejecutarse como root"
+  exit 1
+fi
+
+current_phase="NONE"
+if [[ -f "${PHASE_FILE}" ]]; then
+  phase_value=$(grep -E '^PHASE=' "${PHASE_FILE}" | tail -n1 | cut -d= -f2- || true)
+  if [[ -n "${phase_value}" ]]; then
+    current_phase="${phase_value}"
+  fi
+fi
+
+case "${current_phase}" in
+  2_DONE)
+    log "La instalación completa ya se ejecutó (PHASE=2_DONE)"
+    exit 0
+    ;;
+  1_DONE)
+    log "Detectada fase 1 completada. Ejecutando fase 2"
+    "${SCRIPT_DIR}/install-2-app.sh" --resume
+    exit 0
+    ;;
+  *)
+    log "Iniciando fase 1 (sistema + hardware)"
+    "${SCRIPT_DIR}/install-1-system.sh" --from-all
+    ;;
+esac

--- a/scripts/install-kiosk-xorg.sh
+++ b/scripts/install-kiosk-xorg.sh
@@ -3,13 +3,10 @@ set -euo pipefail
 
 TARGET_USER="${1:-pi}"
 TARGET_HOME="${2:-/home/pi}"
+APP_DIR="${TARGET_HOME}/bascula-cam"
 
 log() { printf '[inst] %s\n' "$*"; }
 warn() { printf '[warn] %s\n' "$*"; }
-
-if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
-  warn "Se requieren privilegios de root para configurar autologin"
-fi
 
 if [[ ! -d "${TARGET_HOME}" ]]; then
   warn "Directorio home ${TARGET_HOME} inexistente"
@@ -28,7 +25,6 @@ chmod 0644 "${GETTY_DIR}/override.conf"
 BASH_PROFILE="${TARGET_HOME}/.bash_profile"
 cat <<'EOF_PROFILE' > "${BASH_PROFILE}"
 if [[ -z "${DISPLAY:-}" && $(tty) == /dev/tty1 ]]; then
-  printf '[inst] Lanzando startx para modo kiosko\n'
   exec startx -- -nocursor
 fi
 EOF_PROFILE
@@ -36,31 +32,16 @@ chown "${TARGET_USER}:${TARGET_USER}" "${BASH_PROFILE}" || true
 chmod 0644 "${BASH_PROFILE}"
 
 XINITRC="${TARGET_HOME}/.xinitrc"
-cat <<'EOF_XINIT' > "${XINITRC}"
+cat <<EOF_XINIT > "${XINITRC}"
 #!/usr/bin/env bash
 set -euo pipefail
 
-xset s off
-xset -dpms
-xset s noblank
-
+xset s off -dpms
 matchbox-window-manager &
-WM_PID=$!
 
-cd "$HOME/bascula-cam"
-if [[ -x ./safe_run.sh ]]; then
-  exec ./safe_run.sh
-elif [[ -x ./.venv/bin/python ]]; then
-  exec ./.venv/bin/python main.py
-else
-  exec python3 main.py
-fi
+exec ${APP_DIR}/scripts/safe_run.sh
 EOF_XINIT
 chown "${TARGET_USER}:${TARGET_USER}" "${XINITRC}" || true
 chmod 0755 "${XINITRC}"
-
-if [[ -x "${TARGET_HOME}/bascula-cam/safe_run.sh" ]]; then
-  chmod 0755 "${TARGET_HOME}/bascula-cam/safe_run.sh"
-fi
 
 log "Autologin y startx configurados para ${TARGET_USER}"

--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -4,41 +4,40 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 LOG_DIR="${REPO_ROOT}/logs"
-LOG_FILE="${LOG_DIR}/safe_run.log"
-
-mkdir -p "${LOG_DIR}"
-
-log_msg() {
-  printf '[%s] %s\n' "$(date --iso-8601=seconds)" "$1" >>"${LOG_FILE}"
-}
-
-if [[ -z "${DISPLAY:-}" && -S /tmp/.X11-unix/X0 ]]; then
-  export DISPLAY=:0
-  log_msg "DISPLAY no definido, usando DISPLAY=:0"
-fi
-
-if [[ -z "${XAUTHORITY:-}" ]]; then
-  export XAUTHORITY="${HOME}/.Xauthority"
-  log_msg "XAUTHORITY no definido, usando ${XAUTHORITY}"
-fi
+LOG_FILE="${LOG_DIR}/ui.log"
+ROTATED_LOG="${LOG_FILE}.1"
+MAX_SIZE=$((5 * 1024 * 1024))
 
 cd "${REPO_ROOT}"
 
-if [ -f ".venv/bin/activate" ]; then
+if [[ -d ".venv" && -f ".venv/bin/activate" ]]; then
   # shellcheck disable=SC1091
   source ".venv/bin/activate"
 fi
 
-if output=$(python3 main.py "$@" 2>&1); then
-  printf '%s\n' "$output"
-  exit 0
-else
-  status=$?
-  printf '%s\n' "$output" >&2
-  {
-    printf '[%s] bascula main.py failed with exit code %s\n' "$(date --iso-8601=seconds)" "$status"
-    printf '%s\n' "$output"
-    printf '\n'
-  } >>"${LOG_FILE}"
-  exit "$status"
+if [[ -z "${DISPLAY:-}" && -S /tmp/.X11-unix/X0 ]]; then
+  export DISPLAY=:0
 fi
+
+if [[ -z "${XAUTHORITY:-}" ]]; then
+  export XAUTHORITY="${HOME}/.Xauthority"
+fi
+
+mkdir -p "${LOG_DIR}"
+if [[ -f "${LOG_FILE}" ]]; then
+  current_size=$(stat -c '%s' "${LOG_FILE}" 2>/dev/null || echo 0)
+  if (( current_size > MAX_SIZE )); then
+    mv "${LOG_FILE}" "${ROTATED_LOG}" 2>/dev/null || true
+  fi
+fi
+
+touch "${LOG_FILE}"
+
+python3 main.py "$@" 2>&1 | tee -a "${LOG_FILE}"
+exit_code=${PIPESTATUS[0]}
+
+if (( exit_code != 0 )); then
+  printf '%s\n' "${exit_code}" > "${LOG_DIR}/last_exit_code"
+fi
+
+exit "${exit_code}"


### PR DESCRIPTION
## Summary
- stream UI output through scripts/safe_run.sh with log rotation and display/Xauthority fallbacks
- update systemd units for the kiosk, recovery UI, and X735 fan control with display environment and socket waits
- orchestrate two-phase installation, virtualenv setup, kiosk autologin, piper voice provisioning, and verification checks

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cae6ee80d08326b830fbce3de0ca9d