### PR TITLE
Configure startx systemd UI launch

### DIFF
--- a/scripts/xsession.sh
+++ b/scripts/xsession.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export DISPLAY=:0
+
+# Evitar apagado de pantalla y cursor visible
+xset s off || true
+xset -dpms || true
+xset s noblank || true
+command -v unclutter >/dev/null 2>&1 && unclutter -idle 0 -root &
+
+cd /opt/bascula/current
+if [[ -f ".venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source ".venv/bin/activate"
+fi
+
+exec python3 -m bascula.ui.app

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -1,37 +1,23 @@
 [Unit]
-Description=Bascula Digital Pro Main Application (X on tty1)
-After=network-online.target
+Description=Bascula Digital Pro - UI (Xorg via startx)
+After=systemd-user-sessions.service network-online.target
 Wants=network-online.target
 ConditionPathExists=/etc/bascula/APP_READY
+Conflicts=getty@tty1.service
 
 [Service]
 Type=simple
-Environment=BASCULA_RUNTIME_DIR=/run/bascula
-Environment=BASCULA_CFG_DIR=/home/pi/.config/bascula
-Environment=BASCULA_PREFIX=/opt/bascula/current
-Environment=BASCULA_VENV=/opt/bascula/current/.venv
-EnvironmentFile=/etc/default/bascula
-RuntimeDirectory=bascula
-RuntimeDirectoryMode=0755
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
-ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0755 /home/pi/.config/bascula
-ExecStart=/opt/bascula/current/.venv/bin/python -m bascula.ui.app
-ProtectSystem=full
-ProtectHome=read-only
-ReadWritePaths=/home/pi/.config/bascula
-NoNewPrivileges=yes
-PrivateTmp=yes
-ProtectHostname=yes
-ProtectKernelTunables=yes
-ProtectKernelModules=yes
-ProtectControlGroups=yes
-RestrictRealtime=yes
-RestrictSUIDSGID=yes
-LockPersonality=yes
-MemoryDenyWriteExecute=yes
-
+Environment=DISPLAY=:0
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+SupplementaryGroups=video,render,input
+# Asegura sockets/entornos necesarios antes de lanzar X
+ExecStartPre=/usr/bin/install -d -m 1777 /tmp/.X11-unix
+ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0700 /run/user/1000
+# Lanza la sesión igual que hicimos a mano
+ExecStart=/usr/bin/startx /opt/bascula/current/scripts/xsession.sh -- :0 -nolisten tcp -noreset
 Restart=on-failure
 RestartSec=3
 


### PR DESCRIPTION
## Summary
- replace the bascula-app systemd unit to launch the UI via startx with the required environment setup
- add the xsession script that mirrors the manual startx invocation used on the device
- update install scripts to install X dependencies, configure kiosk permissions, deploy the new assets, and verify the UI is running

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfb6b3e5ec832680f6f2fec54a7c48