### PR TITLE
Handle optional assets during OTA install

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -101,14 +101,14 @@ if [[ -x "${BASCULA_VENV_DIR}/bin/pip" ]]; then
   fi
 fi
 
-shopt -s nullglob
-for EXTRA_SRC in "${SRC_REPO}/assets" "${SRC_REPO}"/voices-*; do
-  EXTRA_NAME="$(basename "${EXTRA_SRC}")"
-  DEST="${BASCULA_ROOT}/${EXTRA_NAME}"
+shopt -s nullglob dotglob
+for EXTRA_SRC in "${SRC_REPO}"/assets "${SRC_REPO}"/voices-v1 "${SRC_REPO}"/ota; do
+  [[ -d "${EXTRA_SRC}" ]] || continue
+  DEST="/opt/bascula/current/$(basename "${EXTRA_SRC}")"
   install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "${DEST}"
   rsync -a --delete "${EXTRA_SRC}/" "${DEST}/"
 done
-shopt -u nullglob
+shopt -u nullglob dotglob
 
 chown -R "${TARGET_USER}:${TARGET_USER}" "${BASCULA_ROOT}"
 


### PR DESCRIPTION
## Summary
- ensure the OTA install script skips optional asset directories that are absent while still syncing existing ones
- create the destination directory under /opt/bascula/current and copy dotfiles by temporarily enabling nullglob and dotglob

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff3ecf09c8326a344ec7a084e6b58