### PR TITLE
Restore live weight updates on home screen

### DIFF
--- a/bascula/ui/rpi_optimized_ui.py
+++ b/bascula/ui/rpi_optimized_ui.py
@@ -199,10 +199,10 @@ class HomeScreen(BaseScreen):
     def refresh(self) -> None:
         weight = self.app.net_weight
         stable = self.app.scale_stable
-        has_reading = stable and abs(weight) >= 1
-        message = format_weight(weight) if has_reading else "¡Hola! ¿Qué vamos a pesar?"
+        show_live_reading = not stable or abs(weight) >= 1
+        message = format_weight(weight) if show_live_reading else "¡Hola! ¿Qué vamos a pesar?"
         self.message_label.configure(text=message)
-        status = "Peso estable" if stable else "Coloca un ingrediente"
+        status = "Peso estable" if stable else "Leyendo..."
         status_color = CRT_COLORS["accent"] if stable else CRT_COLORS["muted"]
         self.status_label.configure(text=status, fg=status_color)
         if self.app.food_history:


### PR DESCRIPTION
## Summary
- show the live weight while the scale stabilizes so the greeting only appears when idle
- restore the unstable-state status text to "Leyendo..." for clearer feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cce59a7b7c8326a6a7547418111318