### PR TITLE
Add OTA maintenance flow

### DIFF
--- a/bascula/ui/recovery_ui.py
+++ b/bascula/ui/recovery_ui.py
@@ -9,13 +9,13 @@ consistente. Permite intentar una actualización y reiniciar el sistema.
 from __future__ import annotations
 
 import os
+import queue
 import subprocess
 import sys
 import threading
 from pathlib import Path
 import tkinter as tk
 
-from bascula.services.ota import OTAService
 from bascula.ui.widgets import COL_BG, COL_CARD, COL_TEXT, COL_ACCENT, FS_TITLE, FS_TEXT
 
 
@@ -84,10 +84,10 @@ class RecoveryUI:
             pady=12,
         ).pack(side="left", padx=8)
 
-        tk.Button(
+        self.ota_button = tk.Button(
             buttons,
-            text="Actualizar OTA",
-            command=self._run_ota,
+            text="Actualización OTA",
+            command=self._open_ota_dialog,
             bg="#2563eb",
             fg="white",
             bd=0,
@@ -95,7 +95,8 @@ class RecoveryUI:
             cursor="hand2",
             padx=18,
             pady=12,
-        ).pack(side="left", padx=8)
+        )
+        self.ota_button.pack(side="left", padx=8)
 
         tk.Button(
             buttons,
@@ -110,8 +111,14 @@ class RecoveryUI:
             pady=12,
         ).pack(side="left", padx=8)
 
-        repo = _repo_root(Path(__file__).resolve())
-        self.ota = OTAService(repo_path=repo)
+        self.repo = _repo_root(Path(__file__).resolve())
+        self._ota_dialog: tk.Toplevel | None = None
+        self._ota_text: tk.Text | None = None
+        self._ota_queue: queue.Queue[tuple[str, object]] | None = None
+        self._ota_thread: threading.Thread | None = None
+        self._ota_mode = tk.StringVar(value="stash")
+        self._ota_running = False
+        self._ota_controls: dict[str, list[tk.Widget] | tk.Widget] = {}
 
     # ------------------------------------------------------------------ actions
     def _retry(self) -> None:
@@ -122,29 +129,265 @@ class RecoveryUI:
         except Exception as exc:
             self.status.set(f"Error al relanzar: {exc}")
 
-    def _run_ota(self) -> None:
-        if self.ota.is_running():
-            self.status.set("Actualización ya en curso…")
+    def _open_ota_dialog(self) -> None:
+        if self._ota_dialog and self._ota_dialog.winfo_exists():
+            self._ota_dialog.lift()
             return
 
-        self.status.set("Descargando actualización…")
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Actualización OTA")
+        dialog.configure(bg=COL_CARD)
+        dialog.geometry("720x420")
+        dialog.transient(self.root)
+        dialog.grab_set()
 
-        def _callback(result: dict) -> None:
-            def update_label() -> None:
-                if result.get("success"):
-                    ver = result.get("version", "")
-                    self.status.set(f"OTA completada ({ver}). Reinicia la báscula.")
-                else:
-                    self.status.set(f"OTA falló: {result.get('error')}")
+        tk.Label(
+            dialog,
+            text="Selecciona el modo de actualización",
+            bg=COL_CARD,
+            fg=COL_TEXT,
+            font=("DejaVu Sans", max(FS_TEXT, 14), "bold"),
+        ).pack(pady=(18, 6))
 
