### PR TITLE
Fix systemd unit verification glob

### DIFF
--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -43,8 +43,17 @@ fi
 
 log "Validando unidades systemd"
 if command -v systemd-analyze >/dev/null 2>&1; then
-  if ! systemd-analyze verify /etc/systemd/system/bascula-*.service; then
-    fail "systemd-analyze reportó errores"
+  shopt -s nullglob
+  units=(/etc/systemd/system/bascula-*.service)
+  shopt -u nullglob
+  if (( ${#units[@]} == 0 )); then
+    err "No se encontraron unidades systemd bascula-*.service para validar"
+  else
+    for unit in "${units[@]}"; do
+      if ! systemd-analyze verify "${unit}"; then
+        fail "systemd-analyze reportó errores en ${unit}"
+      fi
+    done
   fi
 else
   err "systemd-analyze no disponible; omitiendo verificación"


### PR DESCRIPTION
## Summary
- update scripts/verify-all.sh to iterate over matching systemd unit files
- log when no bascula-*.service units are present and report per-unit failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd6692e45c8326923c6f29f2a329b5