### PR TITLE
Handle Tk initialization failure by switching to headless mode

### DIFF
--- a/tests/test_main_headless.py
+++ b/tests/test_main_headless.py
@@ -1,0 +1,25 @@
+import sys
+import types
+
+import bascula.main as entry
+
+
+class DummyHeadless:
+    def run(self):
+        return True
+
+
+def test_main_falls_back_to_headless(monkeypatch):
+    monkeypatch.setenv("DISPLAY", "")
+
+    def fake_tk():
+        raise entry.tk.TclError("no display")
+
+    monkeypatch.setattr(entry.tk, "Tk", fake_tk)
+
+    dummy_module = types.SimpleNamespace(HeadlessBascula=DummyHeadless)
+    monkeypatch.setitem(sys.modules, "bascula.services.headless_main", dummy_module)
+
+    result = entry.main()
+
+    assert result == 0


### PR DESCRIPTION
## Summary
- add a helper in the Tk entrypoint to launch the headless mode when Tk cannot start
- guard the Tk initialisation to trigger the headless fallback when `_tkinter` raises `TclError`
- add a regression test that simulates a missing display and verifies `main()` returns success via the headless mode

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd5ab8c8a483269eed5f9414c9eed9