### PR TITLE
Fix mascot smoke test import path

### DIFF
--- a/tools/smoke_mascot.py
+++ b/tools/smoke_mascot.py
@@ -3,7 +3,16 @@
 from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
 from tkinter import Tk
+
+
+# Ensure the repository root is on sys.path so ``bascula`` can be imported when
+# this script is executed directly (e.g. ``python tools/smoke_mascot.py``).
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from bascula.ui.mascot import MascotWidget
 


### PR DESCRIPTION
## Summary
- ensure the mascot smoke test adds the repository root to sys.path so it can import bascula when run directly

## Testing
- python3 tools/smoke_mascot.py *(fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9b2c156c8326a8d92685d21de3c8