+        options = tk.Frame(dialog, bg=COL_CARD)
+        options.pack(pady=(0, 12))
+
+        keep = tk.Radiobutton(
+            options,
+            text="Conservar mis cambios (stash)",
+            variable=self._ota_mode,
+            value="stash",
+            bg=COL_CARD,
+            fg=COL_TEXT,
+            selectcolor=COL_ACCENT,
+            font=("DejaVu Sans", max(FS_TEXT - 1, 12)),
+            anchor="w",
+            pady=4,
+        )
+        keep.pack(fill="x", padx=24, pady=2)
+
+        force = tk.Radiobutton(
+            options,
+            text="Forzar actualización (descartar cambios)",
+            variable=self._ota_mode,
+            value="force",
+            bg=COL_CARD,
+            fg=COL_TEXT,
+            selectcolor=COL_ACCENT,
+            font=("DejaVu Sans", max(FS_TEXT - 1, 12)),
+            anchor="w",
+            pady=4,
+        )
+        force.pack(fill="x", padx=24, pady=2)
+
+        text_frame = tk.Frame(dialog, bg=COL_CARD)
+        text_frame.pack(fill="both", expand=True, padx=18, pady=(6, 12))
+
+        scrollbar = tk.Scrollbar(text_frame)
+        scrollbar.pack(side="right", fill="y")
+
+        output = tk.Text(
+            text_frame,
+            bg="#0f172a",
+            fg="#e2e8f0",
+            insertbackground="#e2e8f0",
+            font=("DejaVu Sans Mono", max(FS_TEXT - 4, 10)),
+            wrap="word",
+            state="disabled",
+        )
+        output.pack(fill="both", expand=True)
+        output.configure(yscrollcommand=scrollbar.set)
+        scrollbar.configure(command=output.yview)
+
+        controls = tk.Frame(dialog, bg=COL_CARD)
+        controls.pack(pady=(0, 16))
+
+        start_btn = tk.Button(
+            controls,
+            text="Iniciar actualización",
+            command=self._start_ota,
+            bg=COL_ACCENT,
+            fg="white",
+            bd=0,
+            relief="flat",
+            cursor="hand2",
+            padx=20,
+            pady=10,
+        )
+        start_btn.pack(side="left", padx=8)
+
+        close_btn = tk.Button(
+            controls,
+            text="Cerrar",
+            command=dialog.destroy,
+            bg="#6b7280",
+            fg="white",
+            bd=0,
+            relief="flat",
+            cursor="hand2",
+            padx=20,
+            pady=10,
+        )
+        close_btn.pack(side="left", padx=8)
+
+        self._ota_dialog = dialog
+        self._ota_text = output
+        self._ota_queue = queue.Queue()
+        self._ota_controls = {
+            "start": start_btn,
+            "close": close_btn,
+            "radios": [keep, force],
+        }
+        self._ota_running = False
+        self._append_ota_log("Listo para iniciar OTA\n")
+        self._watch_ota_queue()
+
+    def _append_ota_log(self, message: str) -> None:
+        if not self._ota_text:
+            return
+        self._ota_text.configure(state="normal")
+        self._ota_text.insert("end", message)
+        self._ota_text.see("end")
+        self._ota_text.configure(state="disabled")
+
+    def _watch_ota_queue(self) -> None:
+        if not self._ota_queue:
+            return
+        try:
+            while True:
+                kind, payload = self._ota_queue.get_nowait()
+                if kind == "line":
+                    self._append_ota_log(payload + "\n")
+                elif kind == "result":
+                    info = payload if isinstance(payload, dict) else {}
+                    success = bool(info.get("success"))
+                    message = str(info.get("message", ""))
+                    self._handle_ota_result(success, message)
+        except queue.Empty:
+            pass
+
+        if self._ota_dialog and self._ota_dialog.winfo_exists():
+            self.root.after(150, self._watch_ota_queue)
+
+    def _set_ota_controls_state(self, enabled: bool) -> None:
+        state = tk.NORMAL if enabled else tk.DISABLED
+        start = self._ota_controls.get("start")
+        close = self._ota_controls.get("close")
+        radios = self._ota_controls.get("radios", [])
+        if isinstance(start, tk.Widget):
+            start.configure(state=state)
+        if isinstance(close, tk.Widget):
+            close.configure(state=state if enabled or not self._ota_running else tk.DISABLED)
+        if isinstance(radios, list):
+            for widget in radios:
+                widget.configure(state=state)
+
+    def _start_ota(self) -> None:
+        if self._ota_running:
+            return
+        script = self.repo / "scripts" / "ota.sh"
+        if not script.exists():
+            self._append_ota_log("Script OTA no encontrado\n")
+            return
+        self._ota_running = True
+        self._set_ota_controls_state(False)
+        self.status.set("Ejecutando actualización OTA…")
+        mode = self._ota_mode.get() or "stash"
+        cmd = [str(script)]
+        if mode == "force":
+            cmd.append("--force")
+        else:
+            cmd.append("--stash")
+
+        self._append_ota_log(f"Comando: {' '.join(cmd)}\n")
+
+        def worker() -> None:
+            success = False
+            message = ""
             try:
