### PR TITLE
Ensure Piper voice installer handles missing voices

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -76,7 +76,7 @@ log "Instalando voces Piper"
 if bash "${SCRIPT_DIR}/install-piper-voices.sh"; then
   ok "Voces Piper instaladas"
 else
-  warn "No se pudieron instalar las voces Piper (continuando)"
+  warn "Voces Piper no instaladas (continuo sin abortar Fase 1)"
 fi
 
 log "Configurando soporte X735"


### PR DESCRIPTION
## Summary
- ensure the Piper voice installer counts complete model pairs before creating .default-voice
- respect the voice installer exit code during Phase 1 and log a warning instead of aborting
- extend kiosk verification to validate the default voice reference and confirm model presence

## Testing
- bash -n scripts/install-piper-voices.sh
- bash -n scripts/install-1-system.sh
- bash -n scripts/verify-kiosk.sh

Nota: Se evita escribir .default-voice si no hay voces instaladas; el instalador de voces devuelve código ≠ 0 en ese caso; la Fase 1 continúa con warning.

------
https://chatgpt.com/codex/tasks/task_e_68caf1592fec8326ba236c4fdda75515