### PR TITLE
Expose mini-web on LAN and improve Wi-Fi setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ El comando muestra lecturas parseadas en gramos, indica si el modo es simulació
 - Verificar que existe `/etc/udev/rules.d/90-bascula.rules` con permisos `0660` para los puertos `ttyAMA0`, `ttyS0` y dispositivos USB CDC.
 - Asegurarse de que el fichero `/boot/firmware/cmdline.txt` (o `/boot/cmdline.txt`) no contiene `console=serial0,115200` y que en `config.txt` está definido `enable_uart=1`.
 - En adaptadores USB-serial basados en PL2303/CH340 puede ser necesario instalar el paquete `python3-serial` (ya incluido en `requirements.txt`).
+
+### Acceso mini-web
+
+- En la AP Bascula_AP: http://10.42.0.1:8078/
+- En la LAN: http://<IP-de-la-Pi>:8078/
+- Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_MINIWEB_HOST`/`BASCULA_MINIWEB_PORT`.

--- a/bascula/services/wifi_config.py
+++ b/bascula/services/wifi_config.py
@@ -11,8 +11,8 @@ from flask import Flask, request, redirect, render_template_string, session, jso
 # Antes: `from utils import ...` podía fallar al ejecutarse como módulo (-m)
 from bascula.utils import load_config, save_config
 
-APP_PORT = int(os.environ.get("BASCULA_WEB_PORT", "8080"))
-APP_HOST = os.environ.get("BASCULA_WEB_HOST", "127.0.0.1")
+APP_HOST = os.environ.get("BASCULA_MINIWEB_HOST") or os.environ.get("BASCULA_WEB_HOST", "127.0.0.1")
+APP_PORT = int(os.environ.get("BASCULA_MINIWEB_PORT", os.environ.get("BASCULA_WEB_PORT", "8078")))
 _CFG_ENV = os.environ.get("BASCULA_CFG_DIR", "").strip()
 CFG_DIR = Path(_CFG_ENV) if _CFG_ENV else (Path.home() / ".config" / "bascula")
 CFG_DIR.mkdir(parents=True, exist_ok=True)
@@ -431,6 +431,12 @@ def nightscout_test():
             return jsonify({"ok": False, "error": f"http_{r.status_code}"}), 502
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"ok": True})
+
 
 if __name__ == "__main__":
     app.run(host=APP_HOST, port=APP_PORT, debug=False)

--- a/polkit/50-bascula-nm.rules
+++ b/polkit/50-bascula-nm.rules
@@ -1,8 +1,16 @@
 polkit.addRule(function(action, subject) {
-  if (subject.user == "bascula" || subject.isInGroup("bascula")) {
-    if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" ||
-        action.id == "org.freedesktop.NetworkManager.network-control") {
-      return polkit.Result.YES;
-    }
+  function allowed() {
+    return subject.user == "pi" ||
+           subject.isInGroup("pi") ||
+           subject.user == "bascula" ||
+           subject.isInGroup("bascula");
+  }
+  if (!allowed()) return polkit.Result.NOT_HANDLED;
+
+  const id = action.id;
+  if (id == "org.freedesktop.NetworkManager.settings.modify.system" ||
+      id == "org.freedesktop.NetworkManager.network-control" ||
+      id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
+    return polkit.Result.YES;
   }
 });

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -39,7 +39,10 @@ fi
 unset _len AP_PASS_RAW
 
 TARGET_USER="${TARGET_USER:-${SUDO_USER:-pi}}"
-TARGET_GROUP="$(id -gn "$TARGET_USER")"
+TARGET_GROUP="${TARGET_GROUP:-${TARGET_USER}}"
+if ! getent group "${TARGET_GROUP}" >/dev/null 2>&1; then
+  TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || echo "${TARGET_USER}")"
+fi
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 
 BASCULA_ROOT="/opt/bascula"
@@ -198,12 +201,19 @@ EOF
 install -d -m 0755 /etc/polkit-1/rules.d
 cat > /etc/polkit-1/rules.d/50-bascula-nm.rules <<EOF
 polkit.addRule(function(action, subject) {
-  if (subject.user == "${TARGET_USER}" || subject.isInGroup("${TARGET_GROUP}")) {
-    if (action.id == "org.freedesktop.NetworkManager.settings.modify.system" ||
-        action.id == "org.freedesktop.NetworkManager.network-control" ||
-        action.id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
-      return polkit.Result.YES;
-    }
+  function allowed() {
+    return subject.user == "${TARGET_USER}" ||
+           subject.isInGroup("${TARGET_GROUP}") ||
+           subject.user == "bascula" ||
+           subject.isInGroup("bascula");
+  }
+  if (!allowed()) return polkit.Result.NOT_HANDLED;
+
+  const id = action.id;
+  if (id == "org.freedesktop.NetworkManager.settings.modify.system" ||
+      id == "org.freedesktop.NetworkManager.network-control" ||
+      id == "org.freedesktop.NetworkManager.enable-disable-wifi") {
+    return polkit.Result.YES;
   }
 });
 EOF
@@ -914,23 +924,16 @@ EOF
   log "Dispatcher installed (default)."
 fi
 
-set +e
-nmcli connection show "${AP_NAME}" >/dev/null 2>&1
-EXISTS=$?
-set -e
-if [[ ${EXISTS} -ne 0 ]]; then
+if ! nmcli -t -f NAME connection show | grep -qx "${AP_NAME}"; then
   log "Creating AP connection ${AP_NAME} (SSID=${AP_SSID}) on ${AP_IFACE}"
-  nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" autoconnect no ssid "${AP_SSID}" || true
-else
-  log "Updating existing AP connection ${AP_NAME}"
-  nmcli connection modify "${AP_NAME}" 802-11-wireless.ssid "${AP_SSID}" || true
 fi
+nmcli -t -f NAME connection show | grep -qx "${AP_NAME}" || \
+  nmcli connection add type wifi ifname "${AP_IFACE}" con-name "${AP_NAME}" ssid "${AP_SSID}" || true
+
 nmcli connection modify "${AP_NAME}" \
   802-11-wireless.mode ap \
   802-11-wireless.band bg \
   802-11-wireless.channel 6 \
-  ipv4.method shared \
-  ipv6.method ignore \
   802-11-wireless-security.key-mgmt wpa-psk \
   802-11-wireless-security.proto rsn \
   802-11-wireless-security.group ccmp \
@@ -938,9 +941,13 @@ nmcli connection modify "${AP_NAME}" \
   802-11-wireless-security.auth-alg open \
   802-11-wireless-security.psk "${AP_PASS}" \
   802-11-wireless-security.psk-flags 0 \
-  connection.autoconnect no || true
+  ipv4.method shared \
+  ipv6.method ignore \
+  connection.autoconnect yes || true
 nmcli radio wifi on >/dev/null 2>&1 || true
 rfkill unblock wifi 2>/dev/null || true
+
+nmcli connection up "${AP_NAME}" ifname "${AP_IFACE}" || nmcli connection up "${AP_NAME}" || true
 
 # --- Mini-web service ---
 cat > /etc/systemd/system/bascula-web.service <<EOF
@@ -956,13 +963,36 @@ Group=${TARGET_GROUP}
 WorkingDirectory=${BASCULA_CURRENT_LINK}
 Environment=HOME=${TARGET_HOME}
 Environment=XDG_CONFIG_HOME=${TARGET_HOME}/.config
-Environment=PYTHONPATH=/usr/lib/python3/dist-packages
-Environment=BASCULA_WEB_HOST=0.0.0.0
-Environment=BASCULA_WEB_PORT=8080
+Environment=PYTHONPATH=${BASCULA_CURRENT_LINK}
+Environment=BASCULA_MINIWEB_HOST=0.0.0.0
+Environment=BASCULA_MINIWEB_PORT=8078
 Environment=BASCULA_CFG_DIR=${TARGET_HOME}/.config/bascula
 ExecStart=${BASCULA_CURRENT_LINK}/.venv/bin/python -m bascula.services.wifi_config
 Restart=on-failure
 RestartSec=2
+
+# Hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=${TARGET_HOME}/.config ${TARGET_HOME}/.config/bascula
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+PrivateDevices=yes
+RestrictAddressFamilies=AF_UNIX AF_INET
+IPAddressDeny=
+IPAddressAllow=127.0.0.1
+IPAddressAllow=10.42.0.0/24      # subred AP (NetworkManager "shared")
+IPAddressAllow=192.168.0.0/16    # LAN clásica
+IPAddressAllow=172.16.0.0/12     # LAN privadas
+LockPersonality=yes
+RemoveIPC=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/verify-miniweb-open.sh
+++ b/scripts/verify-miniweb-open.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PORT="${1:-8078}"
+IP="$(hostname -I | awk '{print $1}')"
+echo "[info] Probing http://127.0.0.1:${PORT}/health"
+curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null && echo "OK local"
+
+echo "[info] Probing http://${IP}:${PORT}/health (LAN/AP)"
+curl -fsS "http://${IP}:${PORT}/health" >/dev/null && echo "OK LAN/AP"
+
+echo "[info] Listening sockets"
+ss -tulpen | grep -E "(:${PORT})\\b" || true

--- a/scripts/verify-wifi-perms.sh
+++ b/scripts/verify-wifi-perms.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+USER_CHECK="${1:-pi}"
+echo "[polkit] NM modify perms:"
+pkaction --action-id org.freedesktop.NetworkManager.settings.modify.system | sed -n '1,6p' || true
+echo "[nmcli] test add/delete:"
+set +e
+sudo -u "${USER_CHECK}" nmcli connection add type wifi con-name bascula-test ssid BasculaTest 2>/dev/null
+sudo -u "${USER_CHECK}" nmcli connection delete bascula-test 2>/dev/null
+set -e
+echo "OK"

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -5,13 +5,14 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=bascula
-Group=bascula
-WorkingDirectory=%h/bascula-cam
-Environment=BASCULA_WEB_HOST=127.0.0.1
-Environment=BASCULA_WEB_PORT=8080
-Environment=BASCULA_CFG_DIR=%h/.config/bascula
-ExecStart=/usr/bin/python3 -m bascula.services.wifi_config
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/bascula-cam
+Environment=PYTHONPATH=/home/pi/bascula-cam
+Environment=BASCULA_MINIWEB_HOST=0.0.0.0
+Environment=BASCULA_MINIWEB_PORT=8078
+Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
+ExecStart=/home/pi/bascula-cam/.venv/bin/python -m bascula.services.wifi_config
 Restart=on-failure
 RestartSec=2
 
@@ -26,8 +27,11 @@ ProtectKernelModules=yes
 ProtectControlGroups=yes
 PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET
+IPAddressDeny=
 IPAddressAllow=127.0.0.1
-IPAddressDeny=any
+IPAddressAllow=10.42.0.0/24      # subred AP (NetworkManager "shared")
+IPAddressAllow=192.168.0.0/16    # LAN clásica
+IPAddressAllow=172.16.0.0/12     # LAN privadas
 LockPersonality=yes
 RemoveIPC=yes
 RestrictNamespaces=yes


### PR DESCRIPTION
## Summary
- update the mini-web systemd unit and installer templates to run under the pi user, bind to 0.0.0.0:8078, and allow trusted private subnets while preserving sandboxing
- teach the Flask mini-web to read BASCULA_MINIWEB_* overrides, expose a /health endpoint, and document access along with new verification scripts
- harden the installer by creating resilient WPA2 AP profiles and extending polkit rules so pi/bascula users can control NetworkManager

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*
- pip install pyyaml *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3b7a802c8326b2538c7a6277313e