### PR TITLE
Fix splash guard indentation during vision setup

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -679,7 +679,6 @@ class BasculaAppTk:
 
             # Inicializar IA de visión (opcional)
             try:
-                if self.splash:
                 if self.splash and self.root:
                     self.root.after(0, lambda: self.splash.set_status("Cargando IA de Visión..."))
                 model_path = "/opt/vision-lite/models/food_model.tflite"


### PR DESCRIPTION
## Summary
- remove stray splash check to restore valid indentation during vision service initialization

## Testing
- python -m py_compile bascula/ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68ce2f8900c883268a2fd9e91ebcc1b0