### PR TITLE
Add QA checklist and integration tests for Stage-5 baseline validation

### DIFF
--- a/docs/QA_CHECKLIST.md
+++ b/docs/QA_CHECKLIST.md
@@ -1,0 +1,101 @@
+# QA Checklist · STAGE-5 (Validación Baseline Pi 5)
+
+Este checklist asegura que la rama actual mantiene paridad funcional con la baseline del **06‑Sep‑2025**. Está pensado para ejecutarse en una **Raspberry Pi 5** con la báscula instalada.
+
+## 1. Preparación
+
+1. Actualiza el repositorio y dependencias:
+   ```bash
+   cd ~/bascula-cam
+   git pull
+   make venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. Reinicia servicios para partir de un estado limpio:
+   ```bash
+   sudo systemctl restart bascula-ui.service bascula-web.service bascula-recognizer.service
+   ```
+3. Verifica que el smoke test básico siga funcionando:
+   ```bash
+   ./scripts/smoke.sh
+   ```
+   Debe finalizar en «OK» sin errores.
+
+## 2. UI «Nuevo plato → Añadir → Tabla → Resumen»
+
+1. Conecta pantalla/ratón o usa VNC.
+2. Desde la UI principal selecciona **Nuevo plato**.
+3. Añade dos ingredientes ficticios (usa cámara o introduce peso simulado si no hay sensor):
+   - Verifica que cada ingrediente aparezca en la tabla con peso y macros.
+   - Comprueba que el botón **Resumen** muestre totales y el desglose nutricional.
+4. Guarda como favorito y confirma que aparece en la lista de recetas/favoritos.
+5. Captura de pantalla: vista de la tabla y del resumen (se adjuntan al informe de QA).
+
+## 3. Reconocimiento (local + GPT)
+
+### 3.1 Con token válido y red disponible
+1. Asegúrate de tener conectividad (`ping 8.8.8.8`).
+2. Coloca un alimento conocido frente a la cámara.
+3. Comprueba en la UI que:
+   - Se muestra el resultado del modelo local.
+   - Tras la llamada a GPT (ver logs en `/var/log/bascula/recognizer.log`) se refine la descripción.
+
+### 3.2 Sin token / sin red (fallback manual)
+1. Renombra temporalmente la API Key:
+   ```bash
+   mv ~/.config/bascula/apikey.json ~/.config/bascula/apikey.json.bak
+   sudo systemctl restart bascula-recognizer.service
+   ```
+2. Repite el flujo de reconocimiento:
+   - La UI debe mostrar solo el resultado local y ofrecer edición manual.
+   - Confirma que **no** se bloquea la interfaz.
+3. Restaura la API Key al finalizar.
+
+## 4. Recetas y favoritos
+
+1. Desde la UI, abre **Recetas** y verifica que las existentes cargan correctamente.
+2. Genera una receta nueva (conexión activa) y guarda como favorita.
+3. Desconecta la red y abre de nuevo la sección para asegurar que las recetas guardadas se muestran desde cache local.
+4. Comprueba en disco que `~/.config/bascula/recipes.jsonl` contiene el nuevo registro.
+
+## 5. Mini-web + fallback AP
+
+1. En la Pi ejecuta:
+   ```bash
+   sudo systemctl status bascula-web.service
+   curl -sSf http://127.0.0.1:8080/health
+   ```
+   Debe devolver `{ "ok": true }`.
+2. Desde otro dispositivo en la misma LAN accede a `http://<IP_Pi>:8080/` e inicia sesión con el PIN mostrado en la UI.
+3. Verifica las acciones:
+   - Guardar API Key (usar una clave de prueba).
+   - Actualizar Nightscout y parámetros de bolo.
+   - Comprobar que `/api/status` muestra `api_key_present: true` tras guardar la clave.
+4. Simula caída de red doméstica para probar modo AP:
+   - Desactiva Wi‑Fi doméstico (`nmcli radio wifi off`).
+   - Reinicia `bascula-ap.service` si aplica y conéctate a `Bascula_AP`.
+   - Accede a `http://10.42.0.1:8080/` y repite el flujo anterior.
+
+## 6. Logs de verificación rápida
+
+Revisa que no aparezcan errores críticos tras las pruebas:
+```bash
+sudo journalctl -u bascula-ui.service -u bascula-web.service -u bascula-recognizer.service --since "-30 min"
+```
+
+## 7. Pruebas automatizadas ligeras
+
+1. Ejecuta los tests sin hardware real:
+   ```bash
+   source ~/bascula-cam/.venv/bin/activate
+   pytest tests/test_miniweb.py tests/test_recipes_steps.py
+   ```
+   Deben pasar todos los casos.
+2. (Opcional) Ejecuta la batería completa:
+   ```bash
+   pytest
+   ```
+
+> Guarda capturas relevantes (UI tabla/resumen, mini-web, modo AP) en `docs/screenshots/QA-<fecha>.png` y adjúntalas en el informe.
+

