### PR TITLE
Move optional OTA assets to shared directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ El comando muestra lecturas parseadas en gramos, indica si el modo es simulació
 - Seguridad: la unit permite solo redes privadas (loopback, 10.42.0.0/24, 192.168.0.0/16, 172.16.0.0/12). Si se cambia el puerto o la red, actualizar `IPAddressAllow` y las variables `BASCULA_WEB_HOST`/`BASCULA_WEB_PORT`.
 - La mini-web se expone por defecto en `0.0.0.0:8080` (valores escritos en `/etc/default/bascula`).
 - Nota: si no existe `/opt/bascula/current/.venv/bin/python`, el servicio `bascula-web` utilizará `${BASCULA_VENV}` (definido por `install-2-app.sh`) como intérprete alternativo de desarrollo.
+
+### OTA y recursos opcionales
+
+- El código de la release OTA se sincroniza a `/opt/bascula/current`, mientras que los recursos opcionales (`assets/`, `voices-v1/` y `ota/`) persisten en `/opt/bascula/shared`.
+- Durante la instalación se crean symlinks (`assets`, `voices-v1`, `ota`) en `/opt/bascula/current/` apuntando a los directorios dentro de `shared`, evitando que un OTA sin recursos los borre.
+- Los scripts de instalación toleran errores `rsync` 23/24 y mantienen permisos `0755` con propietario `${TARGET_USER}:${TARGET_USER}` en todos los directorios bajo `/opt/bascula/shared`.

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_install_script_protects_optional_directories() -> None:
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "install-2-app.sh"
+    script_text = script_path.read_text(encoding="utf-8")
+
+    required_excludes = {"--exclude '/assets'", "--exclude '/voices-v1'", "--exclude '/ota'"}
+
+    found = False
+    start = 0
+    while True:
+        idx = script_text.find("rsync -a --delete", start)
+        if idx == -1:
+            break
+
+        end = script_text.find("\"${BASCULA_CURRENT}/\"", idx)
+        if end != -1 and script_text.find("\"${SRC_REPO}/\"", idx, end) != -1:
+            block = script_text[idx:end]
+            missing = sorted(ex for ex in required_excludes if ex not in block)
+            assert not missing, f"Faltan exclusiones en rsync: {', '.join(missing)}"
+            found = True
+
+        start = idx + 1
+
+    assert found, "No se encontró la sincronización principal hacia ${BASCULA_CURRENT}"


### PR DESCRIPTION
## Summary
- persist optional OTA resources under /opt/bascula/shared and expose them via symlinks from /opt/bascula/current during install
- make install script tolerate rsync 23/24 exit codes, add final symlink/shared checks, and document the shared resource layout
- add a test that ensures future installers keep the rsync exclusions for optional resources

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cff5c9ea888326bf040afa594d024f