### PR TITLE
Fix Focus screen registration path

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -249,7 +249,7 @@ class BasculaAppTk:
 
         optional_screens = (
             ("history", "Historial", "bascula.ui.history_screen", "HistoryScreen"),
-            ("focus", "Enfoque", "bascula.ui.screens_focus", "FocusScreen"),
+            ("focus", "Enfoque", "bascula.ui.focus_screen", "FocusScreen"),
             ("nightscout", "Nightscout", "bascula.ui.screens_nightscout", "NightscoutScreen"),
             ("wifi", "Wi-Fi", "bascula.ui.screens_wifi", "WifiScreen"),
             ("apikey", "API Key", "bascula.ui.screens_apikey", "ApiKeyScreen"),


### PR DESCRIPTION
## Summary
- point the Focus optional screen registration to the existing `bascula.ui.focus_screen` module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbdc732c748326986f79677e7066a0