### PR TITLE
Adjust bascula systemd units defaults and directories

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -6,23 +6,22 @@ ConditionPathExists=/etc/bascula/APP_READY
 
 [Service]
 Type=simple
+Environment=BASCULA_RUNTIME_DIR=/run/bascula
+Environment=BASCULA_CFG_DIR=%h/.config/bascula
+Environment=BASCULA_PREFIX=/opt/bascula/current
+Environment=BASCULA_VENV=/opt/bascula/current/venv
 EnvironmentFile=-/etc/default/bascula
+RuntimeDirectory=bascula
+RuntimeDirectoryMode=0755
 User=pi
 Group=pi
 WorkingDirectory=%E{BASCULA_PREFIX}
-ExecStartPre=/bin/bash -lc 'install -d -m 0755 "${BASCULA_RUNTIME_DIR}"'
 ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.ui.app'
-
-# Entorno de la app
-Environment=BASCULA_CFG_DIR=%E{BASCULA_CFG_DIR}
-Environment=BASCULA_RUNTIME_DIR=%E{BASCULA_RUNTIME_DIR}
-Environment=BASCULA_WEB_HOST=%E{BASCULA_WEB_HOST}
-Environment=BASCULA_WEB_PORT=%E{BASCULA_WEB_PORT}
-
-# Sandbox alineado con la app principal
-NoNewPrivileges=yes
 ProtectSystem=full
 ProtectHome=read-only
+ReadWritePaths=%h/.config/bascula
+NoNewPrivileges=yes
+PrivateTmp=yes
 ProtectHostname=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
@@ -31,6 +30,9 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
+
+Restart=on-failure
+RestartSec=3
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -6,25 +6,22 @@ ConditionPathExists=/etc/bascula/WEB_READY
 
 [Service]
 Type=simple
+Environment=BASCULA_RUNTIME_DIR=/run/bascula
+Environment=BASCULA_CFG_DIR=%h/.config/bascula
+Environment=BASCULA_PREFIX=/opt/bascula/current
+Environment=BASCULA_VENV=/opt/bascula/current/venv
 EnvironmentFile=-/etc/default/bascula
+RuntimeDirectory=bascula
+RuntimeDirectoryMode=0755
 User=pi
 Group=pi
 WorkingDirectory=%E{BASCULA_PREFIX}
-Environment=PYTHONUNBUFFERED=1
-ExecStartPre=/bin/bash -lc 'install -d -m 0755 "${BASCULA_RUNTIME_DIR}"'
 ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.services.wifi_config'
-
-# Entorno de la app
-Environment=BASCULA_CFG_DIR=%E{BASCULA_CFG_DIR}
-Environment=BASCULA_RUNTIME_DIR=%E{BASCULA_RUNTIME_DIR}
-Environment=BASCULA_WEB_HOST=%E{BASCULA_WEB_HOST}
-Environment=BASCULA_WEB_PORT=%E{BASCULA_WEB_PORT}
-
-# Sandbox razonable (no uses %E aquí)
-NoNewPrivileges=yes
-PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=read-only
+ReadWritePaths=%h/.config/bascula
+NoNewPrivileges=yes
+PrivateTmp=yes
 ProtectHostname=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
@@ -33,12 +30,6 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
-# Red: deja comentado por defecto; documenta aperturas necesarias
-#IPAddressDeny=any
-#IPAddressAllow=127.0.0.1
-#IPAddressAllow=10.42.0.0/24
-#IPAddressAllow=192.168.0.0/16
-#IPAddressAllow=172.16.0.0/12
 
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
## Summary
- provide default values for bascula runtime, config and installation paths before sourcing /etc/default/bascula
- let systemd manage /run/bascula and allow writing to the per-user config directory while keeping ProtectHome
- simplify ExecStart and security settings for bascula web and app services without using unsupported %E substitutions

## Testing
- not run (systemd units only)

------
https://chatgpt.com/codex/tasks/task_e_68cebd1e66bc8326b321e67657ae179c