### PR TITLE
Fix Tkinter UI robustness and headless fallbacks

### DIFF
--- a/bascula/ui/failsafe_mascot.py
+++ b/bascula/ui/failsafe_mascot.py
@@ -143,7 +143,24 @@ class MascotCanvas(tk.Canvas):
             fill=CRT_COLORS["accent"],
             outline=CRT_COLORS["divider"],
         )
-        self.symbol_text = self.create_text(cx, screen_y0 + screen_h // 2, text="♥", fill=CRT_COLORS["text"], font=mono("lg"))
+        font = mono("lg")
+        try:
+            self.symbol_text = self.create_text(
+                cx,
+                screen_y0 + screen_h // 2,
+                text="♥",
+                fill=CRT_COLORS["text"],
+                font=font,
+            )
+        except Exception:
+            fallback_font = ("Arial", 48, "bold")
+            self.symbol_text = self.create_text(
+                cx,
+                screen_y0 + screen_h // 2,
+                text="♥",
+                fill=CRT_COLORS["text"],
+                font=fallback_font,
+            )
 
     def create_round_rect(self, x1: int, y1: int, x2: int, y2: int, radius: int, **kwargs) -> int:
         points = [


### PR DESCRIPTION
## Summary
- harden lightweight widgets by normalising fonts and numeric options to avoid TclError crashes and keep ValueLabel padding consistent
- ensure the failsafe mascot falls back to a generic font if JetBrains Mono is missing
- refine the Raspberry Pi UI: add a visible Home control on Settings, enforce navbar height, move the scale overlay to a frame-based modal, and improve screen switching cleanup
- allow the main entry point to fall back to the headless service when DISPLAY or Tkinter is unavailable

## Testing
- bash scripts/verify-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68cccbb1d70c832683d012cd0cf4b976