### PR TITLE
Implement OTA workflow and recovery failover

### DIFF
--- a/bascula/recovery/app.py
+++ b/bascula/recovery/app.py
@@ -94,7 +94,7 @@ class RecoveryApp:
 
         self._make_button(
             grid,
-            text="Reintentar aplicación",
+            text="Reintentar",
             command=self._retry_app,
             row=0,
             column=0,
@@ -102,7 +102,7 @@ class RecoveryApp:
         )
         self._make_button(
             grid,
-            text="Actualizar",
+            text="Actualizar OTA",
             command=self._run_update,
             row=0,
             column=1,

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -224,10 +224,13 @@ install -D -m 0755 "${ROOT_DIR}/scripts/recovery_xsession.sh" /opt/bascula/curre
 install -D -m 0755 "${ROOT_DIR}/scripts/recovery_retry.sh" /opt/bascula/current/scripts/recovery_retry.sh
 install -D -m 0755 "${ROOT_DIR}/scripts/recovery_update.sh" /opt/bascula/current/scripts/recovery_update.sh
 install -D -m 0755 "${ROOT_DIR}/scripts/recovery_wifi.sh" /opt/bascula/current/scripts/recovery_wifi.sh
+install -D -m 0755 "${ROOT_DIR}/scripts/ota.sh" /opt/bascula/current/scripts/ota.sh
+install -D -m 0755 "${ROOT_DIR}/scripts/record_app_failure.sh" /opt/bascula/current/scripts/record_app_failure.sh
 
 bash "${ROOT_DIR}/scripts/safe_run.sh"
 
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-app.service" /etc/systemd/system/bascula-app.service
+install -D -m 0644 "${ROOT_DIR}/systemd/bascula-app-failure@.service" /etc/systemd/system/bascula-app-failure@.service
 install -D -m 0644 "${ROOT_DIR}/systemd/bascula-web.service" /etc/systemd/system/bascula-web.service
 sctl daemon-reload                    # CRÍTICO: si systemd está activo y falla, aborta
 # habilita/arranca servicios (CRÍTICO si hay systemd)

--- a/scripts/ota.sh
+++ b/scripts/ota.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  exec sudo -E OTA_SOURCE="${OTA_SOURCE:-}" bash "$0" "$@"
+fi
+
+LOG_DIR="/var/log/bascula"
+LOG_FILE="${LOG_DIR}/ota.log"
+mkdir -p "${LOG_DIR}"
+: "${OTA_SOURCE:=}"
+
+if ! touch "${LOG_FILE}" >/dev/null 2>&1; then
+  echo "[ota] No se pudo abrir ${LOG_FILE}" >&2
+  exit 1
+fi
+
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+log() {
+  local ts
+  ts="$(date --iso-8601=seconds 2>/dev/null || date)"
+  printf '[ota][%s] %s\n' "${ts}" "$*"
+}
+
+fail() {
+  log "ERROR: $*"
+  return 1
+}
+
+usage() {
+  cat <<'USAGE'
+Uso: ota.sh [fuente]
+  fuente puede ser:
+    - Ruta a un archivo .tar.gz/.tgz/.tar/.zip
+    - Ruta a un directorio con el contenido de la release
+    - URL http(s) a un archivo comprimido
+  Si no se especifica, se utilizará la variable OTA_SOURCE.
+USAGE
+}
+
+SOURCE="${1:-${OTA_SOURCE}}"
+if [[ -z "${SOURCE}" ]]; then
+  usage >&2
+  exit 1
+fi
+
+BASCULA_ROOT="/opt/bascula"
+RELEASES_DIR="${BASCULA_ROOT}/releases"
+CURRENT_LINK="${BASCULA_ROOT}/current"
+SHARED_DIR="${BASCULA_ROOT}/shared"
+FORCE_FLAG="${BASCULA_ROOT}/shared/userdata/force_recovery"
+FAIL_COUNT_FILE="${BASCULA_ROOT}/shared/userdata/app_fail_count"
+
+if [[ -f /etc/default/bascula ]]; then
+  # shellcheck disable=SC1091
+  source /etc/default/bascula
+fi
+BASCULA_USER="${BASCULA_USER:-pi}"
+BASCULA_GROUP="${BASCULA_GROUP:-${BASCULA_USER}}"
+
+have_systemd() {
+  command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]
+}
+
+stop_services() {
+  if have_systemd; then
+    systemctl stop bascula-app.service bascula-web.service bascula-recovery.service >/dev/null 2>&1 || true
+  fi
+}
+
+start_services() {
+  if have_systemd; then
+    systemctl daemon-reload || true
+    systemctl reset-failed bascula-app.service bascula-web.service >/dev/null 2>&1 || true
+    systemctl start bascula-web.service || true
+    systemctl start bascula-app.service || true
+  fi
+}
+
+wait_for_service() {
+  local unit="$1" timeout="$2" elapsed=0
+  if ! have_systemd; then
+    return 0
+  fi
+  while (( elapsed < timeout )); do
+    if systemctl is-active --quiet "$unit"; then
+      return 0
+    fi
+    sleep 1
+    ((elapsed++))
+  done
+  return 1
+}
+
+check_web_health() {
+  local url="${HEALTH_URL:-http://127.0.0.1:8080/health}" attempts=30
+  if ! command -v curl >/dev/null 2>&1; then
+    log "curl no disponible para healthcheck"
+    return 0
+  fi
+  for ((i=1; i<=attempts; i++)); do
+    if curl -fsS --max-time 5 "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+TMP_DIR=""
+STAGING_DIR=""
+NEW_RELEASE_DIR=""
+PREVIOUS_RELEASE=""
+
+cleanup() {
+  if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+prepare_staging() {
+  local src="$1"
+  TMP_DIR="$(mktemp -d)"
+  local work="${TMP_DIR}/work"
+  mkdir -p "${work}"
+
+  if [[ "$src" =~ ^https?:// ]]; then
+    local archive="${TMP_DIR}/package"
+    log "Descargando release desde ${src}"
+    if command -v curl >/dev/null 2>&1; then
+      if ! curl -fL --retry 3 --retry-delay 2 -o "${archive}" "$src"; then
+        fail "Descarga falló desde ${src}" || return 1
+      fi
+    elif command -v wget >/dev/null 2>&1; then
+      if ! wget -O "${archive}" "$src"; then
+        fail "Descarga falló desde ${src}" || return 1
+      fi
+    else
+      fail "No se encontró curl ni wget para descargar" || return 1
+    fi
+    src="${archive}"
+  fi
+
+  if [[ -f "$src" ]]; then
+    log "Extrayendo ${src}"
+    if ! tar -xaf "$src" -C "${work}" 2>/dev/null; then
+      if command -v unzip >/dev/null 2>&1; then
+        if ! unzip -q "$src" -d "${work}"; then
+          fail "No se pudo extraer el archivo ${src}" || return 1
+        fi
+      else
+        fail "No se pudo extraer el archivo ${src}" || return 1
+      fi
+    fi
+  elif [[ -d "$src" ]]; then
+    log "Copiando contenido desde directorio ${src}"
+    rsync -a "$src"/ "${work}"/ || {
+      fail "No se pudo copiar el directorio ${src}" || return 1
+    }
+  else
+    fail "Fuente ${src} no encontrada" || return 1
+  fi
+
+  local first
+  first="$(find "${work}" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+  if [[ -n "$first" ]]; then
+    STAGING_DIR="$first"
+  else
+    STAGING_DIR="${work}"
+  fi
+}
+
+ensure_shared_links() {
+  local release_dir="$1" name dest shared_path
+  install -d -m 0755 -o "${BASCULA_USER}" -g "${BASCULA_GROUP}" "${SHARED_DIR}" || true
+  for name in assets voices-v1 ota models userdata config; do
+    shared_path="${SHARED_DIR}/${name}"
+    dest="${release_dir}/${name}"
+    install -d -m 0755 -o "${BASCULA_USER}" -g "${BASCULA_GROUP}" "${shared_path}" || true
+    if [[ -e "${dest}" && ! -L "${dest}" ]]; then
+      rm -rf "${dest}"
+    fi
+    if [[ ! -e "${dest}" ]]; then
+      ln -s "${shared_path}" "${dest}"
+    fi
+  done
+}
+
+migrate_venv() {
+  local old_release="$1" new_release="$2"
+  if [[ -d "${old_release}/.venv" && ! -e "${new_release}/.venv" ]]; then
+    log "Migrando entorno virtual desde release anterior"
+    rsync -a "${old_release}/.venv/" "${new_release}/.venv/" || {
+      fail "No se pudo migrar el entorno virtual" || return 1
+    }
+  fi
+}
+
+update_requirements() {
+  local release_dir="$1" pip_bin="${release_dir}/.venv/bin/pip"
+  if [[ -x "${pip_bin}" && -f "${release_dir}/requirements.txt" ]]; then
+    log "Actualizando dependencias"
+    if ! PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_ROOT_USER_ACTION=ignore PIP_PREFER_BINARY=1 \
+      "${pip_bin}" install --upgrade -r "${release_dir}/requirements.txt"; then
+      fail "pip install falló" || return 1
+    fi
+  fi
+  return 0
+}
+
+reset_failure_state() {
+  rm -f "${FORCE_FLAG}" "${FAIL_COUNT_FILE}" 2>/dev/null || true
+}
+
+rollback() {
+  local new_dir="$1"
+  log "Iniciando rollback"
+  stop_services
+  if [[ -n "${PREVIOUS_RELEASE}" ]]; then
+    ln -sfn "${PREVIOUS_RELEASE}" "${CURRENT_LINK}"
+    log "Restaurado enlace a ${PREVIOUS_RELEASE}"
+    start_services
+  fi
+  if [[ -n "${new_dir}" && -d "${new_dir}" ]]; then
+    mv "${new_dir}" "${new_dir}.failed" 2>/dev/null || rm -rf "${new_dir}" || true
+  fi
+}
+
+main() {
+  prepare_staging "${SOURCE}"
+  install -d -m 0755 "${RELEASES_DIR}"
+  local timestamp
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  NEW_RELEASE_DIR="${RELEASES_DIR}/${timestamp}"
+  log "Creando release ${NEW_RELEASE_DIR}"
+  install -d -m 0755 "${NEW_RELEASE_DIR}"
+
+  local rsync_rc=0
+  rsync -a --delete \
+    --exclude '.git' \
+    --exclude '.venv' \
+    --exclude '__pycache__' \
+    --exclude '*.pyc' \
+    --exclude 'shared/models' \
+    --exclude 'shared/userdata' \
+    --exclude 'shared/config' \
+    "${STAGING_DIR}/" "${NEW_RELEASE_DIR}/" || rsync_rc=$?
+  if [[ ${rsync_rc} -ne 0 && ${rsync_rc} -ne 23 && ${rsync_rc} -ne 24 ]]; then
+    fail "rsync falló con código ${rsync_rc}" || return 1
+  fi
+
+  PREVIOUS_RELEASE="$(readlink -f "${CURRENT_LINK}" 2>/dev/null || true)"
+  if [[ -n "${PREVIOUS_RELEASE}" ]]; then
+    migrate_venv "${PREVIOUS_RELEASE}" "${NEW_RELEASE_DIR}"
+  fi
+
+  if [[ ! -x "${NEW_RELEASE_DIR}/.venv/bin/python" ]]; then
+    log "Creando nuevo entorno virtual"
+    python3 -m venv "${NEW_RELEASE_DIR}/.venv" || {
+      fail "python -m venv falló" || return 1
+    }
+  fi
+
+  ensure_shared_links "${NEW_RELEASE_DIR}"
+
+  chown -R "${BASCULA_USER}:${BASCULA_GROUP}" "${NEW_RELEASE_DIR}"
+
+  update_requirements "${NEW_RELEASE_DIR}" || return 1
+
+  stop_services
+  ln -sfn "${NEW_RELEASE_DIR}" "${CURRENT_LINK}"
+  log "/opt/bascula/current -> ${NEW_RELEASE_DIR}"
+  reset_failure_state
+  start_services
+
+  if ! wait_for_service bascula-web.service 40; then
+    fail "bascula-web.service no se activó" || return 1
+  fi
+  if ! wait_for_service bascula-app.service 60; then
+    fail "bascula-app.service no se activó" || return 1
+  fi
+  if ! check_web_health; then
+    fail "Healthcheck de bascula-web falló" || return 1
+  fi
+  log "Healthcheck web OK"
+  log "OTA completada exitosamente"
+}
+
+if ! main; then
+  rc=$?
+  log "OTA falló (rc=${rc})"
+  rollback "${NEW_RELEASE_DIR}"
+  exit "$rc"
+fi
+
+exit 0

--- a/scripts/record_app_failure.sh
+++ b/scripts/record_app_failure.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+UNIT="${FAIL_UNIT:-${1:-bascula-app.service}}"
+THRESHOLD="${FAIL_THRESHOLD:-3}"
+if ! [[ "${THRESHOLD}" =~ ^[0-9]+$ ]]; then
+  THRESHOLD=3
+fi
+
+BASCULA_ROOT="/opt/bascula"
+SHARED_DIR="${BASCULA_ROOT}/shared"
+USERDATA_DIR="${SHARED_DIR}/userdata"
+COUNT_FILE="${USERDATA_DIR}/app_fail_count"
+FORCE_FLAG="${USERDATA_DIR}/force_recovery"
+LAST_CRASH_FILE="${USERDATA_DIR}/last_crash.json"
+LOG_DIR="/var/log/bascula"
+
+if [[ -f /etc/default/bascula ]]; then
+  # shellcheck disable=SC1091
+  source /etc/default/bascula
+fi
+BASCULA_USER="${BASCULA_USER:-pi}"
+BASCULA_GROUP="${BASCULA_GROUP:-${BASCULA_USER}}"
+
+install -d -m 0755 "${USERDATA_DIR}"
+install -d -m 0755 "${LOG_DIR}"
+
+count=0
+if [[ -f "${COUNT_FILE}" ]]; then
+  if read -r value < "${COUNT_FILE}" && [[ "${value}" =~ ^[0-9]+$ ]]; then
+    count="${value}"
+  fi
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" > "${COUNT_FILE}"
+chown "${BASCULA_USER}:${BASCULA_GROUP}" "${COUNT_FILE}" 2>/dev/null || true
+chmod 0644 "${COUNT_FILE}" 2>/dev/null || true
+
+timestamp="$(date --iso-8601=seconds 2>/dev/null || date)"
+result="$(systemctl show "${UNIT}" -p Result --value 2>/dev/null || echo 'unknown')"
+status="$(systemctl show "${UNIT}" -p ExecMainStatus --value 2>/dev/null || echo '')"
+current_release="$(readlink -f "${BASCULA_ROOT}/current" 2>/dev/null || echo '')"
+message="Fallo consecutivo ${count} en ${UNIT}"
+if [[ -n "${status}" && "${status}" != "0" ]]; then
+  message+=" (status=${status})"
+fi
+if [[ -n "${result}" && "${result}" != "success" ]]; then
+  message+=" (result=${result})"
+fi
+
+printf '[app-failure] %s\n' "${message}"
+
+printf '[%s] %s\n' "${timestamp}" "${message}" >> "${LOG_DIR}/app_failure.log"
+
+python3 - <<'PY' "${LAST_CRASH_FILE}" "${timestamp}" "${message}" "${result}" "${count}" "${current_release}" "${BASCULA_USER}" "${BASCULA_GROUP}"
+import json
+import os
+import sys
+
+path, timestamp, message, result, count, release, user, group = sys.argv[1:9]
+data = {
+    "timestamp": timestamp,
+    "message": message,
+    "error": result,
+    "failures": int(count),
+    "versions": {},
+}
+if release:
+    data["versions"]["app"] = release
+tmp_path = path + ".tmp"
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(tmp_path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, ensure_ascii=False)
+    fh.write("\n")
+os.replace(tmp_path, path)
+try:
+    import pwd, grp
+    os.chown(path, pwd.getpwnam(user).pw_uid, grp.getgrnam(group).gr_gid)
+except Exception:
+    pass
+os.chmod(path, 0o644)
+PY
+
+if (( count >= THRESHOLD )); then
+  printf '[app-failure] Umbral %s alcanzado (count=%s); activando recovery\n' "${THRESHOLD}" "${count}"
+  touch "${FORCE_FLAG}"
+  chown "${BASCULA_USER}:${BASCULA_GROUP}" "${FORCE_FLAG}" 2>/dev/null || true
+  chmod 0644 "${FORCE_FLAG}" 2>/dev/null || true
+fi
+
+exit 0

--- a/scripts/recovery_retry.sh
+++ b/scripts/recovery_retry.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 FORCE_FLAG="/opt/bascula/shared/userdata/force_recovery"
 BOOT_FLAG="/boot/bascula-recovery"
+FAIL_COUNT_FILE="/opt/bascula/shared/userdata/app_fail_count"
 HEALTH_URL="${HEALTH_URL:-http://127.0.0.1:8080/health}"
 WAIT_SECONDS=${WAIT_SECONDS:-30}
 
@@ -11,6 +12,11 @@ log() { printf '[recovery-retry] %s\n' "$*"; }
 if [[ -f "$FORCE_FLAG" ]]; then
   log "Eliminando bandera force_recovery"
   rm -f "$FORCE_FLAG"
+fi
+
+if [[ -f "$FAIL_COUNT_FILE" ]]; then
+  log "Reiniciando contador de fallos"
+  rm -f "$FAIL_COUNT_FILE"
 fi
 
 if [[ -f "$BOOT_FLAG" ]]; then

--- a/scripts/recovery_update.sh
+++ b/scripts/recovery_update.sh
@@ -1,85 +1,61 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR="${APP_DIR:-/opt/bascula/current}"
+OTA_SCRIPT="${OTA_SCRIPT:-/opt/bascula/current/scripts/ota.sh}"
 OTA_DIR="${OTA_DIR:-/opt/bascula/shared/ota}"
-TMP_DIR=""
 
 log() { printf '[recovery-update] %s\n' "$*"; }
-cleanup() {
-  if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
-    rm -rf "$TMP_DIR"
-  fi
-}
-trap cleanup EXIT
 
-ensure_dirs() {
-  install -d -m 0755 "$APP_DIR"
+detect_source() {
+  local latest_archive latest_dir
+  if [[ -d "${OTA_DIR}" ]]; then
+    latest_archive=$(find "${OTA_DIR}" -maxdepth 1 -type f \
+      \( -name '*.tar.gz' -o -name '*.tgz' -o -name '*.tar' -o -name '*.zip' \) \
+      -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n1 | awk '{print $2}')
+    latest_dir=$(find "${OTA_DIR}" -maxdepth 1 -mindepth 1 -type d -print -quit 2>/dev/null || true)
+  fi
+  if [[ -n "${latest_archive}" ]]; then
+    printf '%s' "${latest_archive}"
+    return 0
+  fi
+  if [[ -n "${latest_dir}" ]]; then
+    printf '%s' "${latest_dir}"
+    return 0
+  fi
+  return 1
 }
 
 select_source() {
-  local latest_archive latest_dir
-  if [[ -d "$OTA_DIR" ]]; then
-    latest_archive=$(find "$OTA_DIR" -maxdepth 1 -type f -name '*.tar.gz' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n1 | awk '{print $2}')
-    latest_dir=$(find "$OTA_DIR" -maxdepth 1 -mindepth 1 -type d -name 'latest*' -o -name 'release*' | head -n1)
-  fi
-
-  if [[ -n "$latest_archive" ]]; then
-    TMP_DIR="$(mktemp -d)"
-    log "Extrayendo ${latest_archive}"
-    tar -xzf "$latest_archive" -C "$TMP_DIR"
-    local first_dir
-    first_dir=$(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
-    if [[ -n "$first_dir" ]]; then
-      echo "$first_dir"
-      return 0
-    fi
-    echo "$TMP_DIR"
+  local source="${1:-}" fallback
+  if [[ -n "${source}" ]]; then
+    printf '%s' "${source}"
     return 0
   fi
-
-  if [[ -n "$latest_dir" ]]; then
-    echo "$latest_dir"
+  if fallback="$(detect_source)"; then
+    printf '%s' "${fallback}"
     return 0
   fi
-
-  if [[ -d "$OTA_DIR" ]]; then
-    echo "$OTA_DIR"
-    return 0
-  fi
-
   return 1
 }
 
 main() {
-  ensure_dirs
-  local src
-  if ! src=$(select_source); then
-    log "No se encontró paquete OTA en $OTA_DIR"
+  if [[ ! -x "${OTA_SCRIPT}" ]]; then
+    log "No se encontró ${OTA_SCRIPT}"
     exit 1
   fi
-  log "Sincronizando desde ${src}"
 
-  rsync -a --delete \
-    --exclude '.git' \
-    --exclude '.venv' \
-    --exclude '__pycache__' \
-    --exclude '*.pyc' \
-    --exclude 'shared/models' \
-    --exclude 'shared/userdata' \
-    --exclude 'shared/config' \
-    "$src"/ "$APP_DIR"/
+  local requested="${1:-${OTA_SOURCE:-}}" source
+  if ! source="$(select_source "${requested}")"; then
+    log "No se encontró paquete OTA en ${OTA_DIR}"
+    exit 1
+  fi
+  log "Utilizando fuente OTA: ${source}"
 
-  if [[ -x "$APP_DIR/.venv/bin/pip" && -f "$APP_DIR/requirements.txt" ]]; then
-    log "Actualizando dependencias"
-    "$APP_DIR/.venv/bin/pip" install --upgrade -r "$APP_DIR/requirements.txt"
+  if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+    exec sudo -E OTA_SOURCE="${source}" "${OTA_SCRIPT}" "${source}"
   fi
 
-  if command -v systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload || true
-  fi
-
-  log "Actualización finalizada"
+  exec "${OTA_SCRIPT}" "${source}"
 }
 
 main "$@"

--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -12,6 +12,7 @@ BOOT_FLAG="/boot/bascula-recovery"
 ALIVE="/run/bascula.alive"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-25}"
 MAX_HEARTBEAT_AGE="${MAX_HEARTBEAT_AGE:-12}"
+FAIL_COUNT_FILE="/opt/bascula/shared/userdata/app_fail_count"
 
 log() {
   printf '[safe_run] %s\n' "$*" >&2
@@ -51,6 +52,9 @@ while kill -0 "$app_pid" >/dev/null 2>&1; do
     last=$(stat -c %Y "$ALIVE" 2>/dev/null || echo 0)
     if (( last > 0 && now - last <= MAX_HEARTBEAT_AGE )); then
       health_ok=1
+      if [[ -f "$FAIL_COUNT_FILE" ]]; then
+        rm -f "$FAIL_COUNT_FILE" 2>/dev/null || true
+      fi
       break
     fi
   fi

--- a/systemd/bascula-app-failure@.service
+++ b/systemd/bascula-app-failure@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Registrar fallo consecutivo Báscula App (%i)
+After=network-online.target
+
+[Service]
+Type=oneshot
+Environment=FAIL_UNIT=%i
+ExecStart=/opt/bascula/current/scripts/record_app_failure.sh %i

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 ConditionPathExists=/etc/bascula/APP_READY
 Conflicts=getty@tty1.service
 Conflicts=bascula-recovery.service
-OnFailure=bascula-recovery.target
+OnFailure=bascula-app-failure@%n.service bascula-recovery.target
 StartLimitIntervalSec=120
 StartLimitBurst=3
 


### PR DESCRIPTION
## Summary
- add an OTA installer that stages releases under /opt/bascula/releases, updates the current symlink, runs health checks and performs automatic rollback on failure while logging to /var/log/bascula/ota.log
- introduce a systemd OnFailure handler and helper scripts to count consecutive bascula-app crashes, persist crash metadata and force recovery mode after repeated failures
- refresh recovery tooling to wire the new OTA script, reset failure counters on retries, and surface the recovery options requested in the UI

## Testing
- pytest *(fails: missing pyserial dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13aa3d4f48326be770326444a0bb5