### PR TITLE
Ensure critical runtime dependencies validated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,5 @@ opencv-python-headless>=4.7,<5 ; platform_machine == "aarch64"
 
 # Machine learning runtime
 numpy==2.*
-tflite-runtime==2.14.*
+tflite-runtime==2.14.0
 

--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -42,7 +42,8 @@ apt-get update
 # Paquetes base del sistema (toolchain, python build, OCR, X, cámara, audio, red, utilidades)
 DEPS=(
   # UI/X
-  xserver-xorg x11-xserver-utils xinit xserver-xorg-legacy unclutter python3-tk
+  xserver-xorg x11-xserver-utils xinit xserver-xorg-legacy unclutter
+  python3-tk
   mesa-utils "$(resolve_package libegl1 libegl1-mesa)" "$(resolve_package libgles2 libgles2-mesa)" \
     fonts-dejavu "$(resolve_package fonts-freefont-ttf fonts-freefont)"
   # Cámara

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -132,14 +132,10 @@ if [[ -x "${BASCULA_VENV_DIR}/bin/pip" ]]; then
   fi
 
   if [[ -f "${BASCULA_CURRENT}/requirements.txt" ]]; then
-    req_rc=0
-    pip install -r "${BASCULA_CURRENT}/requirements.txt" || req_rc=$?
-    if [[ ${req_rc} -ne 0 ]]; then
-      echo "[warn] pip install -r requirements.txt falló (rc=${req_rc}). Continuando para comprobar dependencias." >&2
-    fi
+    pip install -r "${BASCULA_CURRENT}/requirements.txt"
   fi
 
-  for pkg in "tflite-runtime==2.14.*" "opencv-python-headless>=4.8,<5"; do
+  for pkg in "tflite-runtime==2.14.0" "opencv-python-headless>=4.8,<5"; do
     pkg_name="${pkg%%[<=>]*}"
     if ! pip show "${pkg_name}" >/dev/null 2>&1; then
       if ! pip install --only-binary=:all: "${pkg}"; then
@@ -149,15 +145,21 @@ if [[ -x "${BASCULA_VENV_DIR}/bin/pip" ]]; then
     fi
   done
 
-  echo "[CHK] Verificando dependencias críticas..."
+  echo "[CHK] Verificando Flask, Pillow (PIL), NumPy, OpenCV, tflite_runtime y tkinter en el venv..."
   if ! python - <<'PY'
 try:
+    import flask; from flask import Flask
     from PIL import Image
     import numpy as np
     import cv2
+    import tflite_runtime.interpreter as tfl
+    import tkinter as tk
+    print("OK: flask", flask.__version__)
     print("OK: PIL", Image.__version__)
     print("OK: numpy", np.__version__)
     print("OK: cv2", cv2.__version__)
+    print("OK: tflite", tfl.__file__)
+    print("OK: tkinter", tk.TkVersion)
 except Exception as e:
     import sys, traceback
     print("ERR: Dependencias incompletas:", e, file=sys.stderr)


### PR DESCRIPTION
## Summary
- pin tflite-runtime to 2.14.0 in the Python requirements
- ensure python3-tk is explicitly installed during system phase 1 setup
- fail fast on pip install errors and extend virtualenv dependency checks to include Flask, OpenCV, TensorFlow Lite and Tkinter

## Testing
- bash -n scripts/install-1-system.sh
- bash -n scripts/install-2-app.sh

------
https://chatgpt.com/codex/tasks/task_e_68d17344784c83269ae1c0249fb8a62d