### PR TITLE
feat: Stage 1 OTA persistence and OCR label caching

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -505,6 +505,32 @@ class HomeScreen(BaseScreen):
             f"{item.fat_g:.1f}",
         ))
         self._update_item_count()
+
+        try:
+            raw_ocr = payload.get('ocr_text') or payload.get('ocr_raw') or payload.get('vision_raw')
+        except Exception:
+            raw_ocr = None
+
+        if raw_ocr:
+            if hasattr(self.app, 'clear_pending_ocr_text'):
+                try:
+                    self.app.clear_pending_ocr_text()
+                except Exception:
+                    pass
+        else:
+            if hasattr(self.app, 'consume_pending_ocr_text'):
+                try:
+                    raw_ocr = self.app.consume_pending_ocr_text()
+                except Exception:
+                    raw_ocr = None
+
+        if raw_ocr and hasattr(self.app, 'remember_ocr_mapping'):
+            try:
+                food_id = payload.get('food_id') or payload.get('id')
+                self.app.remember_ocr_mapping(raw_ocr, food_id=food_id, food_name=item.name)
+            except Exception:
+                pass
+
         return item
 
     def _on_select_item(self, _evt=None):

--- a/recognizer/__init__.py
+++ b/recognizer/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for OCR/vision recognition pipelines."""
+
+from .vision import LabelsCache, VisionRecognizer, normalize_text
+
+__all__ = ["LabelsCache", "VisionRecognizer", "normalize_text"]

--- a/recognizer/vision.py
+++ b/recognizer/vision.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import unicodedata
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+__all__ = ["LabelsCache", "VisionRecognizer", "normalize_text"]
+
+_DEFAULT_PATH = Path("/opt/bascula/shared/userdata/labels.json")
+_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _resolve_path(path: Optional[os.PathLike[str] | str] = None) -> Path:
+    if path is not None:
+        return Path(path)
+    env = os.environ.get("BASCULA_LABELS_PATH")
+    if env:
+        return Path(env)
+    return _DEFAULT_PATH
+
+
+def normalize_text(text: Optional[str]) -> str:
+    """Return a normalized key for OCR text.
+
+    The normalization rules remove surrounding whitespace, convert to lowercase,
+    strip diacritics, and collapse non-alphanumeric characters (basic
+    punctuation) to single spaces.
+    """
+
+    if not text:
+        return ""
+
+    value = unicodedata.normalize("NFKD", str(text))
+    value = "".join(ch for ch in value if not unicodedata.combining(ch))
+    value = value.lower().strip()
+    if not value:
+        return ""
+    value = _NORMALIZE_RE.sub(" ", value)
+    return " ".join(value.split())
+
+
+class LabelsCache:
+    """Simple JSON-based cache for mapping OCR text to food identifiers."""
+
+    def __init__(self, path: Optional[os.PathLike[str] | str] = None) -> None:
+        self.path: Path = _resolve_path(path)
+        self._lock = threading.RLock()
+        self._data: Dict[str, Dict[str, Any]] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            pass
+
+        should_rewrite = False
+        try:
+            with self.path.open("r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except FileNotFoundError:
+            raw = {}
+            should_rewrite = True
+        except json.JSONDecodeError:
+            raw = {}
+            should_rewrite = True
+        except Exception:
+            raw = {}
+            should_rewrite = True
+
+        if not isinstance(raw, dict):
+            raw = {}
+            should_rewrite = True
+
+        cleaned: Dict[str, Dict[str, Any]] = {}
+        for key, value in raw.items():
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            cleaned[key] = {
+                "id": value.get("id"),
+                "name": value.get("name"),
+            }
+
+        self._data = cleaned
+        if should_rewrite or not self.path.exists():
+            self._write_locked()
+
+    # ------------------------------------------------------------------
+    def _write_locked(self) -> None:
+        tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with tmp_path.open("w", encoding="utf-8") as fh:
+                json.dump(self._data, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            os.replace(tmp_path, self.path)
+            try:
+                os.chmod(self.path, 0o644)
+            except Exception:
+                pass
+        except Exception:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    @property
+    def data(self) -> Dict[str, Dict[str, Any]]:
+        with self._lock:
+            return {k: v.copy() for k, v in self._data.items()}
+
+    @property
+    def labels_path(self) -> Path:
+        return self.path
+
+    # ------------------------------------------------------------------
+    def lookup(self, text: Optional[str]) -> Optional[Dict[str, Any]]:
+        key = normalize_text(text)
+        if not key:
+            return None
+        with self._lock:
+            entry = self._data.get(key)
+            if not entry:
+                return None
+            result = entry.copy()
+            result.setdefault("name", entry.get("id") or key)
+            result["normalized"] = key
+            return result
+
+    # ------------------------------------------------------------------
+    def update(
+        self,
+        text: Optional[str],
+        *,
+        food_id: Optional[Any] = None,
+        food_name: Optional[str] = None,
+    ) -> bool:
+        key = normalize_text(text)
+        if not key:
+            return False
+
+        entry: Dict[str, Any] = {}
+        if food_id is not None:
+            entry["id"] = str(food_id)
+        if food_name:
+            entry["name"] = str(food_name)
+        if "name" not in entry:
+            if "id" in entry:
+                entry["name"] = str(entry["id"])
+            else:
+                entry["name"] = key
+
+        with self._lock:
+            if self._data.get(key) == entry:
+                return False
+            self._data[key] = entry
+            self._write_locked()
+        return True
+
+
+class VisionRecognizer:
+    """Lightweight helper to resolve OCR text using the cached labels."""
+
+    def __init__(self, labels_cache: Optional[LabelsCache] = None) -> None:
+        self.labels_cache = labels_cache or LabelsCache()
+        self._last_raw_text: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    def recognize(
+        self,
+        *,
+        image_path: Optional[str] = None,
+        weight: Optional[float] = None,
+        ocr_text: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        del image_path  # Reserved for future use
+        self._last_raw_text = ocr_text or None
+        if not ocr_text:
+            return None
+
+        cached = self.labels_cache.lookup(ocr_text)
+        if not cached:
+            return None
+
+        result: Dict[str, Any] = {
+            "name": cached.get("name") or ocr_text,
+            "grams": float(weight or 0.0),
+            "source": "vision-cache",
+            "ocr_text": ocr_text,
+            "normalized_text": cached.get("normalized") or normalize_text(ocr_text),
+        }
+        if cached.get("id") is not None:
+            result["food_id"] = cached.get("id")
+        return result
+
+    # ------------------------------------------------------------------
+    def record_correction(
+        self,
+        raw_text: Optional[str],
+        *,
+        food_id: Optional[Any] = None,
+        food_name: Optional[str] = None,
+    ) -> bool:
+        if not raw_text:
+            return False
+        return self.labels_cache.update(raw_text, food_id=food_id, food_name=food_name)
+
+    # ------------------------------------------------------------------
+    @property
+    def last_raw_text(self) -> Optional[str]:
+        return self._last_raw_text

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { printf '[SMOKE] %s\n' "$*"; }
+warn() { printf '[WARN ] %s\n' "$*"; }
+info() { printf '[INFO ] %s\n' "$*"; }
+err() { printf '[ERR  ] %s\n' "$*"; }
+
+if command -v systemctl >/dev/null 2>&1; then
+  for svc in bascula-app bascula-web bascula-net-fallback; do
+    if systemctl list-unit-files "${svc}.service" >/dev/null 2>&1; then
+      if ! systemctl is-enabled --quiet "${svc}.service"; then
+        err "${svc}.service no está habilitado"
+        exit 1
+      fi
+      if ! systemctl is-active --quiet "${svc}.service"; then
+        err "${svc}.service no está activo"
+        systemctl status "${svc}.service" --no-pager || true
+        exit 1
+      fi
+    else
+      warn "${svc}.service no encontrado"
+    fi
+  done
+else
+  warn "systemctl no disponible; se omiten comprobaciones de servicios"
+fi
+
+if [[ ! -f /etc/default/bascula ]]; then
+  warn "/etc/default/bascula no encontrado; usando puerto por defecto"
+fi
+
+# shellcheck disable=SC1091
+[[ -f /etc/default/bascula ]] && source /etc/default/bascula
+PORT="${BASCULA_MINIWEB_PORT:-${BASCULA_WEB_PORT:-8080}}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  err "curl no disponible; no se puede comprobar /health"
+  exit 1
+fi
+
+log "Verificando mini-web en puerto ${PORT}"
+curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null
+
+if command -v libcamera-hello >/dev/null 2>&1; then
+  libcamera-hello --version >/dev/null 2>&1 || warn "libcamera-hello falló"
+else
+  info "libcamera-hello no instalado"
+fi
+
+if command -v zbarimg >/dev/null 2>&1; then
+  zbarimg --version >/dev/null 2>&1 || warn "zbarimg falló"
+else
+  info "zbarimg no instalado"
+fi
+
+if command -v tesseract >/dev/null 2>&1; then
+  tesseract --version >/dev/null 2>&1 || warn "tesseract falló"
+else
+  info "tesseract no instalado"
+fi
+
+if command -v speaker-test >/dev/null 2>&1; then
+  speaker-test -t sine -l 1 >/dev/null 2>&1 || warn "speaker-test falló"
+elif command -v aplay >/dev/null 2>&1; then
+  aplay -l >/dev/null 2>&1 || warn "aplay falló"
+else
+  info "No se encontró speaker-test ni aplay"
+fi
+
+echo "SMOKE OK"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -7,7 +7,14 @@ def test_install_script_protects_optional_directories() -> None:
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "install-2-app.sh"
     script_text = script_path.read_text(encoding="utf-8")
 
-    required_excludes = {"--exclude '/assets'", "--exclude '/voices-v1'", "--exclude '/ota'"}
+    required_excludes = {
+        "--exclude '/assets'",
+        "--exclude '/voices-v1'",
+        "--exclude '/ota'",
+        "--exclude '/models'",
+        "--exclude '/userdata'",
+        "--exclude '/config'",
+    }
 
     found = False
     start = 0

--- a/tests/test_recognizer_labels.py
+++ b/tests/test_recognizer_labels.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from recognizer.vision import LabelsCache, VisionRecognizer, normalize_text
+
+
+def test_normalize_text_strips_punctuation() -> None:
+    assert normalize_text("  Café, listo! ") == "cafe listo"
+    assert normalize_text("HELLO-WORLD") == "hello world"
+
+
+def test_labels_cache_persists(monkeypatch, tmp_path: Path) -> None:
+    labels_path = tmp_path / "labels.json"
+    monkeypatch.setenv("BASCULA_LABELS_PATH", str(labels_path))
+
+    cache = LabelsCache()
+    assert labels_path.exists()
+    assert cache.lookup("Manzana") is None
+
+    cache.update("Manzana", food_id=42, food_name="Manzana Roja")
+    entry = cache.lookup("  manzana   ")
+    assert entry is not None
+    assert entry["id"] == "42"
+    assert entry["name"] == "Manzana Roja"
+
+    cache_bis = LabelsCache(path=labels_path)
+    entry_bis = cache_bis.lookup("MANZÁNA!!!")
+    assert entry_bis is not None
+    assert entry_bis["name"] == "Manzana Roja"
+
+    monkeypatch.delenv("BASCULA_LABELS_PATH", raising=False)
+
+
+def test_vision_recognizer_uses_cache(tmp_path: Path) -> None:
+    labels_path = tmp_path / "labels.json"
+    cache = LabelsCache(path=labels_path)
+    cache.update("Leche entera", food_id="abc", food_name="Leche Entera")
+
+    recognizer = VisionRecognizer(labels_cache=cache)
+    result = recognizer.recognize(weight=120, ocr_text="Leché entera!!")
+    assert result is not None
+    assert result["name"] == "Leche Entera"
+    assert result["source"] == "vision-cache"
+    assert result["grams"] == 120
+    assert result["food_id"] == "abc"
+
+    recognizer.record_correction("Yogurt", food_id="y1", food_name="Yogurt Natural")
+    correction = cache.lookup("yogurt")
+    assert correction is not None
+    assert correction["name"] == "Yogurt Natural"


### PR DESCRIPTION
## Summary
- keep OTA deployments from overwriting shared models, userdata and config while creating a persistent labels cache file
- add an OCR labels cache with recognizer helpers that surface cached hits and store user corrections from the UI
- provide a tolerant smoke test script and regression tests for the new label cache utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0059df99c8326aace2ea036d84db1