### PR TITLE
Add FastAPI dependency and install step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,14 @@ name = "bascula-cam"
 version = "0.0.0"
 description = "Báscula con cámara y TTS Piper"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "pyserial>=3.5",
+    "Pillow>=9.5",
+    "Flask>=2.2",
+    "requests>=2.31",
+    "qrcode[pil]>=7.4",
+    "fastapi>=0.110",
+]
 
 [tool.setuptools]
 packages = ["bascula"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Pillow>=9.5
 Flask>=2.2
 requests>=2.31
 qrcode[pil]>=7.4
+fastapi>=0.110

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -87,6 +87,14 @@ fi
 
 if ! sudo -u "${TARGET_USER}" -H "${VENV_DIR}/bin/python" - <<'PY'
 import importlib, sys
+sys.exit(0 if importlib.util.find_spec("fastapi") else 1)
+PY
+then
+  sudo -u "${TARGET_USER}" -H PIP_CACHE_DIR="${PIP_CACHE_DIR}" "${VENV_DIR}/bin/python" -m pip install fastapi
+fi
+
+if ! sudo -u "${TARGET_USER}" -H "${VENV_DIR}/bin/python" - <<'PY'
+import importlib, sys
 sys.exit(0 if importlib.util.find_spec("uvicorn") else 1)
 PY
 then


### PR DESCRIPTION
## Summary
- add FastAPI to the shared dependency lists so the package is installed with the project
- extend install-2-app script to ensure FastAPI is present in the virtual environment alongside uvicorn

## Testing
- ⚠️ `python3 -m venv .venv-test && source .venv-test/bin/activate && pip install --upgrade pip && pip install -r requirements.txt && pip install uvicorn`
  - Failed due to network proxy restrictions while downloading packages


------
https://chatgpt.com/codex/tasks/task_e_68cd0fcda188832691f3e04ab8d89f40