### PR TITLE
Refuerza UI táctil y control de OTA

### DIFF
--- a/tools/smoke_nav.py
+++ b/tools/smoke_nav.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Recorrido rápido de pantallas para detectar fallos de importación.
+
+Se ejecuta sin bloquear la interfaz: crea la aplicación, recorre todas las
+pantallas registradas y llama ``show_screen`` sobre cada una capturando
+excepciones. El objetivo es verificar que ningún import opcional tumba la
+navegación.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tkinter as tk
+from contextlib import suppress
+
+from bascula.ui.app import BasculaAppTk
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        print(f"[FAIL] Tk init: {exc}")
+        return 1
+
+    app = None
+    try:
+        app = BasculaAppTk(root=root)
+    except Exception as exc:
+        print(f"[FAIL] init: {exc}")
+        with suppress(Exception):
+            root.destroy()
+        return 1
+
+    for name in list(app.screens.keys()):
+        try:
+            app.show_screen(name)
+            app.root.update_idletasks()
+            app.root.update()
+        except Exception as exc:
+            print(f"[FAIL] {name}: {exc}")
+        else:
+            print(f"[OK] {name}")
+
+    with suppress(Exception):
+        app.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- limpia la barra superior eliminando textos de depuración, reorganiza los menús y mejora los tamaños táctiles
- limita el peso a la pantalla Pesar y robustecela con `ScaleService.safe_create`, con registros y toasts ante fallos
- añade manejo seguro de importaciones opcionales, herramienta de humo y diálogo OTA resistente a ejecuciones paralelas

## Testing
- python -m py_compile $(git ls-files '*.py')

Nota: Se limpian artefactos UI, se blinda ‘Pesar’ ante drivers ausentes y se evita concurrencia OTA.

------
https://chatgpt.com/codex/tasks/task_e_68cb76506af8832685feead254ac87cf