### PR TITLE
Fix bascula-web sandbox and default mini-web port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,6 @@ El comando muestra lecturas parseadas en gramos, indica si el modo es simulació
 
 - En la AP Bascula_AP: http://10.42.0.1:8080/
 - En la LAN: http://<IP-de-la-Pi>:8080/
-- Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_MINIWEB_HOST`/`BASCULA_MINIWEB_PORT`.
-- Nota: si no existe `/opt/bascula/current/.venv/bin/python`, el servicio `bascula-web` utilizará `${BASCULA_VENV}` (definido por `install-2-app.sh`) como intérprete alternativo.
+- Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_WEB_HOST`/`BASCULA_WEB_PORT`.
+- La mini-web se expone por defecto en `0.0.0.0:8080` (valores escritos en `/etc/default/bascula`).
+- Nota: si no existe `/opt/bascula/current/.venv/bin/python`, el servicio `bascula-web` utilizará `${BASCULA_VENV}` (definido por `install-2-app.sh`) como intérprete alternativo de desarrollo.

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -16,6 +16,7 @@ RuntimeDirectoryMode=0755
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
+ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0755 /home/pi/.config/bascula
 ExecStart=/opt/bascula/current/.venv/bin/python -m bascula.ui.app
 ProtectSystem=full
 ProtectHome=read-only

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -17,12 +17,11 @@ RuntimeDirectory=bascula
 RuntimeDirectoryMode=0755
 User=pi
 Group=pi
-WorkingDirectory=/opt/bascula/current
-ExecStart=
-ExecStart=/bin/bash -lc 'set -eo pipefail; cd "${BASCULA_PREFIX:-/opt/bascula/current}"; PYBIN="${BASCULA_VENV:+${BASCULA_VENV}/bin/python}"; [ -n "$PYBIN" ] && [ -x "$PYBIN" ] || PYBIN="/opt/bascula/current/.venv/bin/python"; exec "$PYBIN" -m bascula.services.wifi_config'
+ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0755 /home/pi/.config/bascula
+ExecStart=/bin/bash -lc 'PYBIN="${BASCULA_VENV:+${BASCULA_VENV}/bin/python}"; [ -x "$PYBIN" ] || PYBIN="/opt/bascula/current/.venv/bin/python"; cd "${BASCULA_PREFIX:-/opt/bascula/current}" && exec "$PYBIN" -m bascula.services.wifi_config'
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=%h/.config/bascula
+ReadWritePaths=/home/pi/.config/bascula
 NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHostname=yes


### PR DESCRIPTION
## Summary
- update the bascula-web systemd unit to create the user config directory, use the configured prefix when launching, and keep the sandbox writable at /home/pi/.config/bascula
- apply the same writable path preparation to bascula-app and document the new defaults for the mini-web service
- adjust install-2-app.sh to populate BASCULA_WEB_* defaults, ensure the config directory exists before restarts, reload systemd, and verify /health on the unified port

## Testing
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68ceefc77ecc83269525d8a50d42230b