### PR TITLE
Improve kiosk startup handling for Raspberry Pi

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -106,6 +106,9 @@ else
 fi
 
 sudo chown -R "${TARGET_USER}:${TARGET_USER}" "${APP_DIR}" || true
+if [[ -f "${APP_DIR}/scripts/safe_run.sh" ]]; then
+  chmod 0755 "${APP_DIR}/scripts/safe_run.sh" || true
+fi
 
 log "Instalando servicios systemd"
 cat <<EOF_UI > /etc/systemd/system/bascula-ui.service

--- a/scripts/install-kiosk-xorg.sh
+++ b/scripts/install-kiosk-xorg.sh
@@ -27,22 +27,45 @@ chmod 0644 "${GETTY_DIR}/override.conf"
 BASH_PROFILE="${TARGET_HOME}/.bash_profile"
 cat <<'EOF_PROFILE' > "${BASH_PROFILE}"
 #!/usr/bin/env bash
+PHASE_FILE="/var/lib/bascula/phase"
+
 if [[ -z "${DISPLAY:-}" && $(tty) == /dev/tty1 ]]; then
-  exec startx -- -nocursor
+  if [[ -f "${PHASE_FILE}" ]] && grep -q 'PHASE=2_DONE' "${PHASE_FILE}"; then
+    exec startx -- -nocursor
+  else
+    echo "[bascula] Inicio gráfico pospuesto: ejecuta install-2-app.sh" >&2
+  fi
 fi
 EOF_PROFILE
 chown "${TARGET_USER}:${TARGET_USER}" "${BASH_PROFILE}" || true
 chmod 0755 "${BASH_PROFILE}"
 
 XINITRC="${TARGET_HOME}/.xinitrc"
-cat <<EOF_XINIT > "${XINITRC}"
+cat <<'EOF_XINIT' > "${XINITRC}"
 #!/usr/bin/env bash
 set -euo pipefail
 
-xset s off -dpms
-matchbox-window-manager &
+export DISPLAY=:0
+export XAUTHORITY="${HOME}/.Xauthority"
 
-if [ -x "${APP_DIR}/scripts/safe_run.sh" ]; then
+if command -v xset >/dev/null 2>&1; then
+  xset s off -dpms || true
+  xset s noblank || true
+fi
+
+PHASE_FILE="/var/lib/bascula/phase"
+if [[ ! -f "${PHASE_FILE}" ]] || ! grep -q 'PHASE=2_DONE' "${PHASE_FILE}"; then
+  echo "[bascula] Instalación incompleta: ejecuta install-2-app.sh" >&2
+  sleep 5
+  exit 0
+fi
+
+APP_DIR="${HOME}/bascula-cam"
+if command -v matchbox-window-manager >/dev/null 2>&1; then
+  matchbox-window-manager -use_titlebar no -use_system_theme &
+fi
+
+if [[ -x "${APP_DIR}/scripts/safe_run.sh" ]]; then
   exec "${APP_DIR}/scripts/safe_run.sh"
 else
   exec python3 "${APP_DIR}/main.py"
@@ -50,5 +73,13 @@ fi
 EOF_XINIT
 chown "${TARGET_USER}:${TARGET_USER}" "${XINITRC}" || true
 chmod 0755 "${XINITRC}"
+
+XAUTH_FILE="${TARGET_HOME}/.Xauthority"
+if [[ -f "${XAUTH_FILE}" ]]; then
+  chown "${TARGET_USER}:${TARGET_USER}" "${XAUTH_FILE}" || true
+  chmod 0600 "${XAUTH_FILE}" || true
+else
+  install -m 0600 -o "${TARGET_USER}" -g "${TARGET_USER}" /dev/null "${XAUTH_FILE}" || true
+fi
 
 log "Autologin y startx configurados para ${TARGET_USER}"

--- a/scripts/verify-kiosk.sh
+++ b/scripts/verify-kiosk.sh
@@ -3,16 +3,49 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET_USER="${TARGET_USER:-${USER:-$(id -un)}}"
+TARGET_HOME_RAW="${TARGET_HOME:-$(eval echo "~${TARGET_USER}")}" 
+HOME_UNRESOLVED=false
+if [[ "$TARGET_HOME_RAW" == ~* ]]; then
+  HOME_UNRESOLVED=true
+  TARGET_HOME=""
+else
+  TARGET_HOME="$TARGET_HOME_RAW"
+fi
 STATUS=0
 
 log() { printf '[verify-kiosk] %s\n' "$*"; }
 warn() { printf '[verify-kiosk][WARN] %s\n' "$*"; }
 err() { printf '[verify-kiosk][ERR] %s\n' "$*" >&2; STATUS=1; }
 
