### PR TITLE
Improve Raspberry Pi UI startup and fallback automation

### DIFF
--- a/packaging/tmpfiles/bascula-x11.conf
+++ b/packaging/tmpfiles/bascula-x11.conf
@@ -1,3 +1,1 @@
-# Socket de X y runtime de usuario para servicio kiosk
 d /tmp/.X11-unix 1777 root root -
-d /run/user/1000 0700 pi pi -

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -13,59 +13,10 @@ TARGET_USER="${TARGET_USER:-${SUDO_USER:-pi}}"
 
 install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "/home/${TARGET_USER}/.config/bascula"
 
-free_tcp_port() {
-  local port="$1"
-  if command -v ss >/dev/null 2>&1 && ss -ltn "sport = :${port}" | grep -q LISTEN; then
-    echo "[inst] Freeing tcp:${port}"
-    if command -v fuser >/dev/null 2>&1; then
-      fuser -k "${port}"/tcp >/dev/null 2>&1 || true
-    fi
-    sleep 0.5
-    return
-  fi
-  if command -v fuser >/dev/null 2>&1 && fuser "${port}"/tcp >/dev/null 2>&1; then
-    echo "[inst] Freeing tcp:${port}"
-    fuser -k "${port}"/tcp >/dev/null 2>&1 || true
-    sleep 0.5
-  fi
-}
-
-nm_up_ap() {
-  local _opts=$-
-  set +e
-  if ! command -v nmcli >/dev/null 2>&1; then
-    echo "[ap] nmcli no disponible; omitiendo Hotspot (ok)"
-    [[ $_opts == *e* ]] && set -e
-    return 0
-  fi
-  if ! ip link show wlan0 >/dev/null 2>&1; then
-    echo "[ap] wlan0 no disponible; omitiendo Hotspot (ok)"
-    [[ $_opts == *e* ]] && set -e
-    return 0
-  fi
-  if nmcli -t -f DEVICE,TYPE,STATE,CONNECTION dev | grep -q '^wlan0:wifi:connected:'; then
-    echo "[ap] wlan0 está conectado como cliente; no se levanta AP (ok)"
-    [[ $_opts == *e* ]] && set -e
-    return 0
-  fi
-  if nmcli -t -f NAME con show | grep -qx "BasculaAP"; then
-    echo "[ap] Conexión BasculaAP ya existe"
-  else
-    echo "[ap] Creando BasculaAP…"
-    nmcli con add type wifi ifname wlan0 con-name BasculaAP ssid "Bascula_AP" \
-      802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel 6 \
-      ipv4.method shared ipv6.method ignore \
-      802-11-wireless-security.key-mgmt wpa-psk 802-11-wireless-security.psk "bascula1234" \
-      || echo "[ap] Aviso: nmcli con add BasculaAP devolvió error; se continúa"
-  fi
-  echo "[ap] Activando BasculaAP (best-effort)…"
-  nmcli con up BasculaAP ifname wlan0 || echo "[ap] Aviso: nmcli con up BasculaAP devolvió error; se continúa"
-  [[ $_opts == *e* ]] && set -e
-}
-
 PHASE=2 TARGET_USER="${TARGET_USER}" bash "${SCRIPT_DIR}/install-all.sh" "$@"
 
-apt-get install -y xserver-xorg x11-xserver-utils xinit xserver-xorg-legacy unclutter
+apt-get install -y xserver-xorg x11-xserver-utils xinit xserver-xorg-legacy unclutter \
+                   libcamera-apps v4l-utils python3-picamera2
 
 install -D -m 0644 /dev/null /etc/Xwrapper.config
 cat >/etc/Xwrapper.config <<'EOF'
@@ -75,12 +26,10 @@ EOF
 
 usermod -aG video,render,input pi || true
 loginctl enable-linger pi || true
-install -d -o pi -g pi -m 0700 /run/user/1000 || true
-install -d -m 1777 /tmp/.X11-unix || true
 install -D -m 0644 "${ROOT_DIR}/packaging/tmpfiles/bascula-x11.conf" /etc/tmpfiles.d/bascula-x11.conf
 systemd-tmpfiles --create /etc/tmpfiles.d/bascula-x11.conf || true
 
