### PR TITLE
Add uvicorn dependency for miniweb service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask>=2.2
 requests>=2.31
 qrcode[pil]>=7.4
 fastapi>=0.110
+uvicorn[standard]>=0.29


### PR DESCRIPTION
## Summary
- include uvicorn[standard] in requirements so the mini web service can import it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd7eb14f70832681cb5ec53b5f8192