### PR TITLE
feat: redesign failsafe mascot

### DIFF
--- a/bascula/ui/failsafe_mascot.py
+++ b/bascula/ui/failsafe_mascot.py
@@ -62,105 +62,315 @@ class MascotCanvas(tk.Canvas):
         cx = w // 2
         cy = h // 2
         self.delete("all")
-        body_w = int(w * 0.6)
-        body_h = int(h * 0.55)
-        radius = 24
+
+        body_w = int(w * 0.58)
+        body_h = int(h * 0.5)
+        head_h = int(h * 0.28)
+        radius = 28
         x0 = cx - body_w // 2
-        y0 = cy - body_h // 2
         x1 = cx + body_w // 2
-        y1 = cy + body_h // 2
-        self.body = self.create_round_rect(x0, y0, x1, y1, radius, fill=MASCOT_STATES["idle"]["color"], outline="")
-        screen_h = int(body_h * 0.35)
-        screen_y0 = y0 + int(body_h * 0.18)
-        screen_y1 = screen_y0 + screen_h
-        self.screen = self.create_round_rect(x0 + 20, screen_y0, x1 - 20, screen_y1, 18, fill=CRT_COLORS["bg"], outline=CRT_COLORS["divider"], width=2)
-        eye_w = 34
-        eye_h = 18
-        eye_y = screen_y0 - 30
-        eye_gap = 46
+        body_y0 = cy - body_h // 2 + int(head_h * 0.35)
+        body_y1 = body_y0 + body_h
+
+        accent = MASCOT_STATES["idle"]["color"]
+        accent_dim = CRT_COLORS["accent_dim"]
+        divider = CRT_COLORS["divider"]
+        bg = CRT_COLORS["bg"]
+
+        # base glow shadow
+        base_w = int(body_w * 0.9)
+        base_y0 = body_y1 + 24
+        self.base_glow = self.create_oval(
+            cx - base_w // 2,
+            base_y0,
+            cx + base_w // 2,
+            base_y0 + 28,
+            outline="",
+            fill=_safe_color(CRT_COLORS.get("shadow"), "#001903"),
+        )
+
+        # legs and feet
+        leg_width = 18
+        leg_height = int(body_h * 0.42)
+        leg_y0 = body_y1 - 12
+        leg_y1 = leg_y0 + leg_height
+        foot_w = 70
+        foot_h = 26
+        foot_y0 = leg_y1 - 14
+
+        self.left_leg = self.create_line(
+            cx - body_w * 0.22,
+            leg_y0,
+            cx - body_w * 0.22,
+            leg_y1,
+            fill=accent,
+            width=leg_width,
+            capstyle="round",
+        )
+        self.right_leg = self.create_line(
+            cx + body_w * 0.22,
+            leg_y0,
+            cx + body_w * 0.22,
+            leg_y1,
+            fill=accent,
+            width=leg_width,
+            capstyle="round",
+        )
+        self.left_foot = self.create_round_rect(
+            cx - body_w * 0.22 - foot_w // 2,
+            foot_y0,
+            cx - body_w * 0.22 + foot_w // 2,
+            foot_y0 + foot_h,
+            12,
+            fill=accent_dim,
+            outline="",
+        )
+        self.right_foot = self.create_round_rect(
+            cx + body_w * 0.22 - foot_w // 2,
+            foot_y0,
+            cx + body_w * 0.22 + foot_w // 2,
+            foot_y0 + foot_h,
+            12,
+            fill=accent_dim,
+            outline="",
+        )
+
+        # Torso and head
+        head_y1 = body_y0 + int(head_h * 0.9)
+        head_y0 = head_y1 - head_h
+        head_x0 = cx - int(body_w * 0.62)
+        head_x1 = cx + int(body_w * 0.62)
+        self.head = self.create_round_rect(head_x0, head_y0, head_x1, head_y1, radius, fill=accent, outline="")
+
+        visor_inset = 26
+        visor_y0 = head_y0 + 32
+        visor_y1 = head_y1 - 32
+        self.visor = self.create_round_rect(
+            head_x0 + visor_inset,
+            visor_y0,
+            head_x1 - visor_inset,
+            visor_y1,
+            22,
+            fill=bg,
+            outline=divider,
+            width=3,
+        )
+
+        # Eyes and mouth line details
+        eye_w = 46
+        eye_h = 22
+        eye_y = visor_y0 + 24
+        eye_gap = 58
         self.left_eye = self.create_oval(
             cx - eye_gap - eye_w // 2,
             eye_y,
             cx - eye_gap + eye_w // 2,
             eye_y + eye_h,
-            fill=CRT_COLORS["bg"],
-            outline=CRT_COLORS["divider"],
-            width=2,
+            fill=bg,
+            outline=divider,
+            width=3,
         )
         self.right_eye = self.create_oval(
             cx + eye_gap - eye_w // 2,
             eye_y,
             cx + eye_gap + eye_w // 2,
             eye_y + eye_h,
-            fill=CRT_COLORS["bg"],
-            outline=CRT_COLORS["divider"],
-            width=2,
+            fill=bg,
+            outline=divider,
+            width=3,
         )