-install -d -m 0755 /etc/bascula
+install -d -m 0755 -o pi -g pi /etc/bascula
 {
   BASCULA_USER=pi
   BASCULA_GROUP=pi
@@ -116,8 +65,6 @@ EOF
 install -D -m 0644 /dev/null /etc/bascula/WEB_READY
 install -D -m 0644 /dev/null /etc/bascula/APP_READY
 
-nm_up_ap
-
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service" /etc/systemd/system/bascula-web.service
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-app.service" /etc/systemd/system/bascula-app.service
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service.d/10-writable-home.conf" \
@@ -125,6 +72,8 @@ install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service.d/10-writable-home.c
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service.d/20-env-and-exec.conf" \
   /etc/systemd/system/bascula-web.service.d/20-env-and-exec.conf
 install -D -m 0755 "${ROOT_DIR}/scripts/xsession.sh" /opt/bascula/current/scripts/xsession.sh
+install -D -m 0755 "${ROOT_DIR}/scripts/net-fallback.sh" /opt/bascula/current/scripts/net-fallback.sh
+install -D -m 0644 "${ROOT_DIR}/systemd/bascula-net-fallback.service" /etc/systemd/system/bascula-net-fallback.service
 
 for svc in bascula-web.service bascula-app.service; do
   systemctl stop "${svc}" 2>/dev/null || true
@@ -135,45 +84,27 @@ done
 # Puerto de mini-web (compatibilidad hacia atrás):
 # 1) BASCULA_MINIWEB_PORT (histórico)  2) BASCULA_WEB_PORT  3) 8080 por defecto
 PORT="${BASCULA_MINIWEB_PORT:-${BASCULA_WEB_PORT:-8080}}"
-free_tcp_port "${PORT}"
+
+if ss -ltn "( sport = :${PORT} )" | grep -q ":${PORT}"; then
+  echo "[WARN] Port ${PORT} is already in use. bascula-web may fail to start."
+fi
 
 systemctl disable getty@tty1.service || true
 
 systemctl daemon-reload
 systemctl enable --now bascula-app.service || true
+systemctl enable --now bascula-web.service || true
+systemctl enable --now bascula-net-fallback.service || true
 
-# Si el puerto ya está ocupado, avisamos y no intentamos arrancar otra instancia;
-# el health-check comprobará este mismo puerto.
-if ss -ltnp | grep -qE ":${PORT}\\b"; then
-  echo "[WARN] Port ${PORT} is already in use. Skipping start. Health check will probe the running service."
-else
-  systemctl enable --now bascula-web.service
-fi
-
-health_ok=""
-delay=1
-for i in $(seq 1 8); do
-  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null; then
-    echo "[verify] Mini-web: OK"
-    health_ok=1
+for i in {1..20}; do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "[OK] bascula-web ${PORT}"
     break
   fi
-  sleep "${delay}"
-  delay=$((delay * 2))
-  if (( delay > 8 )); then
-    delay=8
-  fi
+  sleep 0.5
 done
-
-if [[ -z "${health_ok}" ]]; then
-  echo "[ERR ] Mini-web: health endpoint did not respond on 127.0.0.1:${PORT}"
-  echo "------ journald tail (bascula-web) ------"
-  journalctl -u bascula-web.service -n 80 --no-pager || true
-  exit 1
-fi
-
 if ! curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null; then
-  journalctl -u bascula-web.service -n 120 --no-pager || true
+  journalctl -u bascula-web.service -n 200 --no-pager || true
   exit 1
 fi
 
@@ -183,13 +114,13 @@ echo "Mini-web: http://${IP:-<IP>}:${PORT}/"
 
 sleep 3
 if ! systemctl is-active --quiet bascula-app.service; then
-  journalctl -u bascula-app -n 200 --no-pager || true
-  tail -n 120 "/home/pi/.local/share/xorg/Xorg.0.log" || true
-  echo "[ERR] bascula-app no ha arrancado; revisa logs anteriores" >&2
+  journalctl -u bascula-app -n 300 --no-pager || true
+  tail -n 160 "/home/pi/.local/share/xorg/Xorg.0.log" 2>/dev/null || true
+  echo "[ERR] bascula-app no ha arrancado" >&2
   exit 1
 fi
 
-pgrep -af "Xorg|startx" || { echo "[ERR] Xorg no está corriendo"; exit 1; }
-pgrep -af "python .*bascula.ui.app" || { echo "[ERR] UI de bascula no detectada"; exit 1; }
+pgrep -af "Xorg|startx" >/dev/null || { echo "[ERR] Xorg no está corriendo"; exit 1; }
+pgrep -af "python .*bascula.ui.app" >/dev/null || { echo "[ERR] UI no detectada"; exit 1; }
 
-echo "[OK] UI arrancada correctamente con startx + systemd"
+echo "[OK] Mini-web y UI operativos"

--- a/scripts/net-fallback.sh
+++ b/scripts/net-fallback.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+is_connected() {
+  local type="$1"
+  nmcli -t -f DEVICE,TYPE,STATE dev | awk -F: -v t="${type}" '$2==t && $3=="connected"{ok=1} END{exit ok?0:1}'
+}
+
+ap_up() {
+  if ! nmcli -t -f NAME,TYPE con show --active | awk -F: '$1=="BasculaAP" && $2=="wifi"{ok=1} END{exit ok?0:1}'; then
+    nmcli radio wifi on || true
+    rfkill unblock wifi || true
+    IFACE="$(nmcli -t -f DEVICE,TYPE dev | awk -F: '$2=="wifi"{print $1; exit}')"
+    nmcli con up "BasculaAP" ifname "${IFACE}" || nmcli con up "BasculaAP" || true
+  fi
+}
+
+ap_down() {
+  if nmcli -t -f NAME,TYPE con show --active | awk -F: '$1=="BasculaAP" && $2=="wifi"{ok=1} END{exit ok?0:1}'; then
+    nmcli con down "BasculaAP" || true
+  fi
+}
+
+main() {
+  # Perfil AP si falta (idempotente)
+  if ! nmcli -t -f NAME con show | grep -Fxq "BasculaAP"; then
+    IFACE="$(nmcli -t -f DEVICE,TYPE dev | awk -F: '$2=="wifi"{print $1; exit}')"
+    nmcli con add type wifi ifname "${IFACE}" con-name "BasculaAP" ssid "Bascula_AP" \
+      802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel 6 \
+      ipv4.method shared ipv6.method ignore \
+      wifi-sec.key-mgmt wpa-psk wifi-sec.psk "bascula1234" || true
+  fi
+
+  if is_connected "ethernet"; then ap_down; exit 0; fi
+  if is_connected "wifi";     then ap_down; exit 0; fi
+  ap_up
+}
+main "$@"

--- a/scripts/xsession.sh
+++ b/scripts/xsession.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 export DISPLAY=:0
 
-# Evitar apagado de pantalla y cursor visible
+# Anti-suspensión / cursor
 xset s off || true
 xset -dpms || true
 xset s noblank || true

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -10,15 +10,23 @@ Type=simple
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
+
+# Runtime propio (evita /run/user/1000)
+RuntimeDirectory=bascula
+RuntimeDirectoryMode=0700
 Environment=DISPLAY=:0
-Environment=XDG_RUNTIME_DIR=/run/user/1000
+Environment=XDG_RUNTIME_DIR=/run/bascula
+
 SupplementaryGroups=video,render,input
-# IMPORTANTE: que los ExecStartPre corran como root aunque User=pi
+# Para que los ExecStartPre corran como root aunque User=pi (feedback P0 del bot)
 PermissionsStartOnly=yes
-# Prepara sockets/entornos X antes de arrancar
+
+# Cinturón y tirantes para el socket X (tmpfiles también lo crea)
 ExecStartPre=/usr/bin/install -d -m 1777 /tmp/.X11-unix
-ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0700 /run/user/1000
+
+# Lanza exactamente lo que funcionó manualmente
 ExecStart=/usr/bin/startx /opt/bascula/current/scripts/xsession.sh -- :0 -nolisten tcp -noreset
+
 Restart=on-failure
 RestartSec=3
 

--- a/systemd/bascula-net-fallback.service
+++ b/systemd/bascula-net-fallback.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bascula AP fallback (only when no LAN/Wi-Fi connected)
+After=NetworkManager-wait-online.service
+Wants=NetworkManager-wait-online.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bascula/current/scripts/net-fallback.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/bascula-web.service.d/20-env-and-exec.conf
+++ b/systemd/bascula-web.service.d/20-env-and-exec.conf
@@ -1,9 +1,5 @@
 [Service]
 EnvironmentFile=-/etc/default/bascula
-Environment=BASCULA_WEB_PORT=8080
-Environment=BASCULA_MINIWEB_PORT=8080
-Environment=FLASK_RUN_PORT=8080
-Environment=FLASK_RUN_HOST=0.0.0.0
 WorkingDirectory=/opt/bascula/current
 ExecStart=
 ExecStart=/bin/bash -lc 'set -euo pipefail; VENV="${BASCULA_VENV:-/opt/bascula/current/.venv}"; exec "$VENV/bin/python" -m bascula.services.wifi_config'


### PR DESCRIPTION
## Summary
- replace the bascula-app systemd unit to launch the UI via startx with its own runtime directory and refreshed xsession script
- add a NetworkManager-driven AP fallback script and service and package tmpfiles/Xwrapper updates through the installers
- teach the installers to copy the versioned units, install the required X/camera dependencies and perform dynamic mini-web health checks

## Testing
- not run (infrastructure scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68cfe0e25dc0832690df0530a22d43d6