### PR TITLE
Restore Focus entry in top bar extras

### DIFF
--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -353,6 +353,7 @@ class TopBar(tk.Frame):
 
     _EXTRA_LABELS = [
         ("history", "Historial"),
+        ("focus", "Enfoque"),
         ("diabetes", "Diabetes"),
         ("nightscout", "Nightscout"),
         ("wifi", "Wi-Fi"),


### PR DESCRIPTION
## Summary
- restore the Focus screen entry in the top bar overflow labels while keeping the Diabetes shortcut

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbda61926483268f75d03a7be66205