+if $HOME_UNRESOLVED; then
+  warn "No se pudo resolver el home de ${TARGET_USER}"
+fi
+
 if [[ -S /tmp/.X11-unix/X0 ]]; then
   log 'Socket X0 disponible'
 else
   warn 'No se encontró /tmp/.X11-unix/X0 (modo headless?)'
+fi
+
+if command -v loginctl >/dev/null 2>&1; then
+  env_dump="$(loginctl show-environment 2>/dev/null || true)"
+  if grep -q '^DISPLAY=:0$' <<<"$env_dump"; then
+    log 'DISPLAY=:0 exportado en sesión systemd'
+  else
+    warn 'DISPLAY=:0 no detectado en loginctl show-environment'
+  fi
+else
+  if [[ "${DISPLAY:-}" == ":0" ]]; then
+    log 'DISPLAY=:0 disponible en la sesión actual'
+  else
+    warn 'DISPLAY=:0 no detectado en la sesión actual'
+  fi
+fi
+
+if [[ -n "${TARGET_HOME}" && -f "${TARGET_HOME}/.Xauthority" ]]; then
+  log "${TARGET_HOME}/.Xauthority presente"
+else
+  warn "${TARGET_HOME}/.Xauthority ausente"
 fi
 
 VENV="$ROOT_DIR/.venv"
@@ -35,6 +68,64 @@ if [[ -x "$SAFE_RUN" ]]; then
   log 'safe_run.sh es ejecutable'
 else
   warn 'safe_run.sh no es ejecutable'
+fi
+
+if [[ -n "${TARGET_HOME}" ]]; then
+  XINITRC="${TARGET_HOME}/.xinitrc"
+  if [[ -f "$XINITRC" ]]; then
+    if grep -q 'DISPLAY=:0' "$XINITRC" && grep -q 'XAUTHORITY=' "$XINITRC"; then
+      log '~/.xinitrc exporta DISPLAY y XAUTHORITY'
+    else
+      warn '~/.xinitrc no configura DISPLAY/XAUTHORITY'
+    fi
+    if grep -q 'matchbox-window-manager' "$XINITRC"; then
+      log 'matchbox-window-manager configurado en ~/.xinitrc'
+    else
+      warn 'matchbox-window-manager no referenciado en ~/.xinitrc'
+    fi
+    if grep -q 'safe_run.sh' "$XINITRC"; then
+      log '~/.xinitrc inicia safe_run.sh'
+    else
+      warn '~/.xinitrc no ejecuta safe_run.sh'
+    fi
+    if [[ -x "$XINITRC" ]]; then
+      log '~/.xinitrc es ejecutable'
+    else
+      warn '~/.xinitrc no es ejecutable'
+    fi
+  else
+    warn "${XINITRC} ausente"
+  fi
+
+  PROFILE="${TARGET_HOME}/.bash_profile"
+  if [[ -f "$PROFILE" ]]; then
+    if grep -q 'startx' "$PROFILE"; then
+      if grep -q 'PHASE=2_DONE' "$PROFILE"; then
+        log '.bash_profile lanza startx tras completar install-2'
+      else
+        warn '.bash_profile lanza startx sin comprobar PHASE=2_DONE'
+      fi
+    else
+      warn '.bash_profile no lanza startx'
+    fi
+  else
+    warn "${PROFILE} ausente"
+  fi
+fi
+
+if command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]; then
+  if systemctl is-active bascula-ui.service >/dev/null 2>&1; then
+    log 'bascula-ui.service activo'
+  else
+    if [[ -n "${PROFILE:-}" ]] && [[ -f "$PROFILE" ]] && grep -q 'startx' "$PROFILE"; then
+      log 'bascula-ui.service inactivo; arranque delegado a startx'
+    else
+      warn 'bascula-ui.service inactivo y startx no configurado'
+      STATUS=1
+    fi
+  fi
+else
+  warn 'systemctl no disponible o systemd no se está ejecutando; verificación de bascula-ui.service omitida'
 fi
 
 ASSETS_DIR="$ROOT_DIR/bascula/ui/assets/mascota/_gen"


### PR DESCRIPTION
## Summary
- gate the auto-start of X11 until install phase 2 completes and export DISPLAY/XAUTHORITY in the generated kiosk scripts
- harden the kiosk installer by ensuring matchbox-window-manager runs, .Xauthority exists and safe_run.sh is executable before launch
- expand the kiosk and service verification scripts to assert DISPLAY=:0, XAUTHORITY and service/startx readiness

## Testing
- `bash scripts/verify-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ccc51dd2908326b2ca4369932e631a