### PR TITLE
Improve XDG runtime handling for UI startup

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -213,6 +213,8 @@ install -D -m 0755 "${ROOT_DIR}/scripts/recovery_wifi.sh" /opt/bascula/current/s
 bash "${ROOT_DIR}/scripts/safe_run.sh"
 
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-app.service" /etc/systemd/system/bascula-app.service
+systemctl daemon-reload
+systemctl restart bascula-app.service || true
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service" /etc/systemd/system/bascula-web.service
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-net-fallback.service" /etc/systemd/system/bascula-net-fallback.service
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-alarmd.service" /etc/systemd/system/bascula-alarmd.service

--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -23,17 +23,15 @@ cd "${APP_DIR}"
 export DISPLAY=:0
 
 uid="$(id -u)"
-XDG_DIR="/run/user/${uid}"
-export XDG_RUNTIME_DIR="${XDG_DIR}"
-if [[ ! -d "${XDG_DIR}" ]]; then
-  if ! install -d -m 0700 "${XDG_DIR}"; then
-    echo "[run-ui] No se pudo preparar ${XDG_DIR}" >&2
-    exit 1
+if [ -z "${XDG_RUNTIME_DIR:-}" ] || [ ! -w "${XDG_RUNTIME_DIR:-/dev/null}" ]; then
+  if [ -d "/run/bascula-xdg" ] && [ -w "/run/bascula-xdg" ]; then
+    export XDG_RUNTIME_DIR="/run/bascula-xdg"
+  else
+    fallback="/tmp/bascula-xdg-${uid}"
+    mkdir -p -m 0700 "$fallback" 2>/dev/null || true
+    export XDG_RUNTIME_DIR="$fallback"
   fi
-fi
-
-if [[ $(stat -c %U "${XDG_DIR}" 2>/dev/null || echo "") != "$(id -un)" ]]; then
-  echo "[run-ui] Advertencia: ${XDG_DIR} pertenece a otro usuario" >&2
+  echo "[run-ui] XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR} (fallback)" >&2
 fi
 
 if [[ ! -d .venv ]]; then

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -15,6 +15,10 @@ User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
 EnvironmentFile=/etc/default/bascula
+# Para Xorg rootless y sockets de runtime
+RuntimeDirectory=bascula-xdg
+RuntimeDirectoryMode=0700
+Environment=XDG_RUNTIME_DIR=/run/bascula-xdg
 ExecStartPre=/bin/bash -c 'if [ -f /boot/bascula-recovery ]; then echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; fi'
 ExecStartPre=/bin/bash -c 'if [ -f /opt/bascula/shared/userdata/force_recovery ]; then echo "Flag force_recovery detectada" >&2; exit 1; fi'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg


### PR DESCRIPTION
## Summary
- make run-ui.sh tolerant to missing /run/user/$UID by reusing the systemd-provided runtime directory or falling back to /tmp
- provision a private runtime directory from systemd for the UI service and export it via XDG_RUNTIME_DIR
- reload systemd and restart bascula-app.service immediately after installing the updated unit in install-2-app.sh

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d11097671883269c112d41a6ed777e