### PR TITLE
Include PyYAML dependency for UI smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "requests>=2.31",
     "qrcode[pil]>=7.4",
     "fastapi>=0.110",
+    "PyYAML>=6.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- add PyYAML to the project dependencies so the UI smoke navigation script can import yaml

## Testing
- ⚠️ `pip install -e .` *(fails: network proxy prevents downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9ca2d28883268ad2253b77371fab