--- a/tests/test_miniweb.py
+++ b/tests/test_miniweb.py
@@ -1,0 +1,93 @@
+import importlib
+import pathlib
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def miniweb(tmp_path, monkeypatch):
+    """Load the mini-web module using a temporary config directory."""
+
+    cfg_dir = tmp_path / "cfg"
+    monkeypatch.setenv("BASCULA_CFG_DIR", str(cfg_dir))
+    monkeypatch.setenv("BASCULA_MINIWEB_PORT", "8081")
+    monkeypatch.setenv("BASCULA_WEB_HOST", "127.0.0.1")
+
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+
+    module_name = "bascula.services.wifi_config"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    module = importlib.import_module(module_name)
+    module.app.config.update(TESTING=True)
+    return module
+
+
+@pytest.fixture()
+def client(miniweb):
+    client = miniweb.app.test_client()
+    client.environ_base["REMOTE_ADDR"] = "127.0.0.1"
+    return client
+
+
+def test_health_endpoint_ok(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}
+
+
+def test_status_requires_auth_without_local(monkeypatch, miniweb):
+    client = miniweb.app.test_client()
+    client.environ_base["REMOTE_ADDR"] = "198.51.100.10"
+    response = client.get("/api/status")
+    assert response.status_code == 401
+    payload = response.get_json()
+    assert payload["error"] == "auth"
+
+
+def test_status_allows_local_requests(client):
+    response = client.get("/api/status")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload == {"ok": True, "api_key_present": False}
+
+
+def test_apikey_roundtrip(client, miniweb):
+    payload = {"key": "sk-test-12345678901234567890"}
+    response = client.post("/api/apikey", json=payload)
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    assert miniweb.API_FILE.exists()
+    data = miniweb.API_FILE.read_text(encoding="utf-8")
+    assert "sk-test-12345678901234567890" in data
+
+
+def test_bolus_update_and_fetch(client, miniweb):
+    update = {"tbg": 120, "isf": 45, "carb": 12, "dia": 5}
+    resp = client.post("/api/bolus", json=update)
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    fetched = client.get("/api/bolus")
+    assert fetched.status_code == 200
+    data = fetched.get_json()
+    assert data["ok"] is True
+    assert data["data"]["tbg"] == 120
+    assert data["data"]["isf"] == 45
+    assert data["data"]["carb"] == 12
+    assert data["data"]["dia"] == 5
+
+
+def test_nightscout_store_and_load(client):
+    payload = {"url": "https://ns.example.com", "token": "abc123"}
+    resp = client.post("/api/nightscout", json=payload)
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+    fetched = client.get("/api/nightscout")
+    assert fetched.status_code == 200
+    data = fetched.get_json()
+    assert data["ok"] is True
+    assert data["data"] == payload

--- a/tests/test_recipes_steps.py
+++ b/tests/test_recipes_steps.py
@@ -28,3 +28,38 @@ def test_coerce_steps_timer_string():
         {"text": "Hornear", "timer": "90s"},
     ])
     assert result == [{"text": "Hornear", "timer_s": 90}]
+
+
+def test_generate_recipe_without_api_returns_dummy(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    recipe = recipe_service.generate_recipe("ensalada", servings=3)
+    assert recipe["servings"] == 3
+    assert recipe["ingredients"]
+    assert recipe["steps"]
+
+
+def test_generate_recipe_sanitizes_remote_payload(monkeypatch):
+    def fake_request(prompt, servings):
+        assert prompt == "pollo"
+        assert servings == 2
+        return {
+            "title": "Pollo test",
+            "servings": 4,
+            "steps": [
+                {"instruction": "Preparar", "timer": "01:30"},
+                "Servir",
+            ],
+            "ingredients": [
+                {"name": "Pollo", "grams": "100", "kcal": "200"},
+                {"name": "Aceite", "grams": 10, "kcal": 90},
+            ],
+            "totals": {"grams": "110"},
+            "tts": "Listo",
+        }
+
+    monkeypatch.setattr(recipe_service, "_request_openai", fake_request)
+    recipe = recipe_service.generate_recipe("pollo", servings=2)
+    assert recipe["title"] == "Pollo test"
+    assert recipe["servings"] == 4
+    assert recipe["steps"][0]["timer_s"] == 90
+    assert recipe["totals"]["grams"] == 110.0


### PR DESCRIPTION
## Summary
- add a detailed Pi 5 Stage-5 validation checklist covering UI, recognition, recipes, and mini-web flows
- add integration-style mini-web tests that exercise auth, API key storage, bolus config, and Nightscout endpoints
- extend recipe service tests to cover dummy fallback generation and sanitisation of remote payloads

## Testing
- pytest tests/test_miniweb.py tests/test_recipes_steps.py

------
https://chatgpt.com/codex/tasks/task_e_68d012b0d99c8326b2bb5a85916d966f