### PR TITLE
Fix headless mode service wiring

### DIFF
--- a/bascula/services/wifi_config.py
+++ b/bascula/services/wifi_config.py
@@ -432,5 +432,18 @@ def nightscout_test():
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
 
+def main(host: str | None = None, port: int | None = None, **kwargs) -> None:
+    """Punto de entrada para arrancar el servidor Flask de configuración."""
+
+    params = {
+        "host": host or APP_HOST,
+        "port": int(port or APP_PORT),
+        "debug": False,
+    }
+    params.update(kwargs)
+    params.setdefault("use_reloader", False)
+    app.run(**params)
+
+
 if __name__ == "__main__":
-    app.run(host=APP_HOST, port=APP_PORT, debug=False)
+    main()

--- a/tests/test_headless_main.py
+++ b/tests/test_headless_main.py
@@ -1,0 +1,59 @@
+import threading
+
+from bascula.services import headless_main
+
+
+def test_run_services_starts_components(monkeypatch):
+    server_started = threading.Event()
+    server_shutdown = threading.Event()
+    stop_event = threading.Event()
+
+    class DummyServer:
+        def serve_forever(self):
+            server_started.set()
+            stop_event.wait()
+
+        def shutdown(self):
+            server_shutdown.set()
+            stop_event.set()
+
+    def fake_make_server(*args, **kwargs):
+        return DummyServer()
+
+    monkeypatch.setattr("werkzeug.serving.make_server", fake_make_server)
+
+    class DummyReader:
+        def __init__(self, *args, **kwargs):
+            self.started = threading.Event()
+            self.stopped = threading.Event()
+
+        def start(self):
+            self.started.set()
+
+        def stop(self):
+            self.stopped.set()
+
+    monkeypatch.setattr("bascula.services.serial_reader.SerialReader", DummyReader)
+
+    original_sleep = headless_main.time.sleep
+
+    def fast_sleep(seconds):
+        original_sleep(0.01)
+
+    monkeypatch.setattr(headless_main.time, "sleep", fast_sleep)
+
+    app = headless_main.HeadlessBascula()
+    worker = threading.Thread(target=app.run_services, daemon=True)
+    worker.start()
+
+    assert server_started.wait(timeout=1.0)
+    assert isinstance(app.scale_reader, DummyReader)
+    dummy_reader = app.scale_reader
+    assert dummy_reader.started.is_set()
+
+    app.running = False
+
+    worker.join(timeout=2.0)
+    assert not worker.is_alive()
+    assert server_shutdown.is_set()
+    assert dummy_reader.stopped.is_set()


### PR DESCRIPTION
## Summary
- start the Wi-Fi configuration Flask app in headless mode using Werkzeug's server helper
- integrate the existing serial reader into `HeadlessBascula` and ensure resources are cleaned up
- add a test that verifies `run_services` boots the web server and reader without hitting the error path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd10b3e1708326a036c55de3ffefe9