### PR TITLE
Ensure required groups exist before adding user

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -197,6 +197,11 @@ if [[ ! -f "${LAST_CRASH}" ]]; then
   chmod 0644 "${LAST_CRASH}"
 fi
 
+for grp in video render input; do
+  if ! getent group "${grp}" >/dev/null 2>&1; then
+    groupadd "${grp}" || true
+  fi
+done
 usermod -aG video,render,input "${TARGET_USER}" || true
 loginctl enable-linger "${TARGET_USER}" || true
 

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -198,6 +198,13 @@ if [[ "${PHASE:-all}" != "2" ]]; then
 
 # Añade el usuario al grupo 'video' (acceso a /dev/video* y /dev/dri/*)
   if [[ "${SKIP_INSTALL_ALL_GROUPS:-0}" != "1" ]]; then
+    for grp in video render input; do
+      if ! getent group "$grp" >/dev/null 2>&1; then
+        groupadd "$grp" || true
+        log "Created missing group '$grp'"
+      fi
+    done
+
     if ! id -nG "$TARGET_USER" | tr ' ' '\n' | grep -qx "video"; then
       usermod -aG video "$TARGET_USER" || true
       log "Added $TARGET_USER to 'video' group"


### PR DESCRIPTION
## Summary
- ensure install-2-app creates the video, render and input groups before assigning them to the runtime user
- make install-all resilient by creating the required groups during provisioning and logging when they are created

## Testing
- bash -n scripts/install-2-app.sh
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68d02591eb348326a631690698a64d79