### PR TITLE
Prevent partial UI initialization when dependencies are missing

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -42,12 +42,15 @@ try:
     log = logging.getLogger(__name__)
     log.info("Imports básicos OK")
 except ImportError as e:
+    # Mantenemos el mensaje informativo que se mostraba antes, pero no
+    # continuamos con la importación parcial. Dejar el módulo en un estado
+    # medio inicializado provocaba NameError posteriores (por ejemplo,
+    # AppState no definido) y el servicio systemd terminaba con "exit-code".
+    # Al relanzar la excepción permitimos que main.py capture el error de
+    # importación original y lo registre de forma clara, facilitando el
+    # diagnóstico de dependencias faltantes.
     print(f"Error importando módulos UI: {e}")
-    import logging
-    logging.basicConfig(level=logging.INFO)
-    log = logging.getLogger(__name__)
-    LabelsCache = None  # type: ignore
-    VisionRecognizer = None  # type: ignore
+    raise
 
 # === BACKEND SERIE ===
 ScaleService = None


### PR DESCRIPTION
## Summary
- raise UI import errors instead of leaving the module partially initialised, avoiding subsequent NameError crashes
- document why the import error is re-raised so systemd reports the real missing dependency

## Testing
- python3 main.py

------
https://chatgpt.com/codex/tasks/task_e_68d0203eab348326861ac14d32f4deac