### PR TITLE
feat: add AI food scanner workflow

### DIFF
--- a/bascula/domain/food_items.py
+++ b/bascula/domain/food_items.py
@@ -1,0 +1,58 @@
+"""Dataclasses representing recognized food entries."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import time
+import uuid
+
+
+@dataclass
+class FoodItem:
+    id: str
+    name: str
+    weight_g: float
+    carbs_g: Optional[float]
+    protein_g: Optional[float]
+    fat_g: Optional[float]
+    gi: Optional[int]
+    source: str
+    ts: float
+
+    @staticmethod
+    def new_id() -> str:
+        return uuid.uuid4().hex
+
+    @classmethod
+    def from_ai(cls, weight_g: float, data: dict) -> "FoodItem":
+        name = str(data.get("name") or "Desconocido").strip() or "Desconocido"
+        def _num(key: str):
+            value = data.get(key)
+            try:
+                return round(float(value), 2)
+            except Exception:
+                return None
+
+        def _gi() -> Optional[int]:
+            value = data.get("gi")
+            try:
+                if value in (None, ""):
+                    return None
+                return max(0, min(110, int(value)))
+            except Exception:
+                return None
+
+        return cls(
+            id=data.get("id") or cls.new_id(),
+            name=name,
+            weight_g=float(weight_g or 0.0),
+            carbs_g=_num("carbs_g"),
+            protein_g=_num("protein_g"),
+            fat_g=_num("fat_g"),
+            gi=_gi(),
+            source=str(data.get("source") or "unknown"),
+            ts=float(data.get("ts") or time.time()),
+        )
+
+
+__all__ = ["FoodItem"]

--- a/bascula/services/nutrition_ai.py
+++ b/bascula/services/nutrition_ai.py
@@ -1,0 +1,286 @@
+"""Food recognition via OpenAI with local fallback heuristics."""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import random
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore
+
+try:  # pragma: no cover - compatibility with legacy SDK
+    import openai as openai_legacy  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    openai_legacy = None  # type: ignore
+
+
+class NutritionAIError(RuntimeError):
+    """Base exception for AI food analysis failures."""
+
+
+class NutritionAIAuthError(NutritionAIError):
+    """Raised when the OpenAI API key is invalid."""
+
+
+class NutritionAIServiceError(NutritionAIError):
+    """Raised when the remote AI service is unavailable."""
+
+
+_SYSTEM_PROMPT = (
+    "Eres un asistente nutricional. Recibirás una imagen de comida y el peso en gramos. "
+    "Devuelve un JSON con estos campos obligatorios: name (string), carbs_g (float), "
+    "protein_g (float), fat_g (float), gi (entero 0-110) y confidence (float entre 0 y 1). "
+    "Si no puedes estimar un valor, usa null. No incluyas texto adicional."
+)
+
+_JSON_FIELDS = ("name", "carbs_g", "protein_g", "fat_g", "gi", "confidence", "source")
+
+
+def analyze_food(image_bytes: bytes, weight_g: float) -> Dict[str, Any]:
+    """Analyze a food picture and estimate its macros.
+
+    Returns a dictionary with the schema ``{name, carbs_g, protein_g, fat_g, gi, confidence, source}``.
+    When OpenAI is not available or disabled the function falls back to a lightweight heuristic.
+    """
+
+    weight = float(weight_g or 0.0)
+    if weight < 0:
+        weight = 0.0
+
+    key = os.getenv("OPENAI_API_KEY", "").strip()
+    client = _build_client(key)
+
+    if client is None:
+        return _local_stub(weight)
+
+    payload = _prepare_payload(image_bytes, weight)
+    attempts = 0
+    last_error: Optional[Exception] = None
+    while attempts < 3:
+        attempts += 1
+        try:
+            raw = _invoke_openai(client, payload, timeout=10.0)
+            return _parse_response(raw)
+        except NutritionAIAuthError:
+            raise
+        except NutritionAIServiceError as exc:
+            last_error = exc
+            break
+        except TimeoutError as exc:
+            last_error = exc
+            break
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Fallo analizando alimento (intento %s): %s", attempts, exc)
+            last_error = exc
+            time.sleep(0.5 * attempts)
+
+    if isinstance(last_error, (NutritionAIServiceError, TimeoutError)):
+        raise NutritionAIServiceError("Servicio de IA no disponible") from last_error
+
+    logger.warning("Fallo persistente en IA, usando heurística local: %s", last_error)
+    return _local_stub(weight)
+
+
+def _build_client(key: str):
+    if not key:
+        return None
+    if OpenAI is not None:
+        try:
+            return OpenAI(api_key=key, timeout=10.0)
+        except TypeError:
+            return OpenAI(api_key=key)
+        except Exception as exc:  # pragma: no cover - optional dependency issues
+            logger.warning("OpenAI SDK no disponible: %s", exc)
+    if openai_legacy is not None:
+        openai_legacy.api_key = key
+        return openai_legacy
+    return None
+
+
+def _prepare_payload(image_bytes: bytes, weight: float) -> Dict[str, Any]:
+    encoded = base64.b64encode(image_bytes or b"").decode("ascii") if image_bytes else ""
+    return {
+        "weight": round(weight, 2),
+        "image_b64": encoded,
+    }
+
+
+def _invoke_openai(client, payload: Dict[str, Any], *, timeout: float) -> str:
+    image_b64 = payload.get("image_b64")
+    weight = payload.get("weight", 0)
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": _SYSTEM_PROMPT}],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "Peso en báscula: %.2f g. Identifica los alimentos en la imagen y "
+                        "estima macronutrientes para este peso total." % float(weight)
+                    ),
+                },
+            ],
+        },
+    ]
+    if image_b64:
+        messages[1]["content"].append(
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"},
+            }
+        )
+
+    try:
+        if OpenAI is not None and isinstance(client, OpenAI):
+            response = client.responses.create(
+                model="gpt-4o-mini",
+                input=messages,
+                max_output_tokens=400,
+                temperature=0.1,
+                response_format={"type": "json_object"},
+                timeout=timeout,
+            )
+            return _extract_text_from_response(response)
+        if openai_legacy is not None and client is openai_legacy:
+            response = openai_legacy.ChatCompletion.create(  # type: ignore[attr-defined]
+                model="gpt-4o-mini",
+                messages=messages,
+                temperature=0.1,
+                max_tokens=400,
+                timeout=timeout,
+            )
+            return response["choices"][0]["message"]["content"]  # type: ignore[index]
+    except Exception as exc:
+        _handle_openai_exception(exc)
+    raise NutritionAIServiceError("Servicio de IA no disponible")
+
+
+def _extract_text_from_response(response: Any) -> str:
+    try:
+        parts = []
+        for item in getattr(response, "output", []) or []:
+            if getattr(item, "type", "") == "output_text":
+                for segment in getattr(item, "content", []) or []:
+                    if getattr(segment, "type", "") == "output_text":
+                        parts.append(getattr(segment, "text", ""))
+                    elif isinstance(segment, dict):
+                        parts.append(str(segment.get("text", "")))
+            elif isinstance(item, dict) and item.get("type") == "output_text":
+                parts.append(str(item.get("text", "")))
+        if parts:
+            return "\n".join(p for p in parts if p)
+        # SDK <=1.1 compatibility
+        if getattr(response, "choices", None):
+            return response.choices[0].message["content"]  # type: ignore[index]
+    except Exception:
+        pass
+    return str(getattr(response, "output_text", ""))
+
+
+def _handle_openai_exception(exc: Exception) -> None:
+    status = None
+    try:
+        status = getattr(exc, "status_code", None)
+    except Exception:
+        status = None
+    if status is None:
+        try:
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+        except Exception:
+            status = None
+    if status in (401, 403):
+        raise NutritionAIAuthError("Clave de OpenAI inválida. Revisa Ajustes → Red/IA.") from exc
+    if status in (429,) or (isinstance(status, int) and status >= 500):
+        raise NutritionAIServiceError("Servicio de IA no disponible") from exc
+    if isinstance(exc, TimeoutError):
+        raise TimeoutError("Servicio de IA no disponible") from exc
+    raise NutritionAIServiceError("Servicio de IA no disponible") from exc
+
+
+def _parse_response(text: str) -> Dict[str, Any]:
+    try:
+        data = json.loads(text or "{}")
+    except Exception:
+        logger.debug("Respuesta IA no válida: %s", text)
+        return {"name": "Desconocido", "carbs_g": None, "protein_g": None, "fat_g": None, "gi": None, "confidence": None, "source": "ai_incomplete"}
+
+    result: Dict[str, Any] = {}
+    missing = False
+    for field in _JSON_FIELDS:
+        value = data.get(field)
+        if field == "name":
+            result[field] = str(value).strip() if isinstance(value, str) else "Desconocido"
+            if not result[field]:
+                missing = True
+        elif field in {"carbs_g", "protein_g", "fat_g"}:
+            try:
+                result[field] = round(float(value), 2)
+            except Exception:
+                result[field] = None
+                missing = True
+        elif field == "gi":
+            try:
+                gi_val = int(value)
+            except Exception:
+                gi_val = None
+            if gi_val is None:
+                result[field] = None
+                missing = True
+            else:
+                result[field] = max(0, min(110, gi_val))
+        elif field == "confidence":
+            try:
+                conf = float(value)
+                if conf > 1:
+                    conf = conf / 100.0
+            except Exception:
+                conf = None
+            if conf is None:
+                missing = True
+            else:
+                conf = max(0.0, min(1.0, conf))
+            result[field] = conf
+        elif field == "source":
+            result[field] = str(value or "openai")
+
+    if missing:
+        result["source"] = "ai_incomplete"
+    return result
+
+
+def _local_stub(weight: float) -> Dict[str, Any]:
+    weight = max(0.0, float(weight or 0.0))
+    base = max(1.0, weight)
+    carbs = round(base * random.uniform(0.08, 0.16), 2)
+    protein = round(base * random.uniform(0.05, 0.12), 2)
+    fat = round(base * random.uniform(0.02, 0.08), 2)
+    gi = int(random.uniform(40, 65))
+    return {
+        "name": "Estimación local",
+        "carbs_g": carbs,
+        "protein_g": protein,
+        "fat_g": fat,
+        "gi": gi,
+        "confidence": 0.25,
+        "source": "local_stub",
+    }
+
+
+__all__ = [
+    "analyze_food",
+    "NutritionAIError",
+    "NutritionAIAuthError",
+    "NutritionAIServiceError",
+]

--- a/bascula/services/tts.py
+++ b/bascula/services/tts.py
@@ -1,0 +1,102 @@
+"""Lightweight Piper TTS wrapper used by the UI."""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PiperTTS:
+    """Small non-blocking wrapper around the Piper binary."""
+
+    def __init__(self, model: Optional[str] = None, speaker: Optional[str] = None) -> None:
+        self._piper_bin = shutil.which(os.getenv("PIPER_BIN", "piper"))
+        voice_env = os.getenv("PIPER_MODEL") or os.getenv("PIPER_VOICE")
+        self._model_path = model or voice_env or self._default_voice()
+        self._speaker = speaker or os.getenv("PIPER_SPEAKER")
+
+        if not self._piper_bin:
+            logger.info("Piper no encontrado en PATH; TTS deshabilitado")
+        elif not self._model_path:
+            logger.info("Modelo de Piper no configurado; establece PIPER_MODEL")
+
+    # ------------------------------------------------------------------
+    def speak(self, text: str) -> None:
+        self.speak_text(text)
+
+    def speak_text(self, text: str) -> None:
+        if not text:
+            return
+        if not self._piper_bin or not self._model_path:
+            logger.debug("TTS omitido: Piper no configurado")
+            return
+
+        threading.Thread(target=self._run, args=(text,), daemon=True).start()
+
+    # ------------------------------------------------------------------
+    def _run(self, text: str) -> None:
+        try:
+            with tempfile.NamedTemporaryFile(prefix="piper-", suffix=".wav", delete=False) as tmp:
+                wav_path = Path(tmp.name)
+            cmd = [self._piper_bin, "--model", self._model_path, "--output_file", str(wav_path)]
+            if self._speaker:
+                cmd.extend(["--speaker", self._speaker])
+            proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                stdin = text.strip().encode("utf-8")
+                proc.communicate(stdin, timeout=25)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                raise RuntimeError("Piper timeout")
+            if proc.returncode != 0:
+                raise RuntimeError(f"Piper devolvió {proc.returncode}")
+
+            player = shutil.which(os.getenv("PIPER_PLAYER", "aplay")) or shutil.which("paplay")
+            if player:
+                subprocess.Popen(
+                    [player, str(wav_path)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            else:
+                logger.debug("No se encontró reproductor para Piper")
+        except Exception as exc:  # pragma: no cover - optional audio chain
+            logger.warning("No se pudo reproducir TTS: %s", exc)
+        finally:
+            try:
+                if 'wav_path' in locals() and wav_path.exists():
+                    # Pequeña demora para permitir que el reproductor abra el archivo
+                    time.sleep(0.2)
+                    wav_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    def _default_voice(self) -> Optional[str]:
+        candidates = [
+            Path("/usr/share/piper/voices"),
+            Path.home() / "piper",
+            Path.home() / ".local/share/piper",
+        ]
+        for base in candidates:
+            if not base.exists():
+                continue
+            for path in base.glob("*.onnx"):
+                return str(path)
+        return None
+
+
+__all__ = ["PiperTTS"]

--- a/bascula/ui/views/food_scanner.py
+++ b/bascula/ui/views/food_scanner.py
@@ -1,0 +1,420 @@
+"""Interactive food scanner view using camera + AI recognition."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Dict, List, Optional
+
+from ...domain.food_items import FoodItem
+from ...services.nutrition_ai import (
+    NutritionAIAuthError,
+    NutritionAIError,
+    NutritionAIServiceError,
+    analyze_food,
+)
+from ..theme_neo import COLORS, SPACING, font_sans
+
+logger = logging.getLogger(__name__)
+
+
+class FoodScannerView(tk.Toplevel):
+    """Toplevel window that orchestrates camera capture and AI analysis."""
+
+    def __init__(self, controller, scale, camera=None, tts=None) -> None:
+        super().__init__(controller.root if hasattr(controller, "root") else controller)
+        self.title("Escáner de alimentos")
+        self.configure(bg=COLORS["bg"], padx=SPACING["lg"], pady=SPACING["lg"])
+        self.transient(controller.root if hasattr(controller, "root") else controller)
+        self.resizable(False, False)
+
+        self.controller = controller
+        self.scale = scale
+        self.camera = camera
+        self.tts = tts
+
+        self._current_weight: float = 0.0
+        self._stable: bool = False
+        self._items: Dict[str, FoodItem] = {}
+        self._busy = False
+
+        self._weight_var = tk.StringVar(value="0.0 g")
+        self._stable_var = tk.StringVar(value="Inestable")
+        self._status_var = tk.StringVar(value="")
+        self._totals_var = tk.StringVar(value="Carbs: 0 g · Proteínas: 0 g · Grasas: 0 g · GI medio: -")
+
+        self._build_layout()
+
+        self.protocol("WM_DELETE_WINDOW", self._on_close)
+        try:
+            self.scale.subscribe(self._on_scale_update)
+        except Exception:
+            logger.debug("No se pudo suscribir a la báscula")
+        self.after(100, self._update_weight_label)
+        try:
+            self.grab_set()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    def _build_layout(self) -> None:
+        header = tk.Frame(self, bg=COLORS["bg"])
+        header.pack(fill="x", pady=(0, SPACING["md"]))
+        tk.Label(
+            header,
+            text="Peso en vivo",
+            font=font_sans(24, "bold"),
+            fg=COLORS["text"],
+            bg=COLORS["bg"],
+        ).pack(anchor="w")
+
+        weight_frame = tk.Frame(self, bg=COLORS["surface"], padx=SPACING["lg"], pady=SPACING["lg"], bd=0)
+        weight_frame.pack(fill="x", pady=(0, SPACING["md"]))
+        tk.Label(
+            weight_frame,
+            textvariable=self._weight_var,
+            font=font_sans(48, "bold"),
+            fg=COLORS["primary"],
+            bg=COLORS["surface"],
+        ).pack(side="left")
+        tk.Label(
+            weight_frame,
+            textvariable=self._stable_var,
+            font=font_sans(16, "bold"),
+            fg=COLORS["muted"],
+            bg=COLORS["surface"],
+            padx=SPACING["lg"],
+        ).pack(side="right")
+
+        actions = tk.Frame(self, bg=COLORS["bg"])
+        actions.pack(fill="x", pady=(0, SPACING["md"]))
+        self._recognize_btn = tk.Button(
+            actions,
+            text="📷 Reconocer",
+            font=font_sans(18, "bold"),
+            command=self._handle_recognize,
+            bg=COLORS["primary"],
+            fg=COLORS["bg"],
+            activebackground=COLORS["primary"],
+            activeforeground=COLORS["text"],
+            relief="flat",
+            padx=SPACING["md"],
+            pady=SPACING["sm"],
+        )
+        self._recognize_btn.pack(side="left")
+
+        self._status_label = tk.Label(
+            actions,
+            textvariable=self._status_var,
+            font=font_sans(12),
+            fg=COLORS["muted"],
+            bg=COLORS["bg"],
+        )
+        self._status_label.pack(side="right")
+
+        table_frame = tk.Frame(self, bg=COLORS["bg"])
+        table_frame.pack(fill="both", expand=True)
+
+        columns = ("name", "weight", "carbs", "protein", "fat", "gi")
+        self._tree = ttk.Treeview(
+            table_frame,
+            columns=columns,
+            show="headings",
+            height=8,
+        )
+        self._tree.heading("name", text="Alimento")
+        self._tree.heading("weight", text="Peso (g)")
+        self._tree.heading("carbs", text="Carbs (g)")
+        self._tree.heading("protein", text="Proteínas (g)")
+        self._tree.heading("fat", text="Grasas (g)")
+        self._tree.heading("gi", text="GI")
+        self._tree.column("name", width=200, anchor="w")
+        for key in columns[1:]:
+            self._tree.column(key, width=100, anchor="center")
+
+        scrollbar = ttk.Scrollbar(table_frame, orient="vertical", command=self._tree.yview)
+        self._tree.configure(yscrollcommand=scrollbar.set)
+        self._tree.grid(row=0, column=0, sticky="nsew")
+        scrollbar.grid(row=0, column=1, sticky="ns")
+        table_frame.grid_columnconfigure(0, weight=1)
+        table_frame.grid_rowconfigure(0, weight=1)
+
+        totals = tk.Label(
+            self,
+            textvariable=self._totals_var,
+            font=font_sans(14, "bold"),
+            fg=COLORS["text"],
+            bg=COLORS["bg"],
+            pady=SPACING["sm"],
+        )
+        totals.pack(fill="x")
+
+        footer = tk.Frame(self, bg=COLORS["bg"])
+        footer.pack(fill="x", pady=(SPACING["md"], 0))
+        tk.Button(
+            footer,
+            text="Eliminar seleccionado",
+            command=self._handle_remove,
+            font=font_sans(14, "bold"),
+            bg=COLORS["surface"],
+            fg=COLORS["text"],
+            relief="flat",
+            padx=SPACING["md"],
+            pady=SPACING["sm"],
+        ).pack(side="left")
+        tk.Button(
+            footer,
+            text="Terminar",
+            command=self._handle_finish,
+            font=font_sans(16, "bold"),
+            bg=COLORS["primary"],
+            fg=COLORS["bg"],
+            relief="flat",
+            padx=SPACING["lg"],
+            pady=SPACING["sm"],
+        ).pack(side="right")
+
+    # ------------------------------------------------------------------
+    def _on_scale_update(self, weight: float, stable: bool) -> None:
+        self._current_weight = float(weight)
+        self._stable = bool(stable)
+        try:
+            self.after(0, self._update_weight_label)
+        except Exception:
+            pass
+
+    def _update_weight_label(self) -> None:
+        self._weight_var.set(f"{self._current_weight:.1f} g")
+        self._stable_var.set("Estable" if self._stable else "Inestable")
+
+    # ------------------------------------------------------------------
+    def _handle_recognize(self) -> None:
+        if self._busy:
+            return
+        if not self.camera or not getattr(self.camera, "available", lambda: False)():
+            messagebox.showerror("Cámara", "Cámara no disponible")
+            return
+        weight = self._current_weight
+        if weight <= 0:
+            messagebox.showinfo("Reconocer", "Coloca alimento en la báscula antes de reconocer")
+            return
+
+        self._busy = True
+        self._recognize_btn.configure(state="disabled")
+        self._set_status("Capturando imagen…")
+
+        def worker() -> None:
+            result = None
+            error: Optional[str] = None
+            try:
+                try:
+                    if hasattr(self.camera, "set_mode"):
+                        self.camera.set_mode("foodshot")
+                except Exception:
+                    pass
+                jpeg, _thumb = self.camera.capture_snapshot()
+                result = analyze_food(jpeg, weight)
+            except NutritionAIAuthError as exc:
+                error = str(exc)
+            except NutritionAIServiceError as exc:
+                error = str(exc)
+            except TimeoutError:
+                error = "La captura tardó demasiado"
+            except NutritionAIError as exc:
+                error = str(exc)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Reconocimiento falló: %s", exc)
+                error = f"No se pudo reconocer: {exc}"
+
+            def done() -> None:
+                self._busy = False
+                self._recognize_btn.configure(state="normal")
+                if error:
+                    self._set_status(error, error=True)
+                    return
+                if result is None:
+                    self._set_status("Sin datos de IA", error=True)
+                    return
+                item = FoodItem.from_ai(weight, {**result, "ts": time.time()})
+                self._items[item.id] = item
+                self._tree.insert(
+                    "",
+                    "end",
+                    iid=item.id,
+                    values=(
+                        item.name,
+                        f"{item.weight_g:.1f}",
+                        _fmt(item.carbs_g),
+                        _fmt(item.protein_g),
+                        _fmt(item.fat_g),
+                        item.gi if item.gi is not None else "-",
+                    ),
+                )
+                self._set_status(f"{item.name} añadido ({item.source})")
+                self._update_totals()
+
+            try:
+                self.after(0, done)
+            except Exception:
+                pass
+
+        threading.Thread(target=worker, name="FoodRecognize", daemon=True).start()
+
+    # ------------------------------------------------------------------
+    def _handle_remove(self) -> None:
+        selected = list(self._tree.selection())
+        if not selected:
+            return
+        for iid in selected:
+            self._tree.delete(iid)
+            self._items.pop(iid, None)
+        self._update_totals()
+        self._set_status("Elemento eliminado")
+
+    def _handle_finish(self) -> None:
+        if not self._items:
+            messagebox.showinfo("Resumen", "No hay alimentos reconocidos aún")
+            return
+        totals = self._compute_totals()
+        SummaryDialog(self, totals, list(self._items.values()))
+        self._speak_summary(totals)
+
+    def _speak_summary(self, totals: Dict[str, Optional[float]]) -> None:
+        lines = []
+        carbs = totals.get("carbs")
+        protein = totals.get("protein")
+        fat = totals.get("fat")
+        gi = totals.get("gi")
+        if carbs is not None:
+            lines.append(f"Carbohidratos {carbs:.1f} gramos")
+        if protein is not None:
+            lines.append(f"Proteínas {protein:.1f} gramos")
+        if fat is not None:
+            lines.append(f"Grasas {fat:.1f} gramos")
+        if gi is not None:
+            lines.append(f"Índice glucémico medio {gi:.0f}")
+        if not lines:
+            return
+        text = ", ".join(lines)
+        try:
+            if self.tts and hasattr(self.tts, "speak_text"):
+                self.tts.speak_text(text)
+            elif self.tts and hasattr(self.tts, "speak"):
+                self.tts.speak(text)
+        except Exception:
+            logger.debug("No se pudo reproducir resumen TTS")
+
+    # ------------------------------------------------------------------
+    def _compute_totals(self) -> Dict[str, Optional[float]]:
+        carbs = sum(item.carbs_g or 0.0 for item in self._items.values())
+        protein = sum(item.protein_g or 0.0 for item in self._items.values())
+        fat = sum(item.fat_g or 0.0 for item in self._items.values())
+        gi_values = [item.gi for item in self._items.values() if item.gi is not None]
+        gi_avg = (sum(gi_values) / len(gi_values)) if gi_values else None
+        return {
+            "carbs": carbs,
+            "protein": protein,
+            "fat": fat,
+            "gi": gi_avg,
+        }
+
+    def _update_totals(self) -> None:
+        totals = self._compute_totals()
+        gi_text = f"{totals['gi']:.0f}" if totals["gi"] is not None else "-"
+        self._totals_var.set(
+            "Carbs: {0:.1f} g · Proteínas: {1:.1f} g · Grasas: {2:.1f} g · GI medio: {3}".format(
+                totals["carbs"], totals["protein"], totals["fat"], gi_text
+            )
+        )
+
+    def _set_status(self, text: str, *, error: bool = False) -> None:
+        self._status_var.set(text)
+        self._status_label.configure(fg=COLORS["danger"] if error else COLORS["muted"])
+
+    # ------------------------------------------------------------------
+    def _on_close(self) -> None:
+        try:
+            self.scale.unsubscribe(self._on_scale_update)
+        except Exception:
+            pass
+        self.destroy()
+
+
+class SummaryDialog(tk.Toplevel):
+    """Simple overlay summarising totals and individual items."""
+
+    def __init__(self, parent, totals: Dict[str, Optional[float]], items: List[FoodItem]) -> None:
+        super().__init__(parent)
+        self.title("Resumen de alimentos")
+        self.configure(bg=COLORS["surface"], padx=SPACING["lg"], pady=SPACING["lg"])
+        self.resizable(False, False)
+        self.transient(parent)
+
+        tk.Label(
+            self,
+            text="Resumen nutricional",
+            font=font_sans(22, "bold"),
+            fg=COLORS["text"],
+            bg=COLORS["surface"],
+        ).pack(anchor="w", pady=(0, SPACING["md"]))
+
+        lines = [
+            f"Carbohidratos: {totals['carbs']:.1f} g",
+            f"Proteínas: {totals['protein']:.1f} g",
+            f"Grasas: {totals['fat']:.1f} g",
+            f"GI medio: {totals['gi']:.0f}" if totals["gi"] is not None else "GI medio: -",
+        ]
+        for line in lines:
+            tk.Label(
+                self,
+                text=line,
+                font=font_sans(16, "bold"),
+                fg=COLORS["text"],
+                bg=COLORS["surface"],
+            ).pack(anchor="w")
+
+        if items:
+            tk.Label(
+                self,
+                text="Detalle",
+                font=font_sans(18, "bold"),
+                fg=COLORS["muted"],
+                bg=COLORS["surface"],
+                pady=SPACING["sm"],
+            ).pack(anchor="w")
+            for item in items:
+                desc = (
+                    f"• {item.name} · {item.weight_g:.1f} g · "
+                    f"C:{_fmt(item.carbs_g)} g · P:{_fmt(item.protein_g)} g · "
+                    f"G:{_fmt(item.fat_g)} g · GI {item.gi if item.gi is not None else '-'}"
+                )
+                tk.Label(
+                    self,
+                    text=desc,
+                    font=font_sans(14),
+                    fg=COLORS["text"],
+                    bg=COLORS["surface"],
+                ).pack(anchor="w")
+
+        tk.Button(
+            self,
+            text="Cerrar",
+            command=self.destroy,
+            font=font_sans(14, "bold"),
+            bg=COLORS["primary"],
+            fg=COLORS["bg"],
+            relief="flat",
+            padx=SPACING["md"],
+            pady=SPACING["sm"],
+        ).pack(pady=(SPACING["md"], 0), anchor="e")
+
+
+def _fmt(value: Optional[float]) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):.1f}"
+
+
+__all__ = ["FoodScannerView", "SummaryDialog"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 pyserial>=3.5
 PyYAML>=6.0
 pillow>=9.4
+picamera2>=0.3 ; platform_machine == "aarch64"
 requests>=2.31
 tomli-w>=1.0.0
 
@@ -13,6 +14,7 @@ werkzeug>=3.0
 python-dotenv>=1.0
 uvicorn>=0.23
 pydantic>=2.6
+openai>=1.30
 
 # Imaging, OCR, and barcode helpers
 qrcode[pil]>=7.4


### PR DESCRIPTION
## Summary
- add Picamera2 snapshot helper that returns JPEG and thumbnail with timeout handling
- introduce nutrition AI service with OpenAI integration and local fallback plus FoodItem model
- implement Tk food scanner view with totals, summary dialog, and Piper TTS wrapper

## Testing
- pytest *(fails: missing optional dependency pyserial)*
- python -m compileall bascula


------
https://chatgpt.com/codex/tasks/task_e_68d11f339f40832694c93c47176116fc