-        mouth_y = eye_y + 40
+
+        mouth_y = eye_y + 50
         self.mouth = self.create_arc(
-            cx - 50,
+            cx - 64,
             mouth_y,
-            cx + 50,
-            mouth_y + 60,
+            cx + 64,
+            mouth_y + 80,
             start=200,
             extent=140,
             style="arc",
-            outline=CRT_COLORS["divider"],
+            outline=divider,
+            width=4,
+        )
+
+        # Torso block with inset screen
+        self.body = self.create_round_rect(x0, body_y0, x1, body_y1, radius, fill=accent, outline="")
+        inner_inset = 24
+        screen_y0 = body_y0 + 34
+        screen_y1 = screen_y0 + int(body_h * 0.44)
+        self.screen_frame = self.create_round_rect(
+            x0 + inner_inset,
+            screen_y0,
+            x1 - inner_inset,
+            screen_y1,
+            18,
+            fill=bg,
+            outline=divider,
             width=3,
         )
-        antenna_y = y0 - 30
-        self.left_antenna = self.create_line(
-            cx - body_w // 3,
-            y0 + 10,
-            cx - body_w // 3,
-            antenna_y,
-            fill=CRT_COLORS["accent"],
-            width=4,
-            capstyle="round",
+
+        # cardio wave
+        wave_width = self.coords(self.screen_frame)
+        if len(wave_width) >= 8:
+            sf_x0 = wave_width[0]
+            sf_y0 = wave_width[1]
+            sf_x1 = wave_width[4]
+            sf_y1 = wave_width[5]
+        else:
+            sf_x0 = x0 + inner_inset
+            sf_x1 = x1 - inner_inset
+            sf_y0 = screen_y0
+            sf_y1 = screen_y1
+        wave_y = sf_y0 + (sf_y1 - sf_y0) * 0.6
+        wave_points = [
+            sf_x0 + 12,
+            wave_y,
+            sf_x0 + 48,
+            wave_y,
+            sf_x0 + 74,
+            wave_y - 22,
+            sf_x0 + 98,
+            wave_y + 18,
+            sf_x0 + 132,
+            wave_y,
+            sf_x1 - 48,
+            wave_y,
+            sf_x1 - 24,
+            wave_y,
+        ]
+        self.screen_wave = self.create_line(
+            *wave_points,
+            fill=divider,
+            width=5,
+            smooth=True,
         )
-        self.right_antenna = self.create_line(
-            cx + body_w // 3,
-            y0 + 10,
-            cx + body_w // 3,
-            antenna_y,
-            fill=CRT_COLORS["accent"],
-            width=4,
-            capstyle="round",
-        )
-        self.left_antenna_tip = self.create_oval(
-            cx - body_w // 3 - 10,
-            antenna_y - 10,
-            cx - body_w // 3 + 10,
-            antenna_y + 10,
-            fill=CRT_COLORS["accent"],
-            outline=CRT_COLORS["divider"],
-        )
-        self.right_antenna_tip = self.create_oval(
-            cx + body_w // 3 - 10,
-            antenna_y - 10,
-            cx + body_w // 3 + 10,
-            antenna_y + 10,
-            fill=CRT_COLORS["accent"],
-            outline=CRT_COLORS["divider"],
-        )
-        font = mono("lg")
+
+        info_font = mono("md")
         try:
             self.symbol_text = self.create_text(
                 cx,
-                screen_y0 + screen_h // 2,
+                sf_y0 + (sf_y1 - sf_y0) * 0.28,
                 text="♥",
-                fill=CRT_COLORS["text"],
-                font=font,
+                fill=divider,
+                font=info_font,
             )
         except Exception:
-            fallback_font = ("Arial", 48, "bold")
+            fallback_font = ("Arial", 32, "bold")
             self.symbol_text = self.create_text(
                 cx,
-                screen_y0 + screen_h // 2,
+                sf_y0 + (sf_y1 - sf_y0) * 0.28,
                 text="♥",
-                fill=CRT_COLORS["text"],
+                fill=divider,
                 font=fallback_font,
             )
+
+        # control buttons imitation on torso
+        button_y = screen_y1 + 36
+        button_radius = 14
+        self.left_button = self.create_oval(
+            x0 + inner_inset,
+            button_y,
+            x0 + inner_inset + button_radius * 2,
+            button_y + button_radius * 2,
+            fill=accent_dim,
+            outline="",
+        )
+        self.right_button = self.create_oval(
+            x1 - inner_inset - button_radius * 2,
+            button_y,
+            x1 - inner_inset,
+            button_y + button_radius * 2,
+            fill=divider,
+            outline="",
+        )
+
+        # arms with joints
+        arm_y = body_y0 + body_h * 0.45
+        arm_length = body_w * 0.8
+        elbow_offset = 46
+        self.left_arm = self.create_line(
+            x0 - 24,
+            arm_y,
+            x0 - arm_length * 0.5,
+            arm_y + elbow_offset,
+            fill=accent_dim,
+            width=16,
+            smooth=True,
+            capstyle="round",
+        )
+        self.right_arm = self.create_line(
+            x1 + 24,
+            arm_y,
+            x1 + arm_length * 0.5,
+            arm_y + elbow_offset,
+            fill=accent_dim,
+            width=16,
+            smooth=True,
+            capstyle="round",
+        )
+
+        # antenna and tips
+        antenna_y = head_y0 - 36
+        self.left_antenna = self.create_line(
+            cx - body_w * 0.28,
+            head_y0 + 12,
+            cx - body_w * 0.28,
+            antenna_y,
+            fill=divider,
+            width=5,
+            capstyle="round",
+        )
+        self.right_antenna = self.create_line(
+            cx + body_w * 0.28,
+            head_y0 + 12,
+            cx + body_w * 0.28,
+            antenna_y,
+            fill=divider,
+            width=5,
+            capstyle="round",
+        )
+        self.left_antenna_tip = self.create_oval(
+            cx - body_w * 0.28 - 12,
+            antenna_y - 12,
+            cx - body_w * 0.28 + 12,
+            antenna_y + 12,
+            fill=divider,
+            outline="",
+        )
+        self.right_antenna_tip = self.create_oval(
+            cx + body_w * 0.28 - 12,
+            antenna_y - 12,
+            cx + body_w * 0.28 + 12,
+            antenna_y + 12,
+            fill=divider,
+            outline="",
+        )
+
+        self._breath_targets = [
+            self.body,
+            self.head,
+            self.screen_frame,
+            self.visor,
+            self.symbol_text,
+            self.screen_wave,
+            self.left_button,
+            self.right_button,
+            self.left_arm,
+            self.right_arm,
+            self.left_leg,
+            self.right_leg,
+            self.left_foot,
+            self.right_foot,
+            self.left_antenna,
+            self.right_antenna,
+            self.left_antenna_tip,
+            self.right_antenna_tip,
+        ]
+
+        self._eye_base = {
+            self.left_eye: self.coords(self.left_eye),
+            self.right_eye: self.coords(self.right_eye),
+        }
 
     def create_round_rect(self, x1: int, y1: int, x2: int, y2: int, radius: int, **kwargs) -> int:
         points = [
@@ -196,10 +406,47 @@ class MascotCanvas(tk.Canvas):
         self._state = state if state in MASCOT_STATES else "idle"
         color = _safe_color(data.get("color"), MASCOT_STATES["idle"]["color"])
         symbol = data.get("symbol", MASCOT_STATES["idle"].get("symbol", "♥")) or "♥"
-        try:
-            self.itemconfigure(self.body, fill=color)
-        except Exception:
-            pass
+        detail_color = _safe_color(CRT_COLORS.get("divider"), color)
+        accent_detail = _safe_color(CRT_COLORS.get("accent_dim"), color)
+        for item in (
+            getattr(self, "body", None),
+            getattr(self, "head", None),
+            getattr(self, "left_leg", None),
+            getattr(self, "right_leg", None),
+            getattr(self, "left_foot", None),
+            getattr(self, "right_foot", None),
+        ):
+            if item is None:
+                continue
+            try:
+                self.itemconfigure(item, fill=color)
+            except Exception:
+                continue
+        for item in (
+            getattr(self, "left_button", None),
+            getattr(self, "left_arm", None),
+            getattr(self, "right_arm", None),
+        ):
+            if item is None:
+                continue
+            try:
+                self.itemconfigure(item, fill=accent_detail)
+            except Exception:
+                continue
+        for item in (
+            getattr(self, "screen_wave", None),
+            getattr(self, "right_button", None),
+            getattr(self, "left_antenna", None),
+            getattr(self, "right_antenna", None),
+            getattr(self, "left_antenna_tip", None),
+            getattr(self, "right_antenna_tip", None),
+        ):
+            if item is None:
+                continue
+            try:
+                self.itemconfigure(item, fill=detail_color)
+            except Exception:
+                continue
         try:
             self.itemconfigure(self.symbol_text, text=symbol)
         except Exception:
@@ -222,13 +469,12 @@ class MascotCanvas(tk.Canvas):
 
     def _breath(self) -> None:
         def _update(progress: float) -> None:
-            offset = math.sin(progress * math.pi) * 2
-            try:
-                self.move(self.body, 0, offset)
-                self.move(self.screen, 0, offset)
-                self.move(self.symbol_text, 0, offset)
-            except Exception:
-                pass
+            offset = math.sin(progress * math.pi) * 2.4
+            for item in getattr(self, "_breath_targets", []):
+                try:
+                    self.move(item, 0, offset)
+                except Exception:
+                    continue
 
         self.manager.schedule(self, duration=280, steps=4, updater=_update)
         self._breath_job = self.after(1800, self._breath)
@@ -238,27 +484,25 @@ class MascotCanvas(tk.Canvas):
             scale = max(0.1, 1.0 - progress)
             for item in (self.left_eye, self.right_eye):
                 try:
-                    coords = self.coords(item)
-                    if len(coords) == 4:
-                        x0, y0, x1, y1 = coords
-                        cy = (y0 + y1) / 2
-                        new_y0 = cy - (cy - y0) * scale
-                        new_y1 = cy + (y1 - cy) * scale
-                        self.coords(item, x0, new_y0, x1, new_y1)
+                    base = self._eye_base.get(item)
+                    if not base or len(base) != 4:
+                        continue
+                    x0, y0, x1, y1 = base
+                    cy = (y0 + y1) / 2
+                    half_height = (y1 - y0) / 2
+                    new_half = max(1.0, half_height * scale)
+                    self.coords(item, x0, cy - new_half, x1, cy + new_half)
                 except Exception:
-                    pass
+                    continue
 
         def _restore() -> None:
             for item in (self.left_eye, self.right_eye):
                 try:
-                    coords = self.coords(item)
-                    if len(coords) == 4:
-                        x0, y0, x1, y1 = coords
-                        cy = (y0 + y1) / 2
-                        height = max(1.0, (y1 - y0))
-                        self.coords(item, x0, cy - height / 2, x1, cy + height / 2)
+                    base = self._eye_base.get(item)
+                    if base and len(base) == 4:
+                        self.coords(item, *base)
                 except Exception:
-                    pass
+                    continue
 
         self.manager.schedule(self, duration=160, steps=3, updater=_update, on_complete=_restore)
         self._blink_job = self.after(5200, self._blink)


### PR DESCRIPTION
## Summary
- replace the failsafe Tk mascot drawing with a multi-part robot design that matches the reference proportions and details
- update breathing and blinking animations to account for the new grouped elements and restore eye shapes accurately
- adjust state color handling so the body, accents, and detail highlights respond cohesively to mascot mood changes

## Testing
- python -m compileall bascula/ui/failsafe_mascot.py

------
https://chatgpt.com/codex/tasks/task_e_68ccddc4d8ac832685984f277688dcfa