### PR TITLE
Include python_backend package in build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,12 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["bascula"]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+include = [
+    "bascula",
+    "bascula.*",
+    "python_backend",
+    "python_backend.*",
+]


### PR DESCRIPTION
## Summary
- ensure setuptools discovers both the bascula and python_backend packages so python_backend modules are included when the project is installed

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd9b5a17f48326b92e7868d33ef570