### PR TITLE
docs: actualizar README y añadir ejemplos TOML

### DIFF
--- a/docs/examples/diabetes.toml
+++ b/docs/examples/diabetes.toml
@@ -1,0 +1,13 @@
+# Ejemplo de integración con Nightscout y asistente de bolo.
+url = "https://mi-nightscout.example.com"
+token = "coloca_aqui_api_secret"
+icr = 9.5
+isf = 45.0
+target = 105
+export_mode = "with_bolus"
+enable_bolus_assistant = true
+enable_1515 = true
+low_threshold = 75
+high_threshold = 180
+alarms_enabled = true
+announce_on_alarm = true

--- a/docs/examples/keys.toml
+++ b/docs/examples/keys.toml
@@ -1,0 +1,4 @@
+# Mantén este archivo con permisos 600: chmod 600 keys.toml
+[fatsecret]
+key = "fs_client_id"
+secret = "fs_client_secret"

--- a/docs/examples/scale.toml
+++ b/docs/examples/scale.toml
@@ -1,0 +1,10 @@
+# Ejemplo de configuración para la báscula serie.
+# Ajusta el puerto al ESP32 o convertidor USB-serial utilizado.
+port = "/dev/serial0"
+baud = 115200
+factor = 432.78
+decimals = 1
+density = 0.97
+offset = 0.0
+tare = 0.0
+mode = "device"

--- a/docs/examples/ui.toml
+++ b/docs/examples/ui.toml
@@ -1,0 +1,5 @@
+# Preferencias ligeras para la interfaz.
+show_mascota = true
+timer_last_seconds = 180
+units = "g"
+no_emoji = false


### PR DESCRIPTION
## Summary
- reescribir README con hardware recomendado, instalación paso a paso y flujos de uso
- documentar variables de entorno, mini-web, AP y procesos OTA
- añadir ejemplos de configuración TOML para báscula, diabetes, UI y credenciales FatSecret

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1478049c08326b3f607cb9276eef9