### PR TITLE
Update bascula services to use OTA environment

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -64,7 +64,34 @@ nm_up_ap() {
 PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
 
 install -d -m 0755 /etc/bascula
-install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.env" /etc/default/bascula-web
+{
+  BASCULA_USER=pi
+  BASCULA_GROUP=pi
+  BASCULA_PREFIX=/opt/bascula/current
+  BASCULA_VENV=/opt/bascula/current/venv
+  BASCULA_CFG_DIR=/home/pi/.config/bascula
+  BASCULA_RUNTIME_DIR=/run/bascula
+  BASCULA_WEB_HOST=0.0.0.0
+  BASCULA_WEB_PORT=8078
+
+  # Fallback dev (no OTA instalado)
+  if [[ ! -x "${BASCULA_VENV}/bin/python" && -x "/home/pi/bascula-cam/.venv/bin/python" ]]; then
+    echo "[inst] OTA venv no encontrado; usando fallback de desarrollo"
+    BASCULA_PREFIX=/home/pi/bascula-cam
+    BASCULA_VENV=/home/pi/bascula-cam/.venv
+  fi
+
+  cat <<EOF
+BASCULA_USER=${BASCULA_USER}
+BASCULA_GROUP=${BASCULA_GROUP}
+BASCULA_PREFIX=${BASCULA_PREFIX}
+BASCULA_VENV=${BASCULA_VENV}
+BASCULA_CFG_DIR=${BASCULA_CFG_DIR}
+BASCULA_RUNTIME_DIR=${BASCULA_RUNTIME_DIR}
+BASCULA_WEB_HOST=${BASCULA_WEB_HOST}
+BASCULA_WEB_PORT=${BASCULA_WEB_PORT}
+EOF
+} | tee /etc/default/bascula >/dev/null
 install -D -m 0644 /dev/null /etc/bascula/WEB_READY
 install -D -m 0644 /dev/null /etc/bascula/APP_READY
 
@@ -79,14 +106,11 @@ for svc in bascula-web.service bascula-app.service; do
   systemctl reset-failed "${svc}" 2>/dev/null || true
 done
 
-PORT="$(. /etc/default/bascula-web; printf '%s' \"${BASCULA_WEB_PORT:-8078}\")"
+PORT="$(. /etc/default/bascula; printf '%s' "${BASCULA_WEB_PORT:-8078}")"
 free_tcp_port "${PORT}"
 
-systemctl enable bascula-web.service
-systemctl enable bascula-app.service
-
-systemctl start bascula-web.service
-systemctl restart bascula-app.service
+systemctl enable --now bascula-web.service
+systemctl enable --now bascula-app.service
 
 health_ok=""
 for i in $(seq 1 15); do
@@ -102,6 +126,11 @@ if [[ -z "${health_ok}" ]]; then
   echo "[ERR ] Mini-web: health endpoint did not respond on 127.0.0.1:${PORT}"
   echo "------ journald tail (bascula-web) ------"
   journalctl -u bascula-web.service -n 80 --no-pager || true
+  exit 1
+fi
+
+if ! curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null; then
+  journalctl -u bascula-web.service -n 120 --no-pager || true
   exit 1
 fi
 

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -6,16 +6,31 @@ ConditionPathExists=/etc/bascula/APP_READY
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/default/bascula
 User=pi
 Group=pi
-WorkingDirectory=/opt/bascula/current
-Environment=PYTHONPATH=/usr/lib/python3/dist-packages
-RuntimeDirectory=bascula
-RuntimeDirectoryMode=0755
-Environment=BASCULA_RUNTIME_DIR=/run/bascula
-ExecStart=/usr/bin/xinit /usr/local/bin/bascula-xsession -- :0 vt1 -nolisten tcp
-Restart=on-failure
-RestartSec=3
+WorkingDirectory=%E{BASCULA_PREFIX}
+ExecStartPre=/bin/bash -lc 'install -d -m 0755 "${BASCULA_RUNTIME_DIR}"'
+ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.ui.app'
+
+# Entorno de la app
+Environment=BASCULA_CFG_DIR=%E{BASCULA_CFG_DIR}
+Environment=BASCULA_RUNTIME_DIR=%E{BASCULA_RUNTIME_DIR}
+Environment=BASCULA_WEB_HOST=%E{BASCULA_WEB_HOST}
+Environment=BASCULA_WEB_PORT=%E{BASCULA_WEB_PORT}
+
+# Sandbox alineado con la app principal
+NoNewPrivileges=yes
+ProtectSystem=full
+ProtectHome=read-only
+ProtectHostname=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/bascula-web.env
+++ b/systemd/bascula-web.env
@@ -1,5 +1,0 @@
-# systemd/bascula-web.env (se instala en /etc/default/bascula-web)
-BASCULA_WEB_HOST=0.0.0.0
-BASCULA_WEB_PORT=8078
-BASCULA_WEB_USER=pi
-BASCULA_WEB_GROUP=pi

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -6,37 +6,42 @@ ConditionPathExists=/etc/bascula/WEB_READY
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/bascula-web
+EnvironmentFile=-/etc/default/bascula
 User=pi
 Group=pi
-WorkingDirectory=/home/pi/bascula-cam
+WorkingDirectory=%E{BASCULA_PREFIX}
 Environment=PYTHONUNBUFFERED=1
-Environment=PYTHONPATH=/usr/lib/python3/dist-packages
-ExecStartPre=/usr/bin/env bash -lc 'PORT="${BASCULA_WEB_PORT:-8078}"; \
-  if command -v ss >/dev/null 2>&1 && ss -ltn "sport = :${PORT}" | grep -q LISTEN; then \
-    echo "Freeing tcp:${PORT}"; /usr/bin/fuser -k "${PORT}"/tcp || true; sleep 0.5; \
-  fi'
-ExecStart=/home/pi/bascula-cam/.venv/bin/python -m bascula.services.wifi_config --host ${BASCULA_WEB_HOST:-0.0.0.0} --port ${BASCULA_WEB_PORT:-8078}
-Restart=on-failure
-RestartSec=2
-KillMode=mixed
-TimeoutStopSec=5
-NoNewPrivileges=true
-PrivateTmp=true
+ExecStartPre=/bin/bash -lc 'install -d -m 0755 "${BASCULA_RUNTIME_DIR}"'
+ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.services.wifi_config'
+
+# Entorno de la app
+Environment=BASCULA_CFG_DIR=%E{BASCULA_CFG_DIR}
+Environment=BASCULA_RUNTIME_DIR=%E{BASCULA_RUNTIME_DIR}
+Environment=BASCULA_WEB_HOST=%E{BASCULA_WEB_HOST}
+Environment=BASCULA_WEB_PORT=%E{BASCULA_WEB_PORT}
+
+# Sandbox razonable (no uses %E aquí)
+NoNewPrivileges=yes
+PrivateTmp=yes
 ProtectSystem=full
-ProtectHome=yes
-ReadWritePaths=/home/pi/.config /home/pi/.config/bascula
+ProtectHome=read-only
+ProtectHostname=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes
-PrivateDevices=yes
-RestrictAddressFamilies=AF_UNIX AF_INET
-LockPersonality=yes
-RemoveIPC=yes
-RestrictNamespaces=yes
 RestrictRealtime=yes
-CapabilityBoundingSet=
-AmbientCapabilities=
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+# Red: deja comentado por defecto; documenta aperturas necesarias
+#IPAddressDeny=any
+#IPAddressAllow=127.0.0.1
+#IPAddressAllow=10.42.0.0/24
+#IPAddressAllow=192.168.0.0/16
+#IPAddressAllow=172.16.0.0/12
+
+Restart=on-failure
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add installation defaults under /etc/default/bascula with OTA-aware fallback
- update bascula-web.service to source the defaults, run from OTA venv and create runtime dir
- update bascula-app.service to mirror the environment handling and launch the app from the venv

## Testing
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68cebabbcd0c83269c3f58c19d661293