### PR TITLE
Support flexible bascula-web virtualenv resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ El comando muestra lecturas parseadas en gramos, indica si el modo es simulació
 - En la AP Bascula_AP: http://10.42.0.1:8080/
 - En la LAN: http://<IP-de-la-Pi>:8080/
 - Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_MINIWEB_HOST`/`BASCULA_MINIWEB_PORT`.
+- Nota: si no existe `/opt/bascula/current/.venv/bin/python`, el servicio `bascula-web` utilizará `${BASCULA_VENV}` (definido por `install-2-app.sh`) como intérprete alternativo.

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -8,18 +8,21 @@ ConditionPathExists=/etc/bascula/WEB_READY
 Type=simple
 Environment=BASCULA_RUNTIME_DIR=/run/bascula
 Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
-Environment=BASCULA_PREFIX=/opt/bascula/current
-Environment=BASCULA_VENV=/opt/bascula/current/.venv
 EnvironmentFile=/etc/default/bascula
+Environment=BASCULA_WEB_HOST=0.0.0.0
+Environment=BASCULA_WEB_PORT=8080
+Environment=FLASK_RUN_HOST=0.0.0.0
+Environment=FLASK_RUN_PORT=8080
 RuntimeDirectory=bascula
 RuntimeDirectoryMode=0755
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
-ExecStart=/opt/bascula/current/.venv/bin/python -m bascula.services.wifi_config
+ExecStart=
+ExecStart=/bin/bash -lc 'set -eo pipefail; cd "${BASCULA_PREFIX:-/opt/bascula/current}"; PYBIN="${BASCULA_VENV:+${BASCULA_VENV}/bin/python}"; [ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="/opt/bascula/current/.venv/bin/python"; exec "$PYBIN" -m bascula.services.wifi_config'
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=/home/pi/.config/bascula
+ReadWritePaths=%h/.config/bascula
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHostname=yes


### PR DESCRIPTION
## Summary
- expose default LAN binding variables for the bascula-web systemd service while resolving the Python interpreter dynamically based on BASCULA_VENV or the OTA virtualenv
- ensure the service starts from BASCULA_PREFIX when provided and keep the user config writable via the home-based path specifier
- document that bascula-web falls back to BASCULA_VENV when the OTA virtualenv is missing

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cec7205a0c8326a4e998140d245c46