### PR TITLE
Restore recovery flag checks before launching UI

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -19,7 +19,9 @@ EnvironmentFile=/etc/default/bascula
 RuntimeDirectory=bascula-xdg
 RuntimeDirectoryMode=0700
 Environment=XDG_RUNTIME_DIR=/run/bascula-xdg
-ExecStartPre=
+ExecStartPre=/bin/bash -c 'if [ -f /boot/bascula-recovery ]; then echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; fi'
+ExecStartPre=/bin/bash -c 'if [ -f /opt/bascula/shared/userdata/force_recovery ]; then echo "Flag force_recovery detectada" >&2; exit 1; fi'
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
 ExecStart=/opt/bascula/current/scripts/run-ui.sh
 
 Restart=on-failure


### PR DESCRIPTION
## Summary
- reinstate systemd pre-start checks for recovery flags before launching the UI
- recreate the Xorg runtime directory pre-start step

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d190f2520c832698e17360cadfcbe1