### PR TITLE
Normalize recipe step handling to dict format

### DIFF
--- a/tests/test_recipes_steps.py
+++ b/tests/test_recipes_steps.py
@@ -1,0 +1,30 @@
+from bascula.services import recipes as recipe_service
+
+
+def test_coerce_steps_mixed_entries():
+    raw_steps = [
+        "Cortar",
+        {"text": "Saltear", "timer": 60},
+        {"step": "Servir"},
+    ]
+    result = recipe_service._coerce_steps(raw_steps)
+    assert result == [
+        {"text": "Cortar"},
+        {"text": "Saltear", "timer_s": 60},
+        {"text": "Servir"},
+    ]
+
+
+def test_sanitize_recipe_fallback_steps():
+    sanitized = recipe_service._sanitize_recipe({"steps": None, "ingredients": []}, 2)
+    assert sanitized["steps"] == [
+        {"text": "Prepara los ingredientes."},
+        {"text": "Mezcla/cocina y sirve."},
+    ]
+
+
+def test_coerce_steps_timer_string():
+    result = recipe_service._coerce_steps([
+        {"text": "Hornear", "timer": "90s"},
+    ])
+    assert result == [{"text": "Hornear", "timer_s": 90}]

--- a/tools/migrate_recipes.py
+++ b/tools/migrate_recipes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Utility to migrate stored recipes steps to dict format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, List
+
+from bascula.domain import recipes as domain_recipes
+
+
+def _convert_steps(raw_steps: Any) -> tuple[List[dict], bool]:
+    if not isinstance(raw_steps, list):
+        return [], False
+    changed = False
+    converted: List[dict] = []
+    for item in raw_steps:
+        if isinstance(item, dict):
+            converted.append(item)
+            continue
+        text = str(item or "").strip()
+        if not text:
+            continue
+        converted.append({"text": text})
+        changed = True
+    return converted, changed
+
+
+def migrate_file(path: Path, dry_run: bool = False) -> int:
+    if not path.exists():
+        print(f"No se encontró archivo de recetas en {path}.")
+        return 0
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    updated: List[str] = []
+    migrated_count = 0
+
+    for ln in lines:
+        if not ln.strip():
+            continue
+        try:
+            obj = json.loads(ln)
+        except Exception:
+            updated.append(ln)
+            continue
+        steps, changed = _convert_steps(obj.get("steps"))
+        if changed:
+            obj["steps"] = steps
+            migrated_count += 1
+        updated.append(json.dumps(obj, ensure_ascii=False))
+
+    if migrated_count and not dry_run:
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        backup = path.with_suffix(path.suffix + f".bak{timestamp}")
+        shutil.copy2(path, backup)
+        path.write_text("\n".join(updated) + ("\n" if updated else ""), encoding="utf-8")
+        print(f"Migradas {migrated_count} recetas. Copia de seguridad: {backup}")
+    elif migrated_count:
+        print(f"Se migrarían {migrated_count} recetas (dry-run).")
+    else:
+        print("No se requirió migración.")
+    return migrated_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrar pasos de recetas a formato dict.")
+    parser.add_argument("--dry-run", action="store_true", help="Mostrar cambios sin escribir archivo")
+    args = parser.parse_args()
+    migrate_file(domain_recipes.RECIPES_FILE, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_ai.py
+++ b/tools/test_ai.py
@@ -9,6 +9,10 @@ def main():
     prompt = "ensalada de pollo 2 raciones" if len(sys.argv) < 2 else " ".join(sys.argv[1:])
     servings = 2
     data = generate_recipe(prompt, servings)
+    steps = data.get("steps") or []
+    if not all(isinstance(st, dict) and "text" in st for st in steps):
+        print("ERROR: steps deben ser dicts con texto", file=sys.stderr)
+        sys.exit(1)
     print(json.dumps(data, ensure_ascii=False, indent=2))
 
 


### PR DESCRIPTION
## Summary
- normalize recipe sanitization so steps become dict entries with coerced timer fields and safe defaults
- harden domain persistence and UI rendering to accept legacy string steps and provide a migration helper
- add regression coverage for step coercion and ensure AI recipe tester validates dict-shaped steps

## Testing
- pytest tests/test_recipes_steps.py
- scripts/verify-all.sh


------
https://chatgpt.com/codex/tasks/task_e_68ce47939d70832690a77d11a193ff9d