### PR TITLE
Fix Pillow install prerequisites and venv checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core runtime dependencies
 pyserial>=3.5
 PyYAML>=6.0
-pillow>=9.4
+Pillow>=10,<11
 picamera2>=0.3 ; platform_machine == "aarch64"
 requests>=2.31
 tomli-w>=1.0.0

--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -55,8 +55,8 @@ DEPS=(
   "$(resolve_package libzbar0 libzbar1)" zbar-tools
   # Python build
   python3-venv python3-pip python3-dev build-essential libffi-dev zlib1g-dev \
-  "$(resolve_package libjpeg-dev libjpeg62-turbo-dev)" libopenjp2-7 \
-  "$(resolve_package libtiff6 libtiff5)" libatlas-base-dev
+  libjpeg62-turbo-dev libopenjp2-7 libopenjp2-7-dev libtiff-dev libatlas-base-dev \
+  libfreetype6-dev liblcms2-dev libwebp-dev libwebpdemux2 tcl-dev tk-dev
   # Red
   network-manager rfkill
   # Miscelánea / CLI


### PR DESCRIPTION
## Summary
- bump Pillow requirement to 10.x and pin upper bound
- add native build dependencies needed by modern Pillow wheels
- ensure OTA virtualenv is owned by TARGET_USER and verify Pillow, NumPy, and OpenCV imports during install

## Testing
- bash -n scripts/install-1-system.sh
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1705d69f08326a95c155b75c4b9d3