### PR TITLE
Add smoke scoring tools and commit finder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ firmware-esp32/*.elf
 .idea/
 .vscode/
 
+# Local reports
+artifacts/
+
 # Auditorías
 audit/
 

--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ La aplicación inicia en pantalla de inicio con la mascota y botones principales
 ## Licencia
 
 Consulta el archivo `LICENSE` del repositorio original para los términos de uso.
+
+## Smokes automáticos y búsqueda del mejor commit
+
+Para evaluar commits con los smokes funcionales y localizar el que obtiene la mayor puntuación:
+
+```bash
+git fetch --all
+bash scripts/find_best_commit.sh "origin/main~150..origin/main"
+# Resultado:
+cat artifacts/best-commit.txt
+```
+
+El script genera `artifacts/scores.csv` con la puntuación de cada commit y conserva el último informe detallado en `artifacts/smoke.json`.

--- a/scripts/find_best_commit.sh
+++ b/scripts/find_best_commit.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+RANGE="${1:-origin/main~100..origin/main}"
+ARTIFACT_DIR="$ROOT_DIR/artifacts"
+mkdir -p "$ARTIFACT_DIR"
+
+if ORIG_REF=$(git symbolic-ref --quiet --short HEAD 2>/dev/null); then
+  ORIG_REF="$ORIG_REF"
+else
+  ORIG_REF=""
+fi
+ORIG_COMMIT="$(git rev-parse HEAD)"
+
+TMP_DIR="$(mktemp -d)"
+cp "$ROOT_DIR/scripts/run_smoke.sh" "$TMP_DIR/run_smoke.sh"
+cp "$ROOT_DIR/tools/smoke_score.py" "$TMP_DIR/smoke_score.py"
+chmod +x "$TMP_DIR/run_smoke.sh"
+
+STASHED=0
+if ! git diff --quiet --ignore-submodules --exit-code || ! git diff --cached --quiet --ignore-submodules --exit-code; then
+  git stash push -k -u -m "find-best-smoke" >/dev/null
+  STASHED=1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+cleanup() {
+  set +e
+  if [[ -n "$ORIG_REF" ]]; then
+    git checkout -f "$ORIG_REF" >/dev/null 2>&1
+  else
+    git checkout -f "$ORIG_COMMIT" >/dev/null 2>&1
+  fi
+  if [[ $STASHED -eq 1 ]]; then
+    git stash pop >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+SCORES_CSV="$ARTIFACT_DIR/scores.csv"
+echo "commit,score" >"$SCORES_CSV"
+
+BEST_SCORE=-1
+BEST_COMMIT=""
+
+mapfile -t COMMITS < <(git rev-list --first-parent --reverse "$RANGE")
+
+for COMMIT in "${COMMITS[@]}"; do
+  git checkout -f "$COMMIT" >/dev/null 2>&1
+
+  set +e
+  OUTPUT=$(cd "$ROOT_DIR" && SMOKE_RUNNER_OVERRIDE="$TMP_DIR/smoke_score.py" bash "$TMP_DIR/run_smoke.sh" 2>&1)
+  set -e
+
+  SCORE=$(echo "$OUTPUT" | awk -F '=' '/SCORE=/{print $2; exit}' | tr -d '\r')
+  if [[ -z "$SCORE" ]]; then
+    SCORE=0
+  fi
+
+  echo "$COMMIT,$SCORE" >>"$SCORES_CSV"
+
+  if [[ $SCORE -gt $BEST_SCORE ]]; then
+    BEST_SCORE=$SCORE
+    BEST_COMMIT=$COMMIT
+  fi
+
+  if [[ -n "$OUTPUT" ]]; then
+    echo "$OUTPUT" >&2
+  fi
+
+  if [[ $BEST_SCORE -ge 100 ]]; then
+    break
+  fi
+
+done
+
+if [[ -z "$BEST_COMMIT" ]]; then
+  BEST_COMMIT="$ORIG_COMMIT"
+fi
+
+echo "$BEST_COMMIT" >"$ARTIFACT_DIR/best-commit.txt"
+echo "Best commit: $BEST_COMMIT"

--- a/scripts/run_smoke.sh
+++ b/scripts/run_smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+ARTIFACT_DIR="$ROOT_DIR/artifacts"
+mkdir -p "$ARTIFACT_DIR"
+
+VENV_DIR="$ROOT_DIR/.venv"
+if [[ ! -d "$VENV_DIR" ]]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1090
+source "$VENV_DIR/bin/activate"
+
+DEPS_MARKER="$VENV_DIR/.smoke-deps"
+if [[ ! -f "$DEPS_MARKER" ]]; then
+  python -m pip install --upgrade pip --retries 1 --timeout 20 >&2 || true
+  python -m pip install --retries 1 --timeout 20 PyYAML Pillow fastapi uvicorn qrcode[pil] >&2 || true
+  touch "$DEPS_MARKER"
+fi
+
+SMOKE_SCRIPT="${SMOKE_RUNNER_OVERRIDE:-$ROOT_DIR/tools/smoke_score.py}"
+python "$SMOKE_SCRIPT" >"$ARTIFACT_DIR/smoke.json"
+
+SCORE=$(python -c 'import json,sys; print(json.load(sys.stdin)["score"])' <"$ARTIFACT_DIR/smoke.json")
+echo "SCORE=$SCORE"

--- a/tools/smoke_score.py
+++ b/tools/smoke_score.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Evaluate lightweight smoke tests and produce a JSON score."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import json
+import socket
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass
+class SmokeResult:
+    passed: bool
+    detail: Any
+    skipped: bool = False
+
+
+def _choose_port(candidates: List[int]) -> Optional[int]:
+    for port in candidates:
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+            try:
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+            return port
+    return None
+
+
+def _run_tk_smoke() -> Tuple[SmokeResult, SmokeResult, SmokeResult]:
+    skipped = False
+    try:
+        tk = importlib.import_module("tkinter")  # type: ignore
+    except Exception:
+        return (
+            SmokeResult(False, False, skipped=True),
+            SmokeResult(False, False, skipped=True),
+            SmokeResult(False, False, skipped=True),
+        )
+
+    root = None
+    try:
+        root = tk.Tk()
+        root.withdraw()
+    except Exception as exc:  # pragma: no cover - environment specific
+        if isinstance(exc, getattr(tk, "TclError", Exception)):
+            skipped = True
+        return (
+            SmokeResult(False, False, skipped=skipped),
+            SmokeResult(False, False, skipped=skipped),
+            SmokeResult(False, False, skipped=skipped),
+        )
+
+    tk_passed = True
+
+    value_label_passed = False
+    try:
+        module = importlib.import_module("bascula.ui.lightweight_widgets")
+        ValueLabel = getattr(module, "ValueLabel")
+        widget = ValueLabel(root, text="X", padx=8, pady=4)
+        root.update_idletasks()
+        widget.destroy()
+        value_label_passed = True
+    except Exception:
+        value_label_passed = False
+
+    mascot_passed = False
+    MascotCls = None
+    try:
+        mascot_module = importlib.import_module("bascula.ui.mascot")
+        MascotCls = getattr(mascot_module, "MascotCanvas", None)
+    except Exception:
+        MascotCls = None
+    if MascotCls is None:
+        try:
+            placeholder_module = importlib.import_module("bascula.ui.mascot_placeholder")
+            MascotCls = getattr(placeholder_module, "MascotPlaceholder", None)
+        except Exception:
+            MascotCls = None
+    if MascotCls is not None:
+        try:
+            widget = MascotCls(root, width=160, height=120)
+            root.update_idletasks()
+            widget.destroy()
+            mascot_passed = True
+        except Exception:
+            mascot_passed = False
+
+    if root is not None:
+        with contextlib.suppress(Exception):
+            root.destroy()
+
+    return (
+        SmokeResult(tk_passed, tk_passed),
+        SmokeResult(value_label_passed, value_label_passed, skipped=False if tk_passed else skipped),
+        SmokeResult(mascot_passed, mascot_passed, skipped=False if tk_passed else skipped),
+    )
+
+
+def _run_miniweb_smoke() -> SmokeResult:
+    detail: Dict[str, Any] = {"import": False, "health": False, "port": None}
+    try:
+        uvicorn = importlib.import_module("uvicorn")
+        miniweb = importlib.import_module("bascula.services.miniweb")
+        detail["import"] = True
+    except Exception as exc:
+        detail["error"] = repr(exc)
+        return SmokeResult(False, detail)
+
+    if getattr(uvicorn, "Server", None) is None:
+        detail["error"] = "uvicorn_missing"
+        return SmokeResult(False, detail)
+
+    port = _choose_port([8080, 8078])
+    if port is None:
+        detail["error"] = "no_port"
+        return SmokeResult(False, detail, skipped=True)
+
+    detail["port"] = port
+
+    class _DummyUI:
+        def get_status_snapshot(self) -> Dict[str, Any]:
+            return {"ok": True}
+
+        def get_settings_snapshot(self) -> Dict[str, Any]:
+            return {"ok": True}
+
+        def update_settings_from_dict(self, payload: Dict[str, Any]) -> Tuple[bool, str]:
+            return True, ""
+
+    service = None
+    try:
+        MiniWebService = getattr(miniweb, "MiniWebService")
+        service = MiniWebService(_DummyUI(), host="127.0.0.1", port=port)
+        started = service.start()
+        if not started:
+            detail["error"] = "start_failed"
+            return SmokeResult(False, detail)
+
+        deadline = time.monotonic() + 5.0
+        url = f"http://127.0.0.1:{port}/health"
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=0.8) as response:
+                    if response.status == 200:
+                        detail["health"] = True
+                        break
+            except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+                time.sleep(0.2)
+        passed = bool(detail["health"])
+        if not passed:
+            detail["error"] = "health_timeout"
+        return SmokeResult(passed, detail)
+    except Exception as exc:
+        detail["error"] = repr(exc)
+        return SmokeResult(False, detail)
+    finally:
+        if service is not None:
+            with contextlib.suppress(Exception):
+                service.stop()
+            time.sleep(0.2)
+
+
+def _run_yaml_smoke() -> SmokeResult:
+    try:
+        yaml = importlib.import_module("yaml")
+        yaml.safe_load(io.StringIO("{}"))
+        return SmokeResult(True, True)
+    except Exception as exc:
+        return SmokeResult(False, {"error": repr(exc)})
+
+
+def _run_scale_smoke() -> SmokeResult:
+    detail: Dict[str, Any] = {"ok": False, "weight": 0.0, "stable": False}
+    try:
+        module = importlib.import_module("bascula.core.scale")
+    except Exception as exc:
+        detail["error"] = repr(exc)
+        return SmokeResult(False, detail)
+
+    service = None
+    passed = False
+    try:
+        module.random.seed(0)
+        ScaleService = getattr(module, "ScaleService")
+        service = ScaleService(port="/tmp/bascula-sim")
+        deadline = time.monotonic() + 2.5
+        while time.monotonic() < deadline:
+            value = float(service.read_weight())
+            stable = bool(getattr(service, "stable", False))
+            detail["weight"] = value
+            detail["stable"] = stable
+            if value > 0.0 and stable:
+                passed = True
+                break
+            time.sleep(0.2)
+        detail["ok"] = passed
+        if not passed:
+            detail["error"] = "unstable"
+        return SmokeResult(passed, detail)
+    except Exception as exc:
+        detail["error"] = repr(exc)
+        return SmokeResult(False, detail)
+    finally:
+        if service is not None:
+            with contextlib.suppress(Exception):
+                service.shutdown()
+
+
+def main() -> None:
+    details: Dict[str, Any] = {}
+    skipped: set[str] = set()
+    score = 0
+
+    tk_result, valuelabel_result, mascot_result = _run_tk_smoke()
+    details["tk"] = bool(tk_result.detail)
+    details["valuelabel"] = bool(valuelabel_result.detail)
+    details["mascot"] = bool(mascot_result.detail)
+
+    if tk_result.skipped:
+        skipped.update({"tk", "valuelabel", "mascot"})
+    else:
+        if tk_result.passed:
+            score += 30
+        if valuelabel_result.passed:
+            score += 20
+        if mascot_result.passed:
+            score += 10
+
+    miniweb_result = _run_miniweb_smoke()
+    details["miniweb"] = miniweb_result.detail
+    if miniweb_result.skipped:
+        skipped.add("miniweb")
+    elif miniweb_result.passed and isinstance(miniweb_result.detail, dict) and miniweb_result.detail.get("health"):
+        score += 15
+
+    yaml_result = _run_yaml_smoke()
+    details["yaml"] = yaml_result.detail
+    if yaml_result.passed:
+        score += 15
+
+    scale_result = _run_scale_smoke()
+    details["scale_sim"] = scale_result.detail
+    if scale_result.passed:
+        score += 10
+
+    details["skipped"] = sorted(skipped)
+
+    payload = {"score": score, "details": details}
+    json.dump(payload, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python smoke runner that exercises the UI, miniweb service, YAML loading and scale simulator, emitting a JSON score
- provide bash helpers to run the smoke suite in a venv and walk a commit range to pick the best-scoring revision while preserving local changes
- document how to launch the search and ignore generated artifacts

## Testing
- scripts/run_smoke.sh
- bash scripts/find_best_commit.sh "HEAD~1..HEAD"

------
https://chatgpt.com/codex/tasks/task_e_68ce1c4b869083269237037535b36a38