### PR TITLE
Harden ValueLabel usage and miniweb startup

### DIFF
--- a/bascula/ui/lightweight_widgets.py
+++ b/bascula/ui/lightweight_widgets.py
@@ -26,7 +26,12 @@ def _coerce_int(value: Any, fallback: int) -> int:
             raise TypeError
         return int(float(value))
     except (TypeError, ValueError):
-        return fallback
+        logger.warning("Coerce int fallback: value=%r -> using %r", value, fallback)
+        try:
+            return int(float(fallback))
+        except Exception:
+            logger.error("Fallback for int is invalid: %r; using 0", fallback)
+            return 0
 
 
 def _normalize_font(value: Any, fallback: tuple[str, int, str]) -> Tuple[Any, ...]:
@@ -282,6 +287,14 @@ class ValueLabel(tk.Label):
         font = _normalize_font(kwargs.pop("font", default_font), default_font)
         padx = _coerce_int(kwargs.pop("padx", CRT_SPACING.padding), CRT_SPACING.padding)
         pady = _coerce_int(kwargs.pop("pady", 8), 8)
+        if not isinstance(padx, int) or not isinstance(pady, int):
+            logger.error(
+                "Invalid padding types in ValueLabel: padx=%r (%s), pady=%r (%s)",
+                padx,
+                type(padx).__name__,
+                pady,
+                type(pady).__name__,
+            )
         super().__init__(
             parent,
             bg=_safe_color(kwargs.pop("bg", CRT_COLORS.get("surface"))),

--- a/bascula/ui/rpi_optimized_ui.py
+++ b/bascula/ui/rpi_optimized_ui.py
@@ -365,9 +365,8 @@ class SettingsScreen(BaseScreen):
         header = tk.Frame(self, bg=CRT_COLORS["bg"])
         header.grid(row=0, column=0, sticky="ew", padx=CRT_SPACING.gutter, pady=(CRT_SPACING.gutter, 8))
         header.columnconfigure(0, weight=1)
-        ValueLabel(header, text="Ajustes", size_key="lg", bg=CRT_COLORS["bg"], mono_font=False).grid(
-            row=0, column=0, sticky="w"
-        )
+        header_label = ValueLabel(header, text="Ajustes", size_key="lg", bg=CRT_COLORS["bg"], mono_font=False)
+        header_label.grid(row=0, column=0, sticky="w")
         CRTButton(
             header,
             icon="⌂",
@@ -592,7 +591,8 @@ class FavoritesScreen(BaseScreen):
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
 
-        ValueLabel(self, text="Favoritos", size_key="lg", bg=CRT_COLORS["bg"]).grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
+        favorites_title = ValueLabel(self, text="Favoritos", size_key="lg", bg=CRT_COLORS["bg"])
+        favorites_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
 
         self.list_card = Card(self, bg=CRT_COLORS["surface"])
         self.list_card.grid(row=1, column=0, sticky="nsew", padx=CRT_SPACING.gutter, pady=(0, CRT_SPACING.gutter))
@@ -682,7 +682,8 @@ class HistoryScreen(BaseScreen):
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
 
-        ValueLabel(self, text="Historial de Alimentos", size_key="lg", bg=CRT_COLORS["bg"]).grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
+        history_title = ValueLabel(self, text="Historial de Alimentos", size_key="lg", bg=CRT_COLORS["bg"])
+        history_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
         self.summary_label = tk.Label(
             self,
             text="",
@@ -758,7 +759,8 @@ class ScannerScreen(BaseScreen):
         self.columnconfigure(0, weight=1)
         self.rowconfigure(1, weight=1)
 
-        ValueLabel(self, text="Escáner", size_key="lg", bg=CRT_COLORS["bg"]).grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
+        scanner_title = ValueLabel(self, text="Escáner", size_key="lg", bg=CRT_COLORS["bg"])
+        scanner_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
 
         self.preview_card = Card(self, bg=CRT_COLORS["surface"])
         self.preview_card.grid(row=1, column=0, padx=CRT_SPACING.gutter, pady=(0, CRT_SPACING.padding), sticky="nsew")
@@ -865,7 +867,8 @@ class TimerScreen(BaseScreen):
         super().__init__(parent, app)
         self.columnconfigure(0, weight=1)
 
-        ValueLabel(self, text="Temporizador", size_key="lg", bg=CRT_COLORS["bg"]).grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
+        timer_title = ValueLabel(self, text="Temporizador", size_key="lg", bg=CRT_COLORS["bg"])
+        timer_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
 
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=1, column=0, padx=CRT_SPACING.gutter, pady=(0, CRT_SPACING.gutter), sticky="nsew")
@@ -905,7 +908,8 @@ class VoiceScreen(BaseScreen):
         super().__init__(parent, app)
         self.columnconfigure(0, weight=1)
 
-        ValueLabel(self, text="Asistente de voz", size_key="lg", bg=CRT_COLORS["bg"]).grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
+        voice_title = ValueLabel(self, text="Asistente de voz", size_key="lg", bg=CRT_COLORS["bg"])
+        voice_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
 
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=1, column=0, padx=CRT_SPACING.gutter, pady=(0, CRT_SPACING.gutter), sticky="nsew")
@@ -985,9 +989,8 @@ class DiabetesScreen(BaseScreen):
         self.columnconfigure(0, weight=1)
 
         title = "Diabetes" if mode == "diabetes" else "Nightscout"
-        ValueLabel(self, text=title, size_key="lg", mono_font=False, bg=CRT_COLORS["bg"]).pack(
-            pady=(CRT_SPACING.gutter, 4)
-        )
+        diabetes_title = ValueLabel(self, text=title, size_key="lg", mono_font=False, bg=CRT_COLORS["bg"])
+        diabetes_title.pack(pady=(CRT_SPACING.gutter, 4))
 
         card = Card(self, bg=CRT_COLORS["surface"])
         card.pack(fill="both", expand=True, padx=CRT_SPACING.gutter, pady=CRT_SPACING.gutter)
@@ -1087,9 +1090,8 @@ class MiniwebScreen(BaseScreen):
     def __init__(self, parent: tk.Widget, app: "RpiOptimizedApp") -> None:
         super().__init__(parent, app)
         self.columnconfigure(0, weight=1)
-        ValueLabel(self, text="Miniweb", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"]).grid(
-            row=0, column=0, pady=(CRT_SPACING.gutter, 4)
-        )
+        miniweb_title = ValueLabel(self, text="Miniweb", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"])
+        miniweb_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=1, column=0, sticky="nsew", padx=CRT_SPACING.gutter, pady=CRT_SPACING.gutter)
         card.columnconfigure(0, weight=1)
@@ -1112,9 +1114,8 @@ class OtaScreen(BaseScreen):
     def __init__(self, parent: tk.Widget, app: "RpiOptimizedApp") -> None:
         super().__init__(parent, app)
         self.columnconfigure(0, weight=1)
-        ValueLabel(self, text="Actualizaciones", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"]).grid(
-            row=0, column=0, pady=(CRT_SPACING.gutter, 4)
-        )
+        ota_title = ValueLabel(self, text="Actualizaciones", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"])
+        ota_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=1, column=0, sticky="nsew", padx=CRT_SPACING.gutter, pady=CRT_SPACING.gutter)
         card.columnconfigure(0, weight=1)
@@ -1163,9 +1164,8 @@ class InfoScreen(BaseScreen):
     def __init__(self, parent: tk.Widget, app: "RpiOptimizedApp") -> None:
         super().__init__(parent, app)
         self.columnconfigure(0, weight=1)
-        ValueLabel(self, text="Información", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"]).grid(
-            row=0, column=0, pady=(CRT_SPACING.gutter, 4)
-        )
+        info_title = ValueLabel(self, text="Información", size_key="lg", mono_font=False, bg=CRT_COLORS["bg"])
+        info_title.grid(row=0, column=0, pady=(CRT_SPACING.gutter, 4))
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=1, column=0, sticky="nsew", padx=CRT_SPACING.gutter, pady=CRT_SPACING.gutter)
         card.columnconfigure(0, weight=1)
