### PR TITLE
Restore get_latest alias on scale service

### DIFF
--- a/bascula/services/scale.py
+++ b/bascula/services/scale.py
@@ -115,6 +115,7 @@ class ScaleService:
         return float(self._last_weight)
 
     def get_latest(self) -> float:
+        """Historical alias retained for compatibility with older readers."""
         return self.get_weight()
 
     def is_stable(self) -> bool:

--- a/python_backend/bascula/services/scale.py
+++ b/python_backend/bascula/services/scale.py
@@ -22,6 +22,10 @@ class ScaleService:
     def get_weight(self) -> float:
         return self.backend.get_weight()
 
+    def get_latest(self) -> float:
+        """Historical alias maintained for backwards compatibility."""
+        return self.get_weight()
+
     def is_stable(self) -> bool:
         return self.backend.is_stable()
 


### PR DESCRIPTION
## Summary
- restore the historical get_latest() helper on the scale service implementation
- add the same alias to the python backend version to keep older callers working

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb8f8ea8c883268c0cd41c8c5be807