### PR TITLE
Fix alarmd mock environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,6 @@ alarmd-mock:
 	  cleanup() { kill $$MOCK_PID 2>/dev/null || true; }; \
 	  trap cleanup EXIT INT TERM; \
 	  sleep 1; \
-	  BASCULA_SHARED="$$SHARED" \
-	  BASCULA_RUNTIME_DIR="$$RUNTIME" \
-	  BASCULA_NIGHTSCOUT_URL="http://127.0.0.1:$${PORT}" \
-	  python3 -m bascula.services.alarmd --min-interval $${MIN_INTERVAL:-5} --max-interval $${MAX_INTERVAL:-10} --verbose;'
+          BASCULA_SHARED="$$SHARED" BASCULA_RUNTIME_DIR="$$RUNTIME" BASCULA_NIGHTSCOUT_URL="http://127.0.0.1:$${PORT}" \
+          python3 -m bascula.services.alarmd --min-interval $${MIN_INTERVAL:-5} --max-interval $${MAX_INTERVAL:-10} --verbose;'
 

--- a/bascula/services/alarmd.py
+++ b/bascula/services/alarmd.py
@@ -416,6 +416,12 @@ def main() -> None:
         raise SystemExit("Intervalo mínimo no puede ser mayor que el máximo")
 
     env = _load_environment()
+    log.info(
+        "alarmd env: SHARED=%s, RUNTIME_DIR=%s, NS_URL=%s",
+        env.get("BASCULA_SHARED"),
+        env.get("BASCULA_RUNTIME_DIR"),
+        env.get("BASCULA_NIGHTSCOUT_URL"),
+    )
     config = AlarmConfig.from_sources(env)
     event_path = _runtime_event_path(env)
     snooze_path = _snooze_state_path(env)


### PR DESCRIPTION
## Summary
- ensure the `alarmd-mock` make target forwards mock Nightscout environment variables to the alarmd process
- log the alarmd environment configuration at startup to aid debugging

## Testing
- make alarmd-mock MIN_INTERVAL=1 MAX_INTERVAL=1


------
https://chatgpt.com/codex/tasks/task_e_68d011aa4f5483269dd5578adb2a1a5c