@@ -1216,9 +1216,8 @@ class PlaceholderScreen(BaseScreen):
         card = Card(self, bg=CRT_COLORS["surface"])
         card.grid(row=0, column=0, padx=CRT_SPACING.gutter, pady=CRT_SPACING.gutter, sticky="nsew")
         card.columnconfigure(0, weight=1)
-        ValueLabel(card, text=title, size_key="lg", mono_font=False, bg=CRT_COLORS["surface"]).grid(
-            row=0, column=0, pady=(CRT_SPACING.padding, 8)
-        )
+        placeholder_title = ValueLabel(card, text=title, size_key="lg", mono_font=False, bg=CRT_COLORS["surface"])
+        placeholder_title.grid(row=0, column=0, pady=(CRT_SPACING.padding, 8))
         tk.Label(
             card,
             text=message,
@@ -1342,13 +1341,19 @@ class ScaleOverlay(tk.Frame):
         self.card.place(relx=0.5, rely=0.5, anchor="center")
         self.card.columnconfigure(0, weight=1)
 
-        ValueLabel(
+        logger.debug(
+            "ScaleOverlay header kwargs: fg=%r bg=%r",
+            CRT_COLORS["text"],
+            CRT_COLORS["surface"],
+        )
+        header_label = ValueLabel(
             self.card,
             text="Panel de báscula",
             size_key="lg",
             bg=CRT_COLORS["surface"],
             mono_font=True,
-        ).grid(row=0, column=0, pady=(CRT_SPACING.padding, 4))
+        )
+        header_label.grid(row=0, column=0, pady=(CRT_SPACING.padding, 4))
 
         self.hero = Card(self.card, bg=CRT_COLORS["surface"])
         self.hero.grid(row=1, column=0, padx=CRT_SPACING.padding, pady=(0, CRT_SPACING.padding), sticky="nsew")

--- a/bascula/ui/theme_crt.py
+++ b/bascula/ui/theme_crt.py
@@ -90,6 +90,11 @@ class Spacing:
 CRT_SPACING = Spacing()
 
 
+def _assert_theme_sanity():
+    assert isinstance(CRT_SPACING.padding, int)
+    assert isinstance(CRT_SPACING.gutter, int)
+
+
 def draw_dotted_rule(canvas, x0: int, y0: int, x1: int, *, color: str | None = None, size: int = 2, gap: int = 6) -> None:
     """Draw a dotted horizontal rule on a Tk canvas."""
 

--- a/scripts/run-miniweb.sh
+++ b/scripts/run-miniweb.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 ROOT="/home/pi/bascula-cam"
-VENV="$ROOT/.venv/bin/python"
 cd "$ROOT"
-PORT=8080
+PY="$ROOT/.venv/bin/python"
+PORT="${BASCULA_MINIWEB_PORT:-8080}"
 if ss -tulpen | grep -q ":$PORT "; then PORT=8078; fi
-exec "$VENV" -m uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port "$PORT"
+exec "$PY" -m uvicorn bascula.services.miniweb:app --host 0.0.0.0 --port "$PORT"

--- a/scripts/verify-all.sh
+++ b/scripts/verify-all.sh
@@ -15,9 +15,15 @@ fail() {
 }
 
 log "Comprobando elipsis prohibidas"
-if grep -R -n -E '^\s*\.\.\.\s*$' .; then
+if grep -R -n --exclude-dir=.git --exclude-dir=.venv -E '^\s*\.\.\.\s*$' .; then
   err "Se detectaron elipsis en el repositorio"
   exit 2
+fi
+
+log "Verificando fuentes Tk"
+if grep -R --line-number --exclude-dir=.git --exclude-dir=.venv -E 'font\s*=\s*"[^"]+"' bascula; then
+  echo "[err] font=\"...\" no permitido. Usa tuplas (fam, size[, weight])."
+  exit 3
 fi
 
 log "Compilando módulos Python"

--- a/tests/smoke_tk.py
+++ b/tests/smoke_tk.py
@@ -1,0 +1,13 @@
+from tkinter import Tk
+
+from bascula.ui.lightweight_widgets import ValueLabel
+from bascula.ui.theme_crt import CRT_SPACING, _assert_theme_sanity
+
+_assert_theme_sanity()
+
+root = Tk()
+root.withdraw()
+label = ValueLabel(root, text='X', padx=CRT_SPACING.padding, pady=CRT_SPACING.padding)
+label.destroy()
+root.destroy()
+print('TK_SMOKE_OK')


### PR DESCRIPTION
## Summary
- endurecer ValueLabel para registrar paddings inválidos y mejorar la coerción numérica
- desacoplar las construcciones de ValueLabel en la UI optimizada y añadir diagnóstico en el overlay de báscula
- añadir helper de sanidad del tema, smoke test de Tk y runner dinámico para miniweb

## Testing
- scripts/verify-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd757b99f88326b53481d065de0a9a