### PR TITLE
Avoid double tare subtraction in scale service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ El driver `bascula/core/scale_serial.py` autodetecta puerto y baudios utilizando
 2. Configuración YAML: `~/.bascula/config.yaml`, sección `scale:` (`device`, `baud`, `cmd_tare`, `cmd_zero`).
 3. Puertos comunes: `/dev/serial0`, `/dev/ttyAMA0`, `/dev/ttyS0`, `/dev/ttyUSB*`, `/dev/ttyACM*` y lista de baudios `[115200, 57600, 38400, 19200, 9600, 4800]`.
 
+Para firmwares sin soporte de tara/cero por comando se puede forzar el cálculo en el host exportando `BASCULA_SCALE_HOST_TARE=1`. En ese modo no se envían comandos `TARE`/`ZERO` al dispositivo y los ajustes se aplican con los datos crudos recibidos.
+
 Para diagnosticar la conexión en la Raspberry Pi:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a host tare mode toggle so the firmware handles tare/zero by default
- keep the latest raw sample and introduce a noise tolerance before clamping to zero
- document the BASCULA_SCALE_HOST_TARE variable in the README

## Testing
- pytest *(fails: missing pyserial dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11a6ebf0483268bd2712e818218d0