### PR TITLE
Make Basculín avatar optional via settings toggle

### DIFF
--- a/bascula/ui/overlays/timer.py
+++ b/bascula/ui/overlays/timer.py
@@ -18,10 +18,10 @@ from bascula.ui.widgets import (
     FS_TITLE,
     bind_numeric_entry,
 )
+from bascula.ui.ui_config import CONFIG_PATH
 
 MAX_MINUTES = 120
 MAX_SECONDS = MAX_MINUTES * 60
-CONFIG_PATH = Path.home() / ".config" / "bascula" / "ui.toml"
 
 
 def _format_seconds(seconds: int) -> str:

--- a/bascula/ui/settings_tabs/tabs_general.py
+++ b/bascula/ui/settings_tabs/tabs_general.py
@@ -32,6 +32,27 @@ def add_tab(screen, notebook):
             pass
     ttk.Checkbutton(row_focus, text="UI simplificada con overlays", variable=var_focus, command=on_toggle_focus).pack(side='left', padx=8)
 
+    # Mascota mini opcional
+    row_masc = tk.Frame(inner, bg=COL_CARD)
+    row_masc.pack(fill='x', pady=6)
+    tk.Label(row_masc, text="Mascota:", bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 14)).pack(side='left')
+    try:
+        current_ui = screen.app.get_ui_cfg()
+    except Exception:
+        current_ui = {}
+    var_masc = tk.BooleanVar(value=bool(current_ui.get('show_mascota', False)))
+
+    def on_toggle_masc():
+        try:
+            state = bool(var_masc.get())
+            screen.app.set_mascota_enabled(state)
+            estado = "ON" if state else "OFF"
+            screen.toast.show(f"Mascota: {estado}", 900)
+        except Exception:
+            pass
+
+    ttk.Checkbutton(row_masc, text="Mostrar mascota", variable=var_masc, command=on_toggle_masc).pack(side='left', padx=8)
+
     # Sonido: toggle + tema + probar
     row1 = tk.Frame(inner, bg=COL_CARD)
     row1.pack(fill="x", pady=6)

--- a/bascula/ui/ui_config.py
+++ b/bascula/ui/ui_config.py
@@ -1,0 +1,72 @@
+"""Helpers to persist UI-specific options in ``ui.toml``.
+
+The legacy project mixes JSON configuration (``config.json``) with a
+secondary TOML file that stores lightweight UI preferences.  Several
+modules – the timer overlay, for instance – already read and update the
+``timer_last_seconds`` entry in that file using ad-hoc helpers.  This
+module centralises that logic so new features (like the optional mascot)
+can reuse a single implementation for loading and saving values.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_PATH = Path.home() / ".config" / "bascula" / "ui.toml"
+
+
+def _load_toml(text: str) -> Dict[str, Any]:
+    try:
+        import tomllib  # Python 3.11+
+
+        return tomllib.loads(text)
+    except ModuleNotFoundError:  # pragma: no cover - fallback for <3.11
+        import tomli  # type: ignore
+
+        return tomli.loads(text)
+
+
+def load_ui_config(path: Path = CONFIG_PATH) -> Dict[str, Any]:
+    """Return the parsed UI configuration or an empty dict on failure."""
+
+    try:
+        if path.exists():
+            return _load_toml(path.read_text(encoding="utf-8"))
+    except Exception:
+        pass
+    return {}
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    escaped = text.replace("\\", "\\\\").replace("\"", "\\\"")
+    return f'"{escaped}"'
+
+
+def dump_ui_config(data: Dict[str, Any], path: Path = CONFIG_PATH) -> None:
+    """Persist ``data`` to ``ui.toml`` keeping it human friendly."""
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        return
+
+    lines = [f"{key} = {_format_value(value)}" for key, value in sorted(data.items())]
+    try:
+        path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def set_ui_value(key: str, value: Any, path: Path = CONFIG_PATH) -> Dict[str, Any]:
+    """Convenience helper that updates one key and writes the file."""
+
+    data = load_ui_config(path)
+    data[key] = value
+    dump_ui_config(data, path)
+    return data


### PR DESCRIPTION
## Summary
- add a reusable UI TOML helper and wire BasculaAppTk to load/save UI prefs
- add a "Mostrar mascota" toggle in Ajustes → General that persists to ui.toml
- render a 50×50 MiniMascota avatar in the bottom-right corner when enabled and drive notifications through the TTS engine

## Testing
- pytest *(fails: missing optional dependency `pyserial` triggered script/test_serial.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d14069ff0c8326a783d215ea5a083f