### PR TITLE
Improve scale service resilience and installer setup

### DIFF
--- a/bascula/ui/scale_screen.py
+++ b/bascula/ui/scale_screen.py
@@ -45,7 +45,13 @@ class ScaleScreen(tk.Frame):
         outer = Card(self)
         outer.pack(expand=True, fill="both", padx=get_scaled_size(18), pady=get_scaled_size(18))
 
-        self.weight_label = WeightLabel(outer, textvariable=app.weight_text, bg=COL_CARD)
+        self.weight_label = WeightLabel(
+            outer,
+            textvariable=app.weight_text,
+            bg=COL_CARD,
+            anchor="center",
+            justify="center",
+        )
         self.weight_label.pack(fill="x", pady=(get_scaled_size(12), get_scaled_size(6)))
 
         self.status_label = tk.Label(

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -353,11 +353,10 @@ class TopBar(tk.Frame):
 
     _EXTRA_LABELS = [
         ("history", "Historial"),
-        ("focus", "Enfoque"),
+        ("diabetes", "Diabetes"),
         ("nightscout", "Nightscout"),
         ("wifi", "Wi-Fi"),
         ("apikey", "API Key"),
-        ("diabetes", "Diabetes"),
     ]
 
     _BASE_ITEMS = (
@@ -662,7 +661,7 @@ class TopBar(tk.Frame):
         available: list[tuple[str, str]] = []
         seen: set[str] = set()
         for key, default in self._EXTRA_LABELS:
-            if key in screens and key in advanced:
+            if key in screens:
                 available.append((key, advanced.get(key, default)))
                 seen.add(key)
         for key, label in advanced.items():

--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -73,7 +73,7 @@ apt-get install -y \
   git curl rsync unzip jq \
   xserver-xorg xinit x11-xserver-utils matchbox-window-manager \
   python3-tk libcamera-apps python3-picamera2 \
-  alsa-utils sox piper i2c-tools dos2unix
+  alsa-utils sox piper i2c-tools dos2unix librsvg2-bin
 
 log "Configurando modo kiosko (autologin + startx)"
 "${KIOSK_SCRIPT}" "${TARGET_USER}" "${USER_HOME}"
@@ -120,15 +120,12 @@ else
   warn "Fallo instalando voces Piper"
 fi
 
-log "Ajustando permisos de báscula"
-for group in dialout tty gpio i2c spi; do
-  if id -nG "${TARGET_USER}" | tr ' ' '\n' | grep -qx "${group}"; then
-    ok "${TARGET_USER} ya pertenece a ${group}"
-  else
-    usermod -a -G "${group}" "${TARGET_USER}"
-    ok "${TARGET_USER} añadido a ${group}"
-  fi
-done
+log "Ajustando grupos de pesaje"
+if usermod -aG dialout,tty,gpio,i2c,spi "${TARGET_USER}"; then
+  ok "${TARGET_USER} añadido a dialout,tty,gpio,i2c,spi"
+else
+  warn "No se pudieron ajustar los grupos para ${TARGET_USER}"
+fi
 
 cat <<'RULE' > "${UDEV_RULE}"
 KERNEL=="ttyACM*", MODE="0660", GROUP="dialout"

--- a/tools/check_scale.py
+++ b/tools/check_scale.py
@@ -34,14 +34,20 @@ def main() -> int:
             return 1
 
     LOG.info("Esperando lecturas…")
-    time.sleep(1.0)
-    try:
-        weight = service.get_weight()
-    except Exception as exc:  # pragma: no cover
-        LOG.warning("Lectura fallida: %s", exc)
-        return 1
-
-    LOG.info("Peso actual: %.3f g", weight)
+    for idx in range(10):
+        time.sleep(0.2)
+        try:
+            weight = service.get_weight()
+        except Exception as exc:  # pragma: no cover
+            LOG.warning("Lectura fallida en intento %s: %s", idx + 1, exc)
+            return 1
+        stable = False
+        if hasattr(service, "is_stable"):
+            try:
+                stable = bool(service.is_stable())
+            except Exception:  # pragma: no cover - diagnóstico
+                stable = False
+        LOG.info("Lectura %02d: %.3f g (estable=%s)", idx + 1, weight, "sí" if stable else "no")
     if hasattr(service, "stop"):
         try:
             service.stop()


### PR DESCRIPTION
## Summary
- extend the scale service to expose an `on_tick` shim, log the selected device, and honour environment/config.ini fallbacks before autodetecting ports
- centre the scale screen weight label for compact kiosks and ensure the TopBar overflow includes any registered advanced screens such as diabetes or API key
- install librsvg2-bin and adjust group provisioning in phase 1 while expanding the scale diagnostic smoke test to read several samples

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cbbeeed1c883268bd19f566b6117a9