### PR TITLE
Generate mascot PNGs during install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ firmware-esp32/*.elf
 .idea/
 .vscode/
 
+# Mascot generated assets
+bascula/ui/assets/mascota/_gen/
+bascula/ui/assets/mascota/*.png

--- a/README.md
+++ b/README.md
@@ -57,3 +57,30 @@ sudo bash scripts/install-2-app.sh
 ### Diagnóstico posterior
 
 Ejecuta `scripts/verify-kiosk.sh` (no bloqueante) para validar X11, Tkinter, Piper, audio, cámara, servicios `bascula-miniweb` y `x735-fan`.
+
+## Mascota
+
+La interfaz incluye una mascota robótica con distintos estados animados que ayudan a comunicar lo que ocurre en pantalla sin mostrar cifras de peso. Puedes cambiar su estado desde cualquier punto del código llamando a `app.set_mascot_state("listen")`. Los estados admitidos son:
+
+- `idle`
+- `listen`
+- `think`
+- `error`
+- `sleep`
+
+Variables de entorno:
+
+- `BASCULA_MASCOT_THEME`: tema activo (`retro-green` por defecto) con brillo sutil en la pantalla del pecho.
+- `BASCULA_MASCOT_COMPACT`: si vale `1`, utiliza la versión compacta para pantallas muy pequeñas.
+
+### Mascota (assets)
+
+El repositorio solo versiona los SVG ubicados en `bascula/ui/assets/mascota/`. Los PNG @1x (512px) y @2x (1024px) se generan durante la instalación gracias a `librsvg2-bin` y se guardan en `bascula/ui/assets/mascota/_gen/` (por ejemplo `robot_idle@512.png`).
+
+Para regenerarlos manualmente ejecuta:
+
+```bash
+bash scripts/build-mascot-assets.sh
+```
+
+Al añadir un tema nuevo replica los SVG actuales, ajusta los colores conservando la pantalla vacía en el pecho y vuelve a ejecutar el script para generar los PNG correspondientes.

--- a/bascula/ui/assets/mascota/avatar_mini.svg
+++ b/bascula/ui/assets/mascota/avatar_mini.svg
@@ -1,0 +1,34 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+        <line x1='256' y1='120' x2='256' y2='50' stroke='#52D68A' stroke-width='10' stroke-linecap='round'/>
+        <circle cx='256' cy='45' r='22' fill='#52D68A' stroke='#1F8D50' stroke-width='6'/>
+        <circle cx='256' cy='45' r='36' fill='#52D68A' opacity='0.35'/>
+        
+    
+        <g fill='#F5FFFB'>
+            <circle cx='190' cy='180' r='26'/>
+            <circle cx='322' cy='180' r='26'/>
+        </g>
+        <g fill='#1E3D2C'>
+            <circle cx='190' cy='180' r='12'/>
+            <circle cx='322' cy='180' r='12'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/assets/mascota/robot_error.svg
+++ b/bascula/ui/assets/mascota/robot_error.svg
@@ -1,0 +1,28 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+    
+        <g stroke='#F25F5C' stroke-width='10' stroke-linecap='round'>
+            <path d='M162 158 L218 214'/>
+            <path d='M162 214 L218 158'/>
+            <path d='M294 158 L350 214'/>
+            <path d='M294 214 L350 158'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/assets/mascota/robot_idle.svg
+++ b/bascula/ui/assets/mascota/robot_idle.svg
@@ -1,0 +1,30 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+    
+        <g fill='#F5FFFB'>
+            <circle cx='190' cy='180' r='26'/>
+            <circle cx='322' cy='180' r='26'/>
+        </g>
+        <g fill='#1E3D2C'>
+            <circle cx='190' cy='180' r='12'/>
+            <circle cx='322' cy='180' r='12'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/assets/mascota/robot_listen.svg
+++ b/bascula/ui/assets/mascota/robot_listen.svg
@@ -1,0 +1,34 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+        <line x1='256' y1='120' x2='256' y2='50' stroke='#52D68A' stroke-width='10' stroke-linecap='round'/>
+        <circle cx='256' cy='45' r='22' fill='#52D68A' stroke='#1F8D50' stroke-width='6'/>
+        <circle cx='256' cy='45' r='36' fill='#52D68A' opacity='0.35'/>
+        
+    
+        <g fill='#F5FFFB'>
+            <circle cx='190' cy='180' r='26'/>
+            <circle cx='322' cy='180' r='26'/>
+        </g>
+        <g fill='#1E3D2C'>
+            <circle cx='190' cy='180' r='12'/>
+            <circle cx='322' cy='180' r='12'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/assets/mascota/robot_sleep.svg
+++ b/bascula/ui/assets/mascota/robot_sleep.svg
@@ -1,0 +1,26 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+    
+        <g stroke='#AFE5C2' stroke-width='8' stroke-linecap='round'>
+            <path d='M150 180 L230 180'/>
+            <path d='M282 180 L362 180'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/assets/mascota/robot_think.svg
+++ b/bascula/ui/assets/mascota/robot_think.svg
@@ -1,0 +1,30 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='512' height='512' viewBox='0 0 512 512'>
+    <defs>
+        <linearGradient id='screenGlow' x1='0' x2='0' y1='0' y2='1'>
+            <stop offset='0%' stop-color='#3CCF7A' stop-opacity='0.45'/>
+            <stop offset='100%' stop-color='#1E3D2C' stop-opacity='0.9'/>
+        </linearGradient>
+    </defs>
+    <ellipse cx='256' cy='420' rx='150' ry='36' fill='#00000022'/>
+    <rect x='150' y='240' width='212' height='212' rx='42' fill='#27AE60' stroke='#1F8D50' stroke-width='10'/>
+    <rect x='184' y='276' width='144' height='156' rx='32' fill='url(#screenGlow)' stroke='#144C33' stroke-width='8'/>
+    <rect x='168' y='120' width='176' height='140' rx='44' fill='#27AE60' stroke='#1F8D50' stroke-width='12'/>
+    
+    
+        <g fill='#F5FFFB'>
+            <circle cx='190' cy='150' r='26'/>
+            <circle cx='322' cy='150' r='26'/>
+        </g>
+        <g fill='#1E3D2C'>
+            <circle cx='190' cy='134' r='12'/>
+            <circle cx='322' cy='134' r='12'/>
+        </g>
+        
+    <rect x='210' y='222' width='92' height='28' rx='14' fill='#52D68A'/>
+    <rect x='122' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='354' y='260' width='36' height='124' rx='18' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='198' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='260' y='390' width='54' height='94' rx='24' fill='#27AE60' stroke='#1F8D50' stroke-width='8'/>
+    <rect x='206' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+    <rect x='268' y='456' width='38' height='24' rx='12' fill='#52D68A'/>
+</svg>

--- a/bascula/ui/mascot.py
+++ b/bascula/ui/mascot.py
@@ -1,0 +1,390 @@
+"""Animated robot mascot widget used across the Báscula UI."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import random
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+import tkinter as tk
+
+_LOG = logging.getLogger(__name__)
+
+_ASSET_ROOT = Path(__file__).resolve().parent / "assets" / "mascota"
+_GENERATED_DIR = _ASSET_ROOT / "_gen"
+
+_VALID_STATES = {"idle", "listen", "think", "error", "sleep"}
+_STATE_TO_BASE = {
+    "idle": "robot_idle",
+    "listen": "robot_listen",
+    "think": "robot_think",
+    "error": "robot_error",
+    "sleep": "robot_sleep",
+}
+_STATE_HIGHLIGHT = {
+    "listen": "#2ecc71",
+    "think": "#1abc9c",
+    "error": "#e74c3c",
+    "sleep": "#16a085",
+}
+
+
+def _is_true(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def is_compact_mode() -> bool:
+    """Return ``True`` when the environment requests the compact avatar."""
+
+    return _is_true(os.getenv("BASCULA_MASCOT_COMPACT", "0"))
+
+
+class MascotWidget(tk.Frame):
+    """Simple animated Tk widget that renders the green robot mascot."""
+
+    def __init__(self, parent: tk.Misc, *, max_width: int = 280, **kwargs) -> None:
+        bg = kwargs.pop("bg", None)
+        super().__init__(parent, bg=bg, **kwargs)
+        try:
+            self.configure(highlightthickness=0)
+        except tk.TclError:
+            pass
+
+        self._max_width = max_width
+        self._rng = random.Random()
+        self._state = "idle"
+        self._compact = False
+        self._blink_enabled = False
+        self._pulse_enabled = False
+        self._blink_job: Optional[str] = None
+        self._blink_restore_job: Optional[str] = None
+        self._pulse_job: Optional[str] = None
+        self._pulse_phase = 0.0
+        self._current_photo: Optional[tk.PhotoImage] = None
+        self._images: Dict[Tuple[str, bool], tk.PhotoImage] = {}
+        self._placeholder: Optional[tk.Canvas] = None
+        self._theme = (os.getenv("BASCULA_MASCOT_THEME", "retro-green") or "retro-green").strip()
+        self._revert_job: Optional[str] = None
+
+        self._image_label = tk.Label(self, bd=0, highlightthickness=0, bg=self._bg_color)
+        self._image_label.place(relx=0.5, rely=0.5, anchor="center")
+
+        if is_compact_mode():
+            self.set_compact(True)
+
+        self.set_state("idle")
+
+    # ------------------------------------------------------------------ public API
+    def set_state(self, name: str) -> None:
+        """Switch the mascot to *name* if it is a recognised state."""
+
+        if not name:
+            return
+        key = str(name).strip().lower()
+        if key not in _VALID_STATES:
+            _LOG.debug("MascotWidget: ignoring unknown state '%s'", key)
+            return
+        if self._state == key and not self._compact and self._current_photo is not None:
+            # Avoid unnecessary reloads when nothing changed.
+            return
+        self._state = key
+        self._apply_highlight()
+        self._update_image()
+        if key in {"listen", "think"}:
+            self._schedule_revert(2600)
+        elif key == "error":
+            self._schedule_revert(3600)
+        elif key == "sleep":
+            self._cancel_revert()
+
+    def blink(self, enable: bool = True) -> None:
+        """Enable or disable the random blink animation."""
+
+        self._blink_enabled = bool(enable)
+        if not enable:
+            self._cancel_blink()
+            return
+        if self._blink_job is None:
+            self._schedule_blink()
+
+    def pulse(self, enable: bool = True) -> None:
+        """Enable or disable the idle bobbing animation."""
+
+        self._pulse_enabled = bool(enable)
+        if not enable:
+            self._cancel_pulse()
+            return
+        self._pulse_phase = 0.0
+        if self._pulse_job is None:
+            self._animate_pulse()
+
+    def set_compact(self, compact: bool) -> None:
+        """Toggle compact mode, switching to the mini avatar asset."""
+
+        compact = bool(compact)
+        if self._compact == compact:
+            return
+        self._compact = compact
+        self._images.clear()
+        if compact:
+            try:
+                self.configure(padx=0, pady=0)
+            except tk.TclError:
+                pass
+        self._update_image(force=True)
+
+    # ------------------------------------------------------------------ lifecycle helpers
+    @property
+    def _bg_color(self) -> str:
+        try:
+            return str(self.cget("bg"))
+        except tk.TclError:
+            return "#ffffff"
+
+    def destroy(self) -> None:  # pragma: no cover - Tk teardown
+        self.blink(False)
+        self.pulse(False)
+        self._cancel_revert()
+        super().destroy()
+
+    # ------------------------------------------------------------------ animation internals
+    def _schedule_blink(self) -> None:
+        if not self._blink_enabled:
+            return
+        delay = self._rng.randint(2000, 6000)
+        try:
+            self._blink_job = self.after(delay, self._do_blink)
+        except Exception:  # pragma: no cover - Tk shutdown
+            self._blink_job = None
+
+    def _cancel_blink(self) -> None:
+        if self._blink_job:
+            try:
+                self.after_cancel(self._blink_job)
+            except Exception:
+                pass
+            self._blink_job = None
+        if self._blink_restore_job:
+            try:
+                self.after_cancel(self._blink_restore_job)
+            except Exception:
+                pass
+            self._blink_restore_job = None
+        if not self._compact:
+            self._update_image()
+
+    def _do_blink(self) -> None:
+        self._blink_job = None
+        if not self._blink_enabled or self._compact or self._state != "idle":
+            self._schedule_blink()
+            return
+        blink_photo = self._get_image(self._state, blink=True)
+        if blink_photo is None:
+            self._schedule_blink()
+            return
+        self._set_photo(blink_photo)
+        try:
+            self._blink_restore_job = self.after(160, self._end_blink)
+        except Exception:
+            self._blink_restore_job = None
+
+    def _end_blink(self) -> None:
+        self._blink_restore_job = None
+        self._update_image()
+        self._schedule_blink()
+
+    def _animate_pulse(self) -> None:
+        if not self._pulse_enabled:
+            return
+        self._pulse_phase = (self._pulse_phase + 0.25) % (2 * math.pi)
+        offset = math.sin(self._pulse_phase)
+        amplitude = 4 if not self._compact else 2
+        try:
+            self._image_label.place_configure(rely=0.5, anchor="center", y=int(offset * amplitude))
+            self._pulse_job = self.after(80, self._animate_pulse)
+        except Exception:  # pragma: no cover - Tk teardown
+            self._pulse_job = None
+
+    def _cancel_pulse(self) -> None:
+        if self._pulse_job:
+            try:
+                self.after_cancel(self._pulse_job)
+            except Exception:
+                pass
+            self._pulse_job = None
+        try:
+            self._image_label.place_configure(rely=0.5, anchor="center", y=0)
+        except Exception:
+            pass
+
+    def _schedule_revert(self, delay: int) -> None:
+        self._cancel_revert()
+        try:
+            self._revert_job = self.after(delay, lambda: self.set_state("idle"))
+        except Exception:
+            self._revert_job = None
+
+    def _cancel_revert(self) -> None:
+        if self._revert_job:
+            try:
+                self.after_cancel(self._revert_job)
+            except Exception:
+                pass
+            self._revert_job = None
+
+    # ------------------------------------------------------------------ image helpers
+    def _asset_path(self, base_name: str) -> Optional[str]:
+        for candidate in self._asset_candidates(base_name):
+            if candidate.exists():
+                return str(candidate)
+        _LOG.warning("[warn] Missing mascot asset: %s", base_name)
+        return None
+
+    def _asset_candidates(self, base_name: str) -> Iterable[Path]:
+        seen: set[str] = set()
+        for size in self._preferred_sizes():
+            candidate = _GENERATED_DIR / f"{base_name}@{size}.png"
+            key = str(candidate)
+            if key not in seen:
+                seen.add(key)
+                yield candidate
+        fallback = _ASSET_ROOT / f"{base_name}.png"
+        key = str(fallback)
+        if key not in seen:
+            yield fallback
+
+    def _preferred_sizes(self) -> Tuple[str, ...]:
+        if self._compact:
+            return ("512", "1024")
+        try:
+            width = int(self.winfo_screenwidth())
+        except Exception:
+            width = 0
+        if width >= 800:
+            return ("1024", "512")
+        return ("512", "1024")
+
+    def _get_image(self, state: str, *, blink: bool = False) -> Optional[tk.PhotoImage]:
+        key = (state if not blink else f"{state}-blink", self._compact)
+        if key in self._images:
+            return self._images[key]
+        if blink and state == "idle":
+            base_photo = self._get_image(state, blink=False)
+            if base_photo is None:
+                return None
+            blink_photo = self._make_blink_frame(base_photo)
+            if blink_photo is not None:
+                self._images[key] = blink_photo
+                return blink_photo
+            return base_photo
+        base_name: Optional[str]
+        if self._compact:
+            base_name = "avatar_mini"
+        else:
+            base_name = _STATE_TO_BASE.get(state)
+        if not base_name:
+            return None
+        path = self._asset_path(base_name)
+        if path is None:
+            return None
+        photo = self._load_photo(path)
+        if photo is None:
+            return None
+        self._images[key] = photo
+        return photo
+
+    def _load_photo(self, path: str) -> Optional[tk.PhotoImage]:
+        try:
+            photo = tk.PhotoImage(file=path)
+            target = self._max_width
+            if self._compact:
+                target = max(1, target // 2)
+            if photo.width() > target:
+                scale = max(1, int(math.ceil(photo.width() / float(target))))
+                try:
+                    photo = photo.subsample(scale, scale)
+                except Exception:
+                    pass
+            return photo
+        except Exception:
+            _LOG.warning("[warn] Failed to load mascot asset: %s", path, exc_info=True)
+            return None
+
+    def _make_blink_frame(self, base: tk.PhotoImage) -> Optional[tk.PhotoImage]:
+        try:
+            blink = base.copy()
+        except Exception:
+            return None
+        try:
+            width = max(1, blink.width())
+            height = max(1, blink.height())
+        except Exception:
+            return blink
+        eyelid_height = max(2, height // 8)
+        mid = height // 2
+        y1 = max(0, mid - eyelid_height // 2)
+        y2 = min(height, y1 + eyelid_height)
+        try:
+            blink.put("#0f3a24", to=(0, y1, width, y2))
+        except Exception:
+            return blink
+        return blink
+
+    def _update_image(self, force: bool = False) -> None:
+        if self._compact:
+            photo = self._get_image("idle", blink=False)
+        else:
+            photo = self._get_image(self._state, blink=False)
+        if photo is None:
+            self._show_placeholder()
+            return
+        self._hide_placeholder()
+        if force or photo is not self._current_photo:
+            self._set_photo(photo)
+
+    def _set_photo(self, photo: tk.PhotoImage) -> None:
+        self._current_photo = photo
+        try:
+            self._image_label.configure(image=photo)
+        except Exception:
+            pass
+
+    def _show_placeholder(self) -> None:
+        self._image_label.place_forget()
+        if self._placeholder is None:
+            self._placeholder = tk.Canvas(self, width=self._max_width, height=self._max_width, bg=self._bg_color, highlightthickness=0)
+            shade = "#27AE60"
+            try:
+                w = self._placeholder.winfo_reqwidth()
+                h = self._placeholder.winfo_reqheight()
+            except Exception:
+                w = h = self._max_width
+            size = min(w, h)
+            pad = size * 0.2
+            self._placeholder.create_oval(pad, pad, size - pad, size - pad, outline=shade, width=4)
+            self._placeholder.create_text(size / 2, size / 2, text="🤖", font=("DejaVu Sans", int(size * 0.28)))
+        self._placeholder.place(relx=0.5, rely=0.5, anchor="center")
+
+    def _hide_placeholder(self) -> None:
+        if self._placeholder is not None:
+            self._placeholder.place_forget()
+        self._image_label.place(relx=0.5, rely=0.5, anchor="center")
+
+    def _apply_highlight(self) -> None:
+        color = _STATE_HIGHLIGHT.get(self._state)
+        if color and self._theme == "retro-green":
+            try:
+                self.configure(highlightthickness=2, highlightbackground=color)
+            except tk.TclError:
+                pass
+        else:
+            try:
+                self.configure(highlightthickness=0)
+            except tk.TclError:
+                pass
+
+
+__all__ = ["MascotWidget", "is_compact_mode"]

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -31,7 +31,7 @@ from bascula.ui.widgets import (
     COL_MUTED,
     COL_ACCENT,
 )
-from bascula.ui.widgets_mascota import MascotaCanvas
+from bascula.ui.mascot import MascotWidget, is_compact_mode
 
 
 class BaseScreen(tk.Frame):
@@ -104,8 +104,14 @@ class HomeScreen(BaseScreen):
         )
         subtitle.pack(anchor="w", pady=(0, 12))
 
-        self.mascota = MascotaCanvas(header, width=200, height=200, bg=COL_CARD)
+        self.mascota = MascotWidget(header, bg=COL_CARD, max_width=220)
+        if is_compact_mode():
+            self.mascota.set_compact(True)
         self.mascota.pack(side="right", padx=(16, 0))
+        try:
+            self.app.register_mascot_widget(self.mascota)
+        except Exception:
+            pass
 
         actions = tk.Frame(hero, bg=COL_CARD)
         actions.pack(fill="x", pady=(18, 4))
@@ -130,18 +136,19 @@ class HomeScreen(BaseScreen):
 
     def on_show(self) -> None:  # pragma: no cover - UI update
         self._refresh_history()
-        if hasattr(self.mascota, "start"):
-            try:
-                self.mascota.start()
-            except Exception:
-                pass
+        try:
+            self.mascota.set_state("idle")
+            self.mascota.blink(True)
+            self.mascota.pulse(True)
+        except Exception:
+            pass
 
     def on_hide(self) -> None:  # pragma: no cover - UI update
-        if hasattr(self.mascota, "stop"):
-            try:
-                self.mascota.stop()
-            except Exception:
-                pass
+        try:
+            self.mascota.blink(False)
+            self.mascota.pulse(False)
+        except Exception:
+            pass
 
     def _refresh_history(self) -> None:
         self.history_list.delete(0, tk.END)

--- a/scripts/build-mascot-assets.sh
+++ b/scripts/build-mascot-assets.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ASSETS_DIR="${1:-$(dirname "$0")/../bascula/ui/assets/mascota}"
+OUT_DIR="${ASSETS_DIR}/_gen"
+mkdir -p "$OUT_DIR"
+command -v rsvg-convert >/dev/null 2>&1 || { echo "[err] rsvg-convert no disponible"; exit 1; }
+sizes=("512" "1024")  # @1x y @2x
+for svg in "$ASSETS_DIR"/*.svg; do
+  base="$(basename "$svg" .svg)"
+  for s in "${sizes[@]}"; do
+    png="${OUT_DIR}/${base}@${s}.png"
+    rsvg-convert -w "$s" -h "$s" -o "$png" "$svg"
+    echo "[ok] ${png}"
+  done
+done

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -93,6 +93,18 @@ then
   sudo -u "${TARGET_USER}" -H PIP_CACHE_DIR="${PIP_CACHE_DIR}" "${VENV_DIR}/bin/python" -m pip install uvicorn
 fi
 
+if ! command -v rsvg-convert >/dev/null 2>&1; then
+  log "Instalando librsvg2-bin para assets de la mascota"
+  apt-get update
+  apt-get install -y librsvg2-bin
+fi
+
+if sudo -u "${TARGET_USER}" -H bash "${APP_DIR}/scripts/build-mascot-assets.sh"; then
+  ok "PNG de la mascota generados"
+else
+  warn "no se pudieron generar los PNG de la mascota"
+fi
+
 sudo chown -R "${TARGET_USER}:${TARGET_USER}" "${APP_DIR}" || true
 
 log "Instalando servicios systemd"

--- a/scripts/verify-kiosk.sh
+++ b/scripts/verify-kiosk.sh
@@ -19,6 +19,17 @@ else
   warn "No se detecta /tmp/.X11-unix/X0"
 fi
 
+if [[ -n "${DISPLAY:-}" ]]; then
+  log "Mascota"
+  if python3 "${APP_DIR}/tools/smoke_mascot.py" >/dev/null 2>&1; then
+    ok "Smoke de mascot sin errores"
+  else
+    warn "Smoke de mascot falló"
+  fi
+else
+  warn "DISPLAY no definido, se omite smoke de mascota"
+fi
+
 if command -v startx >/dev/null 2>&1; then
   ok "startx presente"
 else
@@ -118,4 +129,11 @@ if [[ -d "${PIP_CACHE}" ]]; then
   printf '[ok] owner pip-cache=%s\n' "${owner}"
 else
   warn "${PIP_CACHE} no existe"
+fi
+
+ASSETS="${APP_DIR}/bascula/ui/assets/mascota/_gen"
+if ls "${ASSETS}"/*.png >/dev/null 2>&1; then
+  echo "[ok] Mascota PNG generados en ${ASSETS}"
+else
+  echo "[warn] No hay PNG generados de la mascota; intenta: bash scripts/build-mascot-assets.sh"
 fi

--- a/tools/smoke_mascot.py
+++ b/tools/smoke_mascot.py
@@ -1,0 +1,25 @@
+"""Minimal smoke test for the mascot widget animations."""
+
+from __future__ import annotations
+
+import os
+from tkinter import Tk
+
+from bascula.ui.mascot import MascotWidget
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    os.environ.setdefault("BASCULA_MASCOT_THEME", "retro-green")
+    root = Tk()
+    root.title("Mascot smoke test")
+    widget = MascotWidget(root, max_width=260)
+    widget.pack(expand=True, fill="both")
+    widget.blink(True)
+    widget.pulse(True)
+    root.after(800, lambda: widget.set_state("listen"))
+    root.after(1600, lambda: widget.set_state("think"))
+    root.after(2400, lambda: widget.set_state("error"))
+    root.after(3600, lambda: widget.set_state("sleep"))
+    root.after(5000, lambda: widget.set_state("idle"))
+    root.after(6500, root.destroy)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- add a build script that renders mascot PNGs from the tracked SVGs and ignore the generated binaries
- update the mascot widget to prefer the generated PNGs while keeping a placeholder/blink fallback
- ensure installation and verification scripts manage librsvg2-bin and asset generation, and document the process

## Testing
- python -m compileall bascula/ui/mascot.py tools/smoke_mascot.py

------
https://chatgpt.com/codex/tasks/task_e_68cb910739488326b2c5706915bf34ab