### PR TITLE
Add recipe overlay access and OpenAI recipe service

### DIFF
--- a/tools/test_ai.py
+++ b/tools/test_ai.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+from bascula.services.recipes import generate_recipe
+
+
+def main():
+    prompt = "ensalada de pollo 2 raciones" if len(sys.argv) < 2 else " ".join(sys.argv[1:])
+    servings = 2
+    data = generate_recipe(prompt, servings)
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a "Recetas" shortcut to the Home footer and simplify the overlay launcher
- implement the recipe generation service with OpenAI JSON parsing and a deterministic fallback
- update the recipe overlay mascot feedback and expose a CLI helper to test recipe generation

## Testing
- PYTHONPATH=. python tools/test_ai.py "pasta con verduras 3 raciones"


------
https://chatgpt.com/codex/tasks/task_e_68ce446a26948326b66e75b1b9939d42