### PR TITLE
Fix miniweb and X735 setup scripts

### DIFF
--- a/etc/systemd/system/bascula-miniweb.service
+++ b/etc/systemd/system/bascula-miniweb.service
@@ -5,7 +5,9 @@ After=network-online.target
 [Service]
 User=pi
 WorkingDirectory=/home/pi/bascula-cam
-ExecStart=/home/pi/bascula-cam/.venv/bin/uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port 8080
+ExecStart=/home/pi/bascula-cam/.venv/bin/python -m uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port 8080
+ExecStartPre=/bin/sh -c '[ -x /home/pi/bascula-cam/.venv/bin/python ] || exit 1'
+ExecStartPre=/bin/sh -c '/home/pi/bascula-cam/.venv/bin/python -c "import uvicorn" || exit 1'
 Restart=always
 
 [Install]

--- a/scripts/verify-kiosk.sh
+++ b/scripts/verify-kiosk.sh
@@ -153,6 +153,30 @@ else
   warn "bascula-miniweb.service no existe"
 fi
 
+# miniweb
+if systemctl is-active bascula-miniweb >/dev/null 2>&1; then
+  echo "[ok] miniweb activo"
+else
+  echo "[warn] miniweb inactivo"
+fi
+# uvicorn en venv
+if [ -x /home/pi/bascula-cam/.venv/bin/python ] && /home/pi/bascula-cam/.venv/bin/python -c "import uvicorn" >/dev/null 2>&1; then
+  echo "[ok] uvicorn en venv"
+else
+  echo "[err] uvicorn no instalado"
+fi
+# x735
+if [ -x /usr/local/bin/x735.sh ]; then
+  echo "[ok] x735.sh presente"
+else
+  echo "[err] falta /usr/local/bin/x735.sh"
+fi
+if systemctl is-active x735-fan >/dev/null 2>&1; then
+  echo "[ok] x735-fan activo"
+else
+  echo "[warn] x735-fan inactivo"
+fi
+
 if systemctl list-units --type=service --all | grep -q '^bascula-ui.service'; then
   env_output=$(systemctl show bascula-ui.service -p Environment 2>/dev/null || true)
   if grep -q 'DISPLAY=:0' <<<"${env_output}"; then


### PR DESCRIPTION
## Summary
- point the bascula-miniweb service to the venv python and gate startup on the interpreter and uvicorn module
- ensure the app installation script upgrades pip tooling, installs uvicorn when missing, and reloads/enables the miniweb unit
- harden X735 provisioning by normalising scripts, installing the unit with Restart=always, and reporting service health in the kiosk verifier

## Testing
- `bash -n scripts/install-1-system.sh`
- `bash -n scripts/install-2-app.sh`
- `bash -n scripts/verify-kiosk.sh`


------
https://chatgpt.com/codex/tasks/task_e_68cb7446f04883269918944a19533027