### PR TITLE
Fix Tkinter diagnostic tests for pytest

### DIFF
--- a/scripts/test_ui.py
+++ b/scripts/test_ui.py
@@ -9,6 +9,8 @@ import logging
 import tkinter as tk
 from pathlib import Path
 
+import pytest
+
 # Añadir la raíz del proyecto al path
 REPO_ROOT = Path(__file__).parent.parent.absolute()
 if str(REPO_ROOT) not in sys.path:
@@ -22,96 +24,136 @@ logging.basicConfig(
 )
 log = logging.getLogger("test_ui")
 
-def test_tkinter_basic():
-    """Prueba básica de Tkinter"""
+def _require_display() -> None:
+    """Omitir pruebas cuando no hay DISPLAY disponible."""
+    if not os.environ.get("DISPLAY") and sys.platform != "win32":
+        pytest.skip("DISPLAY no disponible para pruebas de Tkinter")
+
+
+def _run_tkinter_basic() -> bool:
+    """Ejecuta la prueba básica de Tkinter y devuelve si fue exitosa."""
     log.info("=== PRUEBA BÁSICA DE TKINTER ===")
-    
+
     try:
         root = tk.Tk()
         root.title("Test Básico")
         root.geometry("800x600")
         root.configure(bg="#0a0e1a")
-        
+
         # Etiqueta de prueba
-        label = tk.Label(root, text="✅ Tkinter funcionando correctamente", 
-                        fg="#00ff66", bg="#0a0e1a", 
-                        font=("DejaVu Sans", 24, "bold"))
+        label = tk.Label(
+            root,
+            text="✅ Tkinter funcionando correctamente",
+            fg="#00ff66",
+            bg="#0a0e1a",
+            font=("DejaVu Sans", 24, "bold"),
+        )
         label.pack(expand=True)
-        
+
         # Botón para cerrar
-        btn = tk.Button(root, text="Cerrar", command=root.destroy,
-                       font=("DejaVu Sans", 16))
+        btn = tk.Button(
+            root,
+            text="Cerrar",
+            command=root.destroy,
+            font=("DejaVu Sans", 16),
+        )
         btn.pack(pady=20)
-        
+
         log.info("Ventana de prueba creada. Mostrando por 5 segundos…")
         root.after(5000, root.destroy)  # Auto-cerrar después de 5 segundos
         root.mainloop()
-        
+
         log.info("✅ Prueba básica de Tkinter: EXITOSA")
         return True
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - errores dependen del entorno gráfico
         log.error(f"❌ Error en prueba básica de Tkinter: {e}")
         return False
 
-def test_fullscreen():
-    """Prueba de modo pantalla completa"""
+
+def test_tkinter_basic() -> None:
+    """Prueba básica de Tkinter"""
+    _require_display()
+    assert _run_tkinter_basic()
+
+def _run_fullscreen() -> bool:
+    """Ejecuta la prueba de modo pantalla completa y devuelve si fue exitosa."""
     log.info("=== PRUEBA MODO PANTALLA COMPLETA ===")
-    
+
     try:
         root = tk.Tk()
         root.title("Test Fullscreen")
-        root.attributes('-fullscreen', True)
-        root.configure(bg="#000000", cursor='none')
-        
+        root.attributes("-fullscreen", True)
+        root.configure(bg="#000000", cursor="none")
+
         # Contenido de prueba
-        tk.Label(root, text="🖥️ MODO PANTALLA COMPLETA", 
-                fg="#00ff66", bg="#000000", 
-                font=("DejaVu Sans", 32, "bold")).pack(pady=100)
-        
-        tk.Label(root, text="Presiona ESC para salir", 
-                fg="#ffffff", bg="#000000", 
-                font=("DejaVu Sans", 16)).pack(pady=20)
-        
+        tk.Label(
+            root,
+            text="🖥️ MODO PANTALLA COMPLETA",
+            fg="#00ff66",
+            bg="#000000",
+            font=("DejaVu Sans", 32, "bold"),
+        ).pack(pady=100)
+
+        tk.Label(
+            root,
+            text="Presiona ESC para salir",
+            fg="#ffffff",
+            bg="#000000",
+            font=("DejaVu Sans", 16),
+        ).pack(pady=20)
+
         # Bind para salir con Escape
-        root.bind('<Escape>', lambda e: root.destroy())
+        root.bind("<Escape>", lambda e: root.destroy())
         root.focus_set()
-        
+
         log.info("Modo fullscreen activado. Presiona ESC para salir…")
         root.after(10000, root.destroy)  # Auto-cerrar después de 10 segundos
         root.mainloop()
-        
+
         log.info("✅ Prueba fullscreen: EXITOSA")
         return True
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - errores dependen del entorno gráfico
         log.error(f"❌ Error en prueba fullscreen: {e}")
         return False
 
-def test_bascula_ui():
-    """Prueba de la UI completa de la báscula"""
+
+def test_fullscreen() -> None:
+    """Prueba de modo pantalla completa"""
+    _require_display()
+    assert _run_fullscreen()
+
+def _run_bascula_ui() -> bool:
+    """Ejecuta la prueba de la UI completa de la báscula y devuelve si fue exitosa."""
     log.info("=== PRUEBA UI COMPLETA DE BÁSCULA ===")
-    
+
     try:
         from bascula.ui.app import BasculaApp
-        
+
         log.info("Creando instancia de BasculaApp…")
         app = BasculaApp()
-        
+
         log.info("✅ BasculaApp creada exitosamente")
         log.info("Iniciando aplicación (se cerrará automáticamente en 15 segundos)…")
-        
+
         # Auto-cerrar después de 15 segundos para prueba
         app.root.after(15000, app.quit)
-        
+
         app.run()
-        
+
         log.info("✅ Prueba UI completa: EXITOSA")
         return True
-        
-    except Exception as e:
+
+    except Exception as e:  # pragma: no cover - errores dependen del entorno gráfico
         log.error(f"❌ Error en prueba UI completa: {e}", exc_info=True)
         return False
+
+
+def test_bascula_ui() -> None:
+    """Prueba de la UI completa de la báscula"""
+    _require_display()
+    assert _run_bascula_ui()
 
 def check_environment():
     """Verificar el entorno de ejecución"""
@@ -150,9 +192,9 @@ def main():
     
     # Ejecutar pruebas
     tests = [
-        ("Tkinter Básico", test_tkinter_basic),
-        ("Modo Fullscreen", test_fullscreen),
-        ("UI Completa Báscula", test_bascula_ui)
+        ("Tkinter Básico", _run_tkinter_basic),
+        ("Modo Fullscreen", _run_fullscreen),
+        ("UI Completa Báscula", _run_bascula_ui),
     ]
     
     results = []


### PR DESCRIPTION
## Summary
- refactor the Tkinter diagnostic tests to reuse helper runners and keep the CLI workflow intact
- add pytest-aware skips when DISPLAY is not available so the tests no longer fail headless
- ensure pytest uses assertions instead of boolean returns to eliminate warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd50401e188326a972d36f5e215dc0