### PR TITLE
Fix miniweb env handling and services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ allow-lan:
 	  "# Directorio de trabajo por defecto: %h/bascula-cam (repo en HOME)" \
 	  "WorkingDirectory=%h/bascula-cam" \
 	  "# Abrir a la red" \
-	  "Environment=BASCULA_WEB_HOST=0.0.0.0" \
-	  "Environment=BASCULA_WEB_PORT=8080" \
+          "Environment=BASCULA_WEB_HOST=0.0.0.0" \
+          "Environment=BASCULA_MINIWEB_PORT=8080" \
 	  "Environment=BASCULA_CFG_DIR=%h/.config/bascula" \
 	  "# Asegurar que se sobreescribe ExecStart y usar Python del sistema" \
 	  "ExecStart=" \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ El comando muestra lecturas parseadas en gramos, indica si el modo es simulació
 
 ### Acceso mini-web
 
-- En la AP Bascula_AP: http://10.42.0.1:8078/
-- En la LAN: http://<IP-de-la-Pi>:8078/
+- En la AP Bascula_AP: http://10.42.0.1:8080/
+- En la LAN: http://<IP-de-la-Pi>:8080/
 - Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_MINIWEB_HOST`/`BASCULA_MINIWEB_PORT`.

--- a/bascula/services/wifi_config.py
+++ b/bascula/services/wifi_config.py
@@ -11,25 +11,14 @@ from flask import Flask, request, redirect, render_template_string, session, jso
 # Antes: `from utils import ...` podía fallar al ejecutarse como módulo (-m)
 from bascula.utils import load_config, save_config
 
-def _get_host() -> str:
-    host = (os.environ.get("BASCULA_MINIWEB_HOST") or os.environ.get("BASCULA_WEB_HOST") or "").strip()
-    return host or "0.0.0.0"
+_port_value = os.getenv("BASCULA_MINIWEB_PORT") or os.getenv("BASCULA_WEB_PORT") or "8080"
+try:
+    APP_PORT = int(_port_value)
+except (TypeError, ValueError):
+    APP_PORT = 8080
 
-
-def _get_port() -> int:
-    for key in ("BASCULA_MINIWEB_PORT", "BASCULA_WEB_PORT"):
-        value = os.environ.get(key, "").strip()
-        if not value:
-            continue
-        try:
-            return int(value)
-        except ValueError:
-            continue
-    return 8078
-
-
-APP_HOST = _get_host()
-APP_PORT = _get_port()
+_host_value = os.getenv("BASCULA_WEB_HOST", "0.0.0.0") or "0.0.0.0"
+APP_HOST = _host_value.strip() or "0.0.0.0"
 _CFG_ENV = os.environ.get("BASCULA_CFG_DIR", "").strip()
 CFG_DIR = Path(_CFG_ENV) if _CFG_ENV else (Path.home() / ".config" / "bascula")
 CFG_DIR.mkdir(parents=True, exist_ok=True)

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1070,7 +1070,7 @@ Environment=HOME=${TARGET_HOME}
 Environment=XDG_CONFIG_HOME=${TARGET_HOME}/.config
 Environment=PYTHONPATH=${BASCULA_CURRENT_LINK}
 Environment=BASCULA_MINIWEB_HOST=0.0.0.0
-Environment=BASCULA_MINIWEB_PORT=8078
+Environment=BASCULA_MINIWEB_PORT=8080
 Environment=BASCULA_CFG_DIR=${TARGET_HOME}/.config/bascula
 ExecStart=${BASCULA_CURRENT_LINK}/.venv/bin/python -m bascula.services.wifi_config
 Restart=on-failure
@@ -1089,9 +1089,12 @@ PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET
 IPAddressDeny=
 IPAddressAllow=127.0.0.1
-IPAddressAllow=10.42.0.0/24      # subred AP (NetworkManager "shared")
-IPAddressAllow=192.168.0.0/16    # LAN clásica
-IPAddressAllow=172.16.0.0/12     # LAN privadas
+# subred AP (NetworkManager "shared")
+IPAddressAllow=10.42.0.0/24
+# LAN clásica
+IPAddressAllow=192.168.0.0/16
+# LAN privadas
+IPAddressAllow=172.16.0.0/12
 LockPersonality=yes
 RemoveIPC=yes
 RestrictNamespaces=yes
@@ -1104,9 +1107,9 @@ WantedBy=multi-user.target
 EOF
 systemctl daemon-reload
 install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${TARGET_HOME}/.config/bascula" || true
-# Preflight: ensure port 8078 is free
-if ss -ltn '( sport = :8078 )' | grep -q ':8078'; then
-  warn "Port 8078 is already in use. bascula-web will not start. Free the port or set BASCULA_MINIWEB_PORT."
+# Preflight: ensure port 8080 is free
+if ss -ltn '( sport = :8080 )' | grep -q ':8080'; then
+  warn "Port 8080 is already in use. bascula-web will not start. Free the port or set BASCULA_MINIWEB_PORT."
 fi
 systemctl enable --now bascula-web.service || true
 su -s /bin/bash -c 'mkdir -p ~/.config/bascula' "${TARGET_USER}" || true

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -980,7 +980,7 @@ Environment=HOME=${TARGET_HOME}
 Environment=XDG_CONFIG_HOME=${TARGET_HOME}/.config
 Environment=PYTHONPATH=${BASCULA_CURRENT_LINK}
 Environment=BASCULA_MINIWEB_HOST=0.0.0.0
-Environment=BASCULA_MINIWEB_PORT=8078
+Environment=BASCULA_MINIWEB_PORT=8080
 Environment=BASCULA_CFG_DIR=${TARGET_HOME}/.config/bascula
 ExecStart=${BASCULA_CURRENT_LINK}/.venv/bin/python -m bascula.services.wifi_config
 Restart=on-failure
@@ -999,9 +999,12 @@ PrivateDevices=yes
 RestrictAddressFamilies=AF_UNIX AF_INET
 IPAddressDeny=
 IPAddressAllow=127.0.0.1
-IPAddressAllow=10.42.0.0/24      # subred AP (NetworkManager "shared")
-IPAddressAllow=192.168.0.0/16    # LAN clásica
-IPAddressAllow=172.16.0.0/12     # LAN privadas
+# subred AP (NetworkManager "shared")
+IPAddressAllow=10.42.0.0/24
+# LAN clásica
+IPAddressAllow=192.168.0.0/16
+# LAN privadas
+IPAddressAllow=172.16.0.0/12
 LockPersonality=yes
 RemoveIPC=yes
 RestrictNamespaces=yes

--- a/scripts/verify-miniweb-open.sh
+++ b/scripts/verify-miniweb-open.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-PORT="${1:-8078}"
+PORT="${1:-8080}"
 IP="$(hostname -I | awk '{print $1}')"
 echo "[info] Probing http://127.0.0.1:${PORT}/health"
 curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null && echo "OK local"

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -7,19 +7,19 @@ ConditionPathExists=/etc/bascula/APP_READY
 [Service]
 Type=simple
 Environment=BASCULA_RUNTIME_DIR=/run/bascula
-Environment=BASCULA_CFG_DIR=%h/.config/bascula
+Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
 Environment=BASCULA_PREFIX=/opt/bascula/current
-Environment=BASCULA_VENV=/opt/bascula/current/venv
-EnvironmentFile=-/etc/default/bascula
+Environment=BASCULA_VENV=/opt/bascula/current/.venv
+EnvironmentFile=/etc/default/bascula
 RuntimeDirectory=bascula
 RuntimeDirectoryMode=0755
 User=pi
 Group=pi
-WorkingDirectory=%E{BASCULA_PREFIX}
-ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.ui.app'
+WorkingDirectory=/opt/bascula/current
+ExecStart=/opt/bascula/current/.venv/bin/python -m bascula.ui.app
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=%h/.config/bascula
+ReadWritePaths=/home/pi/.config/bascula
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHostname=yes

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -7,19 +7,19 @@ ConditionPathExists=/etc/bascula/WEB_READY
 [Service]
 Type=simple
 Environment=BASCULA_RUNTIME_DIR=/run/bascula
-Environment=BASCULA_CFG_DIR=%h/.config/bascula
+Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
 Environment=BASCULA_PREFIX=/opt/bascula/current
-Environment=BASCULA_VENV=/opt/bascula/current/venv
-EnvironmentFile=-/etc/default/bascula
+Environment=BASCULA_VENV=/opt/bascula/current/.venv
+EnvironmentFile=/etc/default/bascula
 RuntimeDirectory=bascula
 RuntimeDirectoryMode=0755
 User=pi
 Group=pi
-WorkingDirectory=%E{BASCULA_PREFIX}
-ExecStart=/bin/bash -lc 'exec "${BASCULA_VENV}/bin/python" -m bascula.services.wifi_config'
+WorkingDirectory=/opt/bascula/current
+ExecStart=/opt/bascula/current/.venv/bin/python -m bascula.services.wifi_config
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=%h/.config/bascula
+ReadWritePaths=/home/pi/.config/bascula
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHostname=yes


### PR DESCRIPTION
## Summary
- point the bascula systemd units at the OTA layout, drop %E expansions, and rely on the default env file
- read BASCULA_MINIWEB_PORT/BASCULA_WEB_HOST directly in the wifi miniweb entrypoint with an 8080 default
- teach the app installer to write the canonical host/port defaults and probe the health endpoint via BASCULA_MINIWEB_PORT

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec1d50b7c8326b3292f0b0c06d5ac