-                self.root.after(0, update_label)
-            except Exception:
-                update_label()
+                process = subprocess.Popen(
+                    cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                self._ota_queue.put(("line", f"Error al iniciar OTA: {exc}"))
+                self._ota_queue.put(("result", {"success": False, "message": str(exc)}))
+                return
 
-        ok = self.ota.trigger_update(callback=_callback)
-        if not ok:
-            self.status.set("No se pudo iniciar OTA. Consulta logs.")
+            assert process.stdout is not None
+            for raw in process.stdout:
+                line = raw.rstrip("\n")
+                self._ota_queue.put(("line", line))
+                if line.startswith("OTA_OK"):
+                    success = True
+                    message = line
+                elif line.startswith("OTA_FAIL:"):
+                    success = False
+                    message = line
+            process.wait()
+            if process.returncode == 0 and success:
+                self._ota_queue.put(("result", {"success": True, "message": message}))
+            else:
+                if not message:
+                    message = f"OTA_FAIL:Proceso terminó con código {process.returncode}"
+                    self._ota_queue.put(("line", message))
+                self._ota_queue.put(("result", {"success": False, "message": message}))
+
+        self._ota_thread = threading.Thread(target=worker, daemon=True)
+        self._ota_thread.start()
+
+    def _handle_ota_result(self, success: bool, message: str) -> None:
+        self._ota_running = False
+        self._set_ota_controls_state(True)
+        if success:
+            suffix = f" ({message})" if message else ""
+            self.status.set(f"Actualizado; reiniciando UI…{suffix}")
+            self._append_ota_log("Actualización finalizada correctamente\n")
+            self._restart_ui()
+        else:
+            detail = message or "ver registros"
+            self.status.set(f"OTA falló: {detail}")
+            if message:
+                self._append_ota_log(message + "\n")
+            else:
+                self._append_ota_log("OTA falló\n")
+
+    def _restart_ui(self) -> None:
+        if self._ota_dialog and self._ota_dialog.winfo_exists():
+            self._ota_dialog.after(1500, self._ota_dialog.destroy)
+
+        def _close() -> None:
+            try:
+                self.root.destroy()
+            except Exception:
+                pass
+
+        if self._launched_by_systemd():
+            self._append_ota_log("Reiniciando servicio bascula-ui\n")
+            cmd = ["systemctl", "restart", "bascula-ui"]
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            if result.stdout:
+                self._append_ota_log(result.stdout)
+            if result.returncode != 0:
+                self._append_ota_log("No se pudo reiniciar bascula-ui automáticamente\n")
+            self.root.after(2000, _close)
+        else:
+            launcher = self.repo / "scripts" / "safe_run.sh"
+            if launcher.exists():
+                self._append_ota_log("Lanzando interfaz principal\n")
+                try:
+                    subprocess.Popen([str(launcher)])
+                except Exception as exc:
+                    self._append_ota_log(f"No se pudo lanzar safe_run.sh: {exc}\n")
+            self.root.after(2000, _close)
+
+    def _launched_by_systemd(self) -> bool:
+        if os.environ.get("INVOCATION_ID") or os.environ.get("JOURNAL_STREAM"):
+            return True
+        return Path("/run/systemd/system").exists()
 
     def run(self) -> None:
         self.root.mainloop()

--- a/scripts/ota.sh
+++ b/scripts/ota.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_BRANCH="main"
+LOG_FILE="/var/log/bascula/ota.log"
+
+mkdir -p "$(dirname "${LOG_FILE}")"
+
+declare FAIL_REASON=""
+
+cleanup() {
+  local status=$?
+  if (( status != 0 )); then
+    local message=${FAIL_REASON:-"Error inesperado (código ${status})"}
+    printf 'OTA_FAIL:%s\n' "$message"
+  fi
+}
+trap cleanup EXIT
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+declare mode="stash"
+declare branch="$DEFAULT_BRANCH"
+
+usage() {
+  cat <<USAGE
+Uso: ${0##*/} [--stash|--force] [--branch=BR]
+
+  --stash      Guarda los cambios locales en git stash antes de actualizar (por defecto)
+  --force      Descarta los cambios locales con reset --hard y clean -fdx
+  --branch=BR  Rama a sincronizar (por defecto: ${DEFAULT_BRANCH})
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stash)
+      mode="stash"
+      ;;
+    --force)
+      mode="force"
+      ;;
+    --branch=*)
+      branch="${1#*=}"
+      ;;
+    --branch)
+      shift
+      if [[ $# -eq 0 ]]; then
+        FAIL_REASON="Falta el nombre de la rama para --branch"
+        exit 1
+      fi
+      branch="$1"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      FAIL_REASON="Parámetro desconocido: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+log() {
+  printf '[ota] %s\n' "$*"
+}
+
+fail() {
+  FAIL_REASON="$1"
+  exit 1
+}
+
+log "Iniciando actualización OTA (modo=${mode}, rama=${branch})"
+
+if ! command -v git >/dev/null 2>&1; then
+  fail "git no está disponible"
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  fail "curl no está disponible"
+fi
+if ! command -v tar >/dev/null 2>&1; then
+  fail "tar no está disponible"
+fi
+if [[ ! -d "${REPO}/.git" ]]; then
+  fail "Repositorio no encontrado en ${REPO}"
+fi
+
+log "Verificando conectividad a GitHub"
+if ! curl -Is --max-time 10 https://github.com >/dev/null 2>&1; then
+  fail "Sin conectividad a https://github.com"
+fi
+
+log "Verificando espacio libre en /home"
+avail_kb=$(df -Pk /home 2>/dev/null | awk 'NR==2 {print $4}')
+if [[ -z "${avail_kb}" ]]; then
+  fail "No se pudo determinar espacio libre en /home"
+fi
+if (( avail_kb < 300 * 1024 )); then
+  fail "Espacio insuficiente en /home (<300MB)"
+fi
+
+if ! git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  fail "Directorio ${REPO} no es un repositorio git válido"
+fi
+
+status_output=$(git -C "$REPO" status --porcelain)
+if [[ -n "${status_output}" ]]; then
+  log "Repositorio con cambios locales, creando respaldos"
+  mkdir -p /home/pi/bascula-cam/logs /home/pi/bascula-cam/backups
+  patch_file="/home/pi/bascula-cam/logs/local.patch"
+  backup_file="/home/pi/bascula-cam/backups/working-tree-$(date +%F-%H%M%S).tgz"
+  if ! git -C "$REPO" diff >"${patch_file}"; then
+    fail "No se pudo crear diff local en ${patch_file}"
+  fi
+  if ! tar -czf "${backup_file}" -C "$REPO" .; then
+    fail "No se pudo crear respaldo ${backup_file}"
+  fi
+  log "Respaldos guardados en ${patch_file} y ${backup_file}"
+  if [[ "${mode}" == "force" ]]; then
+    log "Descartando cambios locales (reset --hard + clean)"
+    if ! git -C "$REPO" reset --hard "origin/${branch}"; then
+      fail "git reset --hard origin/${branch} falló"
+    fi
+    if ! git -C "$REPO" clean -fdx; then
+      fail "git clean -fdx falló"
+    fi
+  else
+    stash_message="ota-$(date +%F-%H%M%S)"
+    log "Guardando cambios en git stash (${stash_message})"
+    if ! git -C "$REPO" stash push -u -m "$stash_message"; then
+      fail "git stash falló"
+    fi
+  fi
+else
+  log "Repositorio limpio"
+fi
+
+log "Actualizando repositorio"
+if ! git -C "$REPO" fetch --all --prune; then
+  fail "git fetch falló"
+fi
+if ! git -C "$REPO" reset --hard "origin/${branch}"; then
+  fail "git reset --hard origin/${branch} falló"
+fi
+
+log "Ejecutando fase 2 del instalador"
+if ! sudo TARGET_USER=pi bash "$REPO/scripts/install-2-app.sh" --resume; then
+  fail "Fase 2 del instalador falló"
+fi
+
+short_commit=$(git -C "$REPO" rev-parse --short HEAD)
+log "Actualización completada en ${branch} (${short_commit})"
+
+trap - EXIT
+printf 'OTA_OK:%s:%s\n' "$branch" "$short_commit"
+exit 0

--- a/scripts/verify-kiosk.sh
+++ b/scripts/verify-kiosk.sh
@@ -210,4 +210,18 @@ else
   warn "Repositorio no encontrado en ${REPO_DIR}"
 fi
 
+log "Estado del repositorio bascula-cam"
+if command -v git >/dev/null 2>&1; then
+  status_list=$(git -C "${REPO_DIR}" status --porcelain 2>/dev/null || true)
+  repo_changes=$(printf '%s\n' "${status_list}" | sed '/^$/d' | wc -l | tr -d '[:space:]')
+  repo_changes=${repo_changes:-0}
+  if [[ "${repo_changes}" == "0" ]]; then
+    ok "Repositorio limpio tras OTA"
+  else
+    warn "Repositorio con ${repo_changes} cambios pendientes"
+  fi
+else
+  warn "git no está disponible para verificar el estado del repositorio"
+fi
+
 ok "Diagnóstico completado"


### PR DESCRIPTION
## Summary
- add a scripts/ota.sh helper that guards backups, handles --stash/--force, and logs OTA outcomes
- refactor the recovery UI to offer stash/force choices, stream ota.sh output, and restart the graphical UI accordingly
- extend verify-kiosk.sh with a cleanliness check that warns when the repository still has local changes after an OTA

## Testing
- bash -n scripts/ota.sh
- bash -n scripts/verify-kiosk.sh
- python3 -m compileall bascula/ui/recovery_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68caffafe51083268d70c629a95b34ac