### PR TITLE
Handle mascot UI defaults and missing assets

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -751,14 +751,36 @@ class BasculaAppTk:
         *args,
         kind: str = "info",
         priority: int = 0,
-        icon: str = "💬",
-        ttl_ms: int = 2200,
+        icon: str | None = "💬",
+        ttl_ms: int | None = 2200,
+        icon_color: str | None = None,
     ) -> None:
+        icon = str(icon or "info")
+        icon_color = str(icon_color or "#44cc66")
+        kind = str(kind or "info")
+        try:
+            ttl_ms = int(ttl_ms or 2500)
+        except Exception:
+            ttl_ms = 2500
         try:
             text, action, anim = get_message(key, *args)
         except Exception:
             text, action, anim = str(key), None, None
-        self.mascot_messenger.show(text, kind=kind, ttl_ms=ttl_ms, priority=priority, icon=icon, action=action, anim=anim)
+        messenger = getattr(self, "mascot_messenger", None)
+        if messenger is not None:
+            try:
+                messenger.show(
+                    text,
+                    kind=kind,
+                    ttl_ms=ttl_ms,
+                    priority=priority,
+                    icon=icon,
+                    icon_color=icon_color,
+                    action=action,
+                    anim=anim,
+                )
+            except Exception:
+                self.logger.warning("No se pudo mostrar mensaje en la mascota", exc_info=True)
         self.messenger.show(text, kind=kind, priority=priority, icon=icon)
 
     def _register_screen(

--- a/tools/smoke_mascot.py
+++ b/tools/smoke_mascot.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from tkinter import Tk
 
 
@@ -14,10 +16,27 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from bascula.ui.app import BasculaAppTk
 from bascula.ui.mascot import MascotWidget
+from bascula.ui.mascot_messages import MascotMessenger
+
+
+def _exercise_show_message_defaults() -> None:
+    """Ensure ``show_mascot_message`` tolerates ``None`` icon inputs."""
+
+    class _StubMessenger:
+        def show(self, text: str, *, kind: str = "info", priority: int = 0, icon: str = "") -> None:
+            """No-op stub used for smoke verification."""
+
+    dummy = SimpleNamespace()
+    dummy.logger = logging.getLogger("bascula.smoke_mascot")
+    dummy.mascot_messenger = MascotMessenger(lambda: None, lambda: None)
+    dummy.messenger = _StubMessenger()
+    BasculaAppTk.show_mascot_message(dummy, "auto_captured", 42, icon=None, icon_color=None, ttl_ms=None)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    _exercise_show_message_defaults()
     os.environ.setdefault("BASCULA_MASCOT_THEME", "retro-green")
     root = Tk()
     root.title("Mascot smoke test")


### PR DESCRIPTION
## Summary
- harden mascot message bubbles against missing colours and drawing errors while supporting icon colour defaults
- ensure show_mascot_message supplies safe defaults and tolerates a missing mascot messenger
- look for generated mascot assets before falling back to a placeholder and exercise the None-icon path in the smoke test

## Testing
- python -m py_compile bascula/ui/mascot_messages.py bascula/ui/app.py bascula/ui/mascot.py tools/smoke_mascot.py

------
https://chatgpt.com/codex/tasks/task_e_68cbf940b49083268fccae9c686d29c2