### PR TITLE
Ensure X11 pre-start runs as root

### DIFF
--- a/packaging/tmpfiles/bascula-x11.conf
+++ b/packaging/tmpfiles/bascula-x11.conf
@@ -1,0 +1,3 @@
+# Socket de X y runtime de usuario para servicio kiosk
+d /tmp/.X11-unix 1777 root root -
+d /run/user/1000 0700 pi pi -

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -77,6 +77,8 @@ usermod -aG video,render,input pi || true
 loginctl enable-linger pi || true
 install -d -o pi -g pi -m 0700 /run/user/1000 || true
 install -d -m 1777 /tmp/.X11-unix || true
+install -D -m 0644 "${ROOT_DIR}/packaging/tmpfiles/bascula-x11.conf" /etc/tmpfiles.d/bascula-x11.conf
+systemd-tmpfiles --create /etc/tmpfiles.d/bascula-x11.conf || true
 
 install -d -m 0755 /etc/bascula
 {

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1119,6 +1119,8 @@ usermod -aG video,render,input pi || true
 loginctl enable-linger pi || true
 install -d -o pi -g pi -m 0700 /run/user/1000 || true
 install -d -m 1777 /tmp/.X11-unix || true
+install -D -m 0644 "${SCRIPT_DIR}/../packaging/tmpfiles/bascula-x11.conf" /etc/tmpfiles.d/bascula-x11.conf
+systemd-tmpfiles --create /etc/tmpfiles.d/bascula-x11.conf || true
 
 install -D -m 0755 "${SCRIPT_DIR}/../scripts/xsession.sh" /opt/bascula/current/scripts/xsession.sh
 install -D -m 0644 "${SCRIPT_DIR}/../systemd/bascula-app.service" /etc/systemd/system/bascula-app.service

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -13,10 +13,11 @@ WorkingDirectory=/opt/bascula/current
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/1000
 SupplementaryGroups=video,render,input
-# Asegura sockets/entornos necesarios antes de lanzar X
+# IMPORTANTE: que los ExecStartPre corran como root aunque User=pi
+PermissionsStartOnly=yes
+# Prepara sockets/entornos X antes de arrancar
 ExecStartPre=/usr/bin/install -d -m 1777 /tmp/.X11-unix
 ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0700 /run/user/1000
-# Lanza la sesión igual que hicimos a mano
 ExecStart=/usr/bin/startx /opt/bascula/current/scripts/xsession.sh -- :0 -nolisten tcp -noreset
 Restart=on-failure
 RestartSec=3


### PR DESCRIPTION
## Summary
- ensure the bascula-app systemd service runs ExecStartPre commands as root by setting PermissionsStartOnly
- install tmpfiles configuration and pre-create X11 runtime directories during installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfb8b89ef88326a0f7ad36d32fc0ae