### PR TITLE
Restore optional Focus screen navigation

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -249,7 +249,7 @@ class BasculaAppTk:
 
         optional_screens = (
             ("history", "Historial", "bascula.ui.history_screen", "HistoryScreen"),
-            ("focus", "Enfoque", "bascula.ui.focus_screen", "FocusScreen"),
+            ("focus", "Enfoque", "bascula.ui.screens_focus", "FocusScreen"),
             ("nightscout", "Nightscout", "bascula.ui.screens_nightscout", "NightscoutScreen"),
             ("wifi", "Wi-Fi", "bascula.ui.screens_wifi", "WifiScreen"),
             ("apikey", "API Key", "bascula.ui.screens_apikey", "ApiKeyScreen"),

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -353,6 +353,7 @@ class TopBar(tk.Frame):
 
     _EXTRA_LABELS = [
         ("history", "Historial"),
+        ("focus", "Enfoque"),
         ("diabetes", "Diabetes"),
         ("nightscout", "Nightscout"),
         ("wifi", "Wi-Fi"),

--- a/tools/smoke_nav.py
+++ b/tools/smoke_nav.py
@@ -28,20 +28,29 @@ def main() -> int:
             root.destroy()
         return 1
 
-    visited = set()
-    for name in list(app.screens.keys()):
-        canonical = app.resolve_screen_name(name)
-        if canonical in visited:
+    targets = [
+        "home",
+        "scale",
+        "settings",
+        "history",
+        "focus",
+        "diabetes",
+        "nightscout",
+        "wifi",
+        "apikey",
+    ]
+    for name in targets:
+        if name not in app.screens:
+            print(f"[WARN] {name} no disponible")
             continue
-        visited.add(canonical)
         try:
-            app.show_screen(canonical)
+            app.show_screen(name)
             app.root.update_idletasks()
             app.root.update()
         except Exception as exc:  # pragma: no cover - diagnóstico
-            print(f"[FAIL] {canonical}: {exc}")
+            print(f"[FAIL] {name}: {exc}")
         else:
-            print(f"[OK] {canonical}")
+            print(f"[OK] {name}")
 
     with suppress(Exception):
         app.close()


### PR DESCRIPTION
## Summary
- restore the optional Focus entry in the TopBar overflow labels
- register the Focus screen lazily from bascula.ui.screens_focus when available
- extend the navigation smoke test to exercise the Focus route when present

## Testing
- python -m compileall bascula/ui/widgets.py bascula/ui/app.py tools/smoke_nav.py

------
https://chatgpt.com/codex/tasks/task_e_68cbdb12103083268c9c627c8ae94793