### PR TITLE
Fix TARGET_USER default handling in installer

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-TARGET_USER="${TARGET_USER:-pi}"
-
 if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  TARGET_USER="${TARGET_USER:-$(id -un)}"
   exec sudo TARGET_USER="${TARGET_USER}" bash "$0" "$@"
 fi
 


### PR DESCRIPTION
## Summary
- ensure install-1-system.sh defaults TARGET_USER to the invoking user before re-execing with sudo
- preserve existing fallback to SUDO_USER when running as root

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce588069588326a3244ff5f8be98b5