### PR TITLE
Configure NetworkManager AP setup

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -1,9 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Forward TARGET_USER if provided, else let install-all.sh default to SUDO_USER or pi
-if [[ -n "${TARGET_USER:-}" ]]; then
-  exec sudo PHASE=1 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
-else
-  exec sudo PHASE=1 bash "${SCRIPT_DIR}/install-all.sh" "$@"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_USER="${TARGET_USER:-pi}"
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  exec sudo TARGET_USER="${TARGET_USER}" bash "$0" "$@"
 fi
+
+TARGET_USER="${TARGET_USER:-${SUDO_USER:-pi}}"
+
+# Asegura NetworkManager
+sudo apt-get update -y
+sudo apt-get install -y network-manager
+sudo systemctl enable NetworkManager
+sudo systemctl restart NetworkManager
+
+# Polkit para permitir shared/system changes al grupo netdev
+if [[ -f "${ROOT_DIR}/scripts/polkit/10-nm-shared.pkla" ]]; then
+  sudo install -m 0644 -o root -g root "${ROOT_DIR}/scripts/polkit/10-nm-shared.pkla" \
+    /etc/polkit-1/localauthority/50-local.d/10-nm-shared.pkla
+  sudo usermod -aG netdev "${TARGET_USER}"
+fi
+
+# Resto de instalación principal
+PHASE=1 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
+
+# Configura y levanta AP con NM (idempotente)
+bash "${ROOT_DIR}/scripts/setup_ap_nm.sh"
+
+# Verificación resumida
+nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev || true
+ip -4 -o addr show | sed -n '1,200p' || true
+echo "[install-1-system] OK"

--- a/scripts/polkit/10-nm-shared.pkla
+++ b/scripts/polkit/10-nm-shared.pkla
@@ -1,0 +1,6 @@
+[Allow NetworkManager shared & system changes for netdev]
+Identity=unix-group:netdev
+Action=org.freedesktop.NetworkManager.settings.modify.system;org.freedesktop.NetworkManager.network-control
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes

--- a/scripts/setup_ap_nm.sh
+++ b/scripts/setup_ap_nm.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detecta interfaz Wi-Fi gestionada por NetworkManager (primera)
+WIFI_IF="${WIFI_IF:-$(nmcli -t -f DEVICE,TYPE dev | awk -F: '$2=="wifi"{print $1;exit}')}"
+
+if [[ -z "${WIFI_IF}" ]]; then
+  echo "[setup_ap_nm] ERROR: no se detectó interfaz Wi-Fi gestionada por NetworkManager" >&2
+  exit 1
+fi
+
+SSID="${SSID:-Bascula_AP}"
+PSK="${PSK:-bascula1234}"
+AP_CON="${AP_CON:-BasculaAP}"
+AP_ADDR="${AP_ADDR:-10.42.0.1/24}"
+AP_CHANNEL="${AP_CHANNEL:-6}"
+COUNTRY="${WIFI_COUNTRY:-ES}"
+
+echo "[setup_ap_nm] Wi-Fi IF=${WIFI_IF} SSID=${SSID} CON=${AP_CON}"
+
+# 1) País Wi-Fi / regulatory domain
+if command -v raspi-config >/dev/null 2>&1; then
+  sudo raspi-config nonint do_wifi_country "${COUNTRY}" || true
+fi
+sudo iw reg set "${COUNTRY}" || true
+
+# 2) AP soportada
+if command -v iw >/dev/null 2>&1; then
+  if ! iw list | awk '/Supported interface modes/{flag=1;next}/^$/{flag=0}flag' | grep -q '\bAP\b'; then
+    echo "[setup_ap_nm] ADVERTENCIA: el driver no reporta modo AP; se intenta igualmente." >&2
+  fi
+fi
+
+# 3) Evita conflictos con servicios externos
+sudo systemctl stop hostapd dnsmasq 2>/dev/null || true
+
+# 4) Crea o normaliza la conexión AP
+if nmcli -t -f NAME con show | grep -Fxq "${AP_CON}"; then
+  sudo nmcli con mod "${AP_CON}" connection.interface-name "${WIFI_IF}" || true
+else
+  sudo nmcli con add type wifi ifname "${WIFI_IF}" con-name "${AP_CON}" ssid "${SSID}"
+fi
+
+# Parámetros AP + WPA2/AES
+sudo nmcli con mod "${AP_CON}" \
+  802-11-wireless.mode ap \
+  802-11-wireless.band bg \
+  802-11-wireless.channel "${AP_CHANNEL}" \
+  wifi-sec.key-mgmt wpa-psk \
+  wifi-sec.psk "${PSK}" \
+  802-11-wireless-security.proto rsn \
+  802-11-wireless-security.group ccmp \
+  802-11-wireless-security.pairwise ccmp
+
+# NAT + DHCP embebido de NM
+sudo nmcli con mod "${AP_CON}" \
+  ipv4.method shared \
+  ipv4.addresses "${AP_ADDR}" \
+  ipv6.method ignore \
+  connection.autoconnect yes \
+  connection.autoconnect-priority 100
+
+# 5) Desactiva Wi-Fi cliente por defecto que compite (si existe)
+if nmcli -t -f NAME,TYPE con show | awk -F: '$2=="wifi"{print $1}' | grep -Fxq "preconfigured"; then
+  sudo nmcli con mod preconfigured connection.autoconnect no || true
+fi
+
+# 6) Levanta la AP
+sudo nmcli radio wifi on
+sudo rfkill unblock wifi 2>/dev/null || true
+sudo ip link set "${WIFI_IF}" up || true
+sudo nmcli con up "${AP_CON}" ifname "${WIFI_IF}"
+
+# 7) Verificación rápida
+sleep 1
+IFADDR=$(ip -4 -o addr show dev "${WIFI_IF}" | awk '{print $4}' | head -n1 || true)
+echo "[setup_ap_nm] ${WIFI_IF} addr=${IFADDR}"
+if [[ "${IFADDR}" != 10.42.0.1/24 ]]; then
+  echo "[setup_ap_nm] ADVERTENCIA: no se ve 10.42.0.1/24 aún (IF=${WIFI_IF}); revisar NetworkManager logs." >&2
+fi
+
+echo "[setup_ap_nm] OK"

--- a/scripts/verify-ap.sh
+++ b/scripts/verify-ap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+AP_CON="${AP_CON:-BasculaAP}"
+nmcli -t -f NAME con show | grep -Fxq "${AP_CON}" || { echo "[verify-ap] Falta conexión ${AP_CON}"; exit 2; }
+nmcli -t -f all con show "${AP_CON}" | grep -q '^ipv4.method:.*shared' || { echo "[verify-ap] Falta ipv4.method=shared"; exit 2; }
+nmcli -t -f all con show "${AP_CON}" | grep -q '^wifi-sec.key-mgmt:.*wpa-psk' || { echo "[verify-ap] Falta wpa-psk"; exit 2; }
+echo "[verify-ap] OK"


### PR DESCRIPTION
## Summary
- ensure `install-1-system.sh` installs/enables NetworkManager, deploys the polkit policy, and runs the AP setup with verification
- add `setup_ap_nm.sh` to configure the Bascula_AP hotspot with shared IPv4, WPA2 PSK, and regulatory domain handling
- ship a polkit policy and `verify-ap.sh` helper for checking the NetworkManager profile

## Testing
- not run (requires NetworkManager hardware environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce56ea16f083269b1634568c9af314