### PR TITLE
Gate bascula services on readiness flags

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -26,6 +26,13 @@ fi
 # Resto de instalación principal
 PHASE=1 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
 
+# Despliega units pero sin habilitarlos todavía
+echo "[install-1-system] Installing gated systemd units (bascula-web/app)"
+sudo systemctl disable --now bascula-web bascula-miniweb bascula-app 2>/dev/null || true
+sudo install -m 0644 "${ROOT_DIR}/systemd/bascula-web.service" /etc/systemd/system/
+sudo install -m 0644 "${ROOT_DIR}/systemd/bascula-app.service" /etc/systemd/system/
+sudo systemctl daemon-reload
+
 # Configura y levanta AP con NM (idempotente)
 bash "${ROOT_DIR}/scripts/setup_ap_nm.sh"
 

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -1,9 +1,61 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# Forward TARGET_USER if provided, else let install-all.sh default to SUDO_USER or pi
-if [[ -n "${TARGET_USER:-}" ]]; then
-  exec sudo PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
-else
-  exec sudo PHASE=2 bash "${SCRIPT_DIR}/install-all.sh" "$@"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  TARGET_USER="${TARGET_USER:-${SUDO_USER:-pi}}"
+  exec sudo TARGET_USER="${TARGET_USER}" bash "$0" "$@"
 fi
+
+TARGET_USER="${TARGET_USER:-${SUDO_USER:-pi}}"
+
+# Ejecuta la fase 2 principal (instalación de dependencias y app)
+PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
+
+# Asegura los unit files actualizados antes de arrancar
+install -m 0644 "${ROOT_DIR}/systemd/bascula-web.service" /etc/systemd/system/
+install -m 0644 "${ROOT_DIR}/systemd/bascula-app.service" /etc/systemd/system/
+systemctl daemon-reload
+
+# Prepara entorno de configuración y flags de readiness
+install -d -m 0755 /etc/bascula
+DEFAULT_FILE="/etc/default/bascula-web"
+if [[ ! -f "${DEFAULT_FILE}" ]]; then
+  {
+    echo 'BASCULA_WEB_HOST=0.0.0.0'
+    echo 'BASCULA_WEB_PORT=8078'
+  } > "${DEFAULT_FILE}"
+else
+  if ! grep -q '^BASCULA_WEB_HOST=' "${DEFAULT_FILE}"; then
+    echo 'BASCULA_WEB_HOST=0.0.0.0' >> "${DEFAULT_FILE}"
+  fi
+  if ! grep -q '^BASCULA_WEB_PORT=' "${DEFAULT_FILE}"; then
+    echo 'BASCULA_WEB_PORT=8078' >> "${DEFAULT_FILE}"
+  fi
+fi
+install -D -m 0644 /dev/null /etc/bascula/WEB_READY
+install -D -m 0644 /dev/null /etc/bascula/APP_READY
+
+# Asegura que los servicios estén parados antes de validar el puerto
+systemctl stop bascula-web bascula-app 2>/dev/null || true
+
+# Determina el puerto configurado y verifica disponibilidad
+BASCULA_WEB_PORT=8078
+if [[ -f "${DEFAULT_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${DEFAULT_FILE}"
+fi
+PORT_CHECK="${BASCULA_WEB_PORT:-8078}"
+if ss -ltn | awk -v port=":${PORT_CHECK}$" 'NR>1 && $4 ~ port {exit 0} END {exit 1}'; then
+  echo "[install-2] ERROR: puerto ${PORT_CHECK} en uso. Libera o ajusta BASCULA_WEB_PORT en /etc/default/bascula-web" >&2
+  exit 1
+fi
+
+# Habilita y arranca los servicios ya con flags creados
+systemctl enable bascula-web bascula-app
+systemctl restart bascula-web
+systemctl restart bascula-app
+
+echo "[install-2-app] Servicios bascula-web y bascula-app activos"

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Bascula Digital Pro Main Application (X on tty1)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bascula/APP_READY
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/opt/bascula/current
+Environment=PYTHONPATH=/usr/lib/python3/dist-packages
+RuntimeDirectory=bascula
+RuntimeDirectoryMode=0755
+Environment=BASCULA_RUNTIME_DIR=/run/bascula
+ExecStart=/usr/bin/xinit /usr/local/bin/bascula-xsession -- :0 vt1 -nolisten tcp
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -2,6 +2,7 @@
 Description=Bascula Mini-Web (Wi-Fi/APIs) on localhost
 After=network-online.target
 Wants=network-online.target
+ConditionPathExists=/etc/bascula/WEB_READY
 
 [Service]
 Type=simple
@@ -9,10 +10,9 @@ User=pi
 Group=pi
 WorkingDirectory=/home/pi/bascula-cam
 Environment=PYTHONPATH=/home/pi/bascula-cam
-Environment=BASCULA_MINIWEB_HOST=0.0.0.0
-Environment=BASCULA_MINIWEB_PORT=8078
 Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
-ExecStart=/home/pi/bascula-cam/.venv/bin/python -m bascula.services.wifi_config
+EnvironmentFile=-/etc/default/bascula-web
+ExecStart=/usr/bin/env bash -lc '/home/pi/bascula-cam/.venv/bin/python -m uvicorn bascula.services.miniweb:app --host ${BASCULA_WEB_HOST:-0.0.0.0} --port ${BASCULA_WEB_PORT:-8078}'
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- add readiness gating and environment file support to the bascula web/app systemd units
- deploy the units without enabling them during phase 1 of the installer
- configure defaults, readiness flags, port validation, and activation during phase 2

## Testing
- shellcheck scripts/install-1-system.sh scripts/install-2-app.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce826f0834832681b013ce57f9c995