### PR TITLE
Use APT picamera2/prctl packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 pyserial>=3.5
 PyYAML>=6.0
 Pillow>=10,<11
-picamera2>=0.3 ; platform_machine == "aarch64"
 requests>=2.31
 tomli-w>=1.0.0
 

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -42,7 +42,20 @@ if [[ -z "${TARGET_HOME}" ]]; then
 fi
 
 apt-get update
-apt-get install -y python3-venv python3-pip xinit python3-picamera2 libcamera-apps
+apt-get install -y \
+  python3-venv python3-pip xinit \
+  python3-picamera2 libcamera-apps \
+  python3-prctl libcap-dev
+
+python3 - <<'PY'
+try:
+    import picamera2
+    import prctl  # de python3-prctl
+    print("OK: picamera2 + prctl")
+except Exception as e:
+    print("ERR:", e)
+    raise SystemExit(1)
+PY
 
 install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" "${TARGET_HOME}/.config/bascula"
 


### PR DESCRIPTION
## Summary
- install Picamera2 and prctl via Debian packages during phase 2 setup and validate their imports
- rely on system Picamera2 package by removing the pip requirement entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2134dbca4832684bd926b33386307