### PR TITLE
Improve recovery handling and optional Piper extras

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -235,9 +235,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
-EnvironmentFile=-/etc/default/x735
-; Importante: systemd no expande ${..} en ExecStart. Usar bash -lc.
-ExecStart=/bin/bash -lc 'exec /usr/bin/python3 /opt/x735/x735-poweroff.py --threshold ${X735_POWER_OFF_MV:-5000}'
+ExecStart=/bin/bash -lc 'source /etc/default/x735 2>/dev/null; exec /usr/bin/python3 /opt/x735/x735-poweroff.py --threshold ${X735_POWER_OFF_MV:-5000}'
 Restart=always
 User=root
 Group=root

--- a/scripts/install-3-extras.sh
+++ b/scripts/install-3-extras.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log()  { printf "\033[1;34m[extras]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[warn ]\033[0m %s\n" "$*"; }
+err()  { printf "\033[1;31m[err  ]\033[0m %s\n" "$*"; }
+
+usage() {
+  cat <<USAGE
+Uso: ${0##*/} [--with-piper] [--piper-voice VOZ]
+
+Instala componentes opcionales de Báscula.
+
+Opciones:
+  --with-piper         Instala Piper TTS y una voz en español.
+  --piper-voice VOZ    Selecciona la voz (por defecto: es_ES-mls-medium).
+  -h, --help           Muestra esta ayuda.
+USAGE
+}
+
+WITH_PIPER=0
+PIPER_VOICE="es_ES-mls-medium"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-piper)
+      WITH_PIPER=1
+      shift
+      ;;
+    --piper-voice)
+      if [[ $# -lt 2 ]]; then
+        err "--piper-voice requiere un argumento"
+        usage
+        exit 1
+      fi
+      PIPER_VOICE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      err "Opción desconocida: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if (( WITH_PIPER )); then
+  log "Instalando Piper TTS (voz ${PIPER_VOICE})"
+  DEFAULT_VOICE="${PIPER_VOICE}" bash "${SCRIPT_DIR}/install-piper-voices.sh"
+
+  if ! command -v piper >/dev/null 2>&1; then
+    err "Piper no está disponible tras la instalación"
+    exit 1
+  fi
+
+  if ! piper --list-voices >/tmp/piper_voices.txt 2>&1; then
+    warn "piper --list-voices falló"
+  else
+    if ! grep -Fq "${PIPER_VOICE}" /tmp/piper_voices.txt; then
+      warn "La voz ${PIPER_VOICE} no aparece en piper --list-voices"
+    fi
+  fi
+
+  TEST_WAV="/tmp/piper_test.wav"
+  MODEL="/usr/share/piper/voices/${PIPER_VOICE}.onnx"
+  CONFIG="${MODEL}.json"
+  if [[ -f "${MODEL}" && -f "${CONFIG}" ]]; then
+    if ! printf 'Instalación correcta de Piper.' | piper --model "${MODEL}" --config "${CONFIG}" --output_file "${TEST_WAV}" >/dev/null 2>&1; then
+      warn "No se pudo sintetizar audio de prueba con Piper"
+    else
+      log "Audio de prueba generado en ${TEST_WAV}"
+    fi
+  else
+    warn "No se encontraron ficheros de voz (${MODEL})"
+  fi
+else
+  log "Piper no se instalará (use --with-piper para habilitarlo)"
+fi
+
+log "Extras completados"

--- a/scripts/install-piper-voices.sh
+++ b/scripts/install-piper-voices.sh
@@ -5,7 +5,7 @@ log(){ printf "\033[1;34m[inst]\033[0m %s\n" "$*"; }
 warn(){ printf "\033[1;33m[warn]\033[0m %s\n" "$*"; }
 err(){ printf "\033[1;31m[ERR ]\033[0m %s\n" "$*"; }
 
-DEFAULT_VOICE="es_ES-mls_10246-low"
+DEFAULT_VOICE="${DEFAULT_VOICE:-es_ES-mls-medium}"
 VOICE_DEST="/usr/share/piper/voices"
 PIPER_ROOT="/opt/piper"
 BIN_DEST="${PIPER_ROOT}/bin"

--- a/scripts/safe_run.sh
+++ b/scripts/safe_run.sh
@@ -7,17 +7,35 @@ IFS=$'\n\t'
 
 APP_DIR="${APP_DIR:-/opt/bascula/current}"
 PY="$APP_DIR/.venv/bin/python3"
-# Evitar flags persistentes que bloqueen arranques. Si hace falta marcar, usar /tmp.
-RECOVERY_FLAG="/tmp/bascula_force_recovery"
+PERSISTENT_RECOVERY_FLAG="/opt/bascula/shared/userdata/force_recovery"
+TEMP_RECOVERY_FLAG="/tmp/bascula_force_recovery"
 BOOT_FLAG="/boot/bascula-recovery"
-ALIVE="/run/bascula.alive"
-HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-25}"
-MAX_HEARTBEAT_AGE="${MAX_HEARTBEAT_AGE:-12}"
+HEARTBEAT_FILE="${HEARTBEAT_FILE:-/run/bascula/heartbeat}"
+LEGACY_HEARTBEAT_FILE="${LEGACY_HEARTBEAT_FILE:-/run/bascula.alive}"
 FAIL_COUNT_FILE="/opt/bascula/shared/userdata/app_fail_count"
+INITIAL_HEALTH_TIMEOUT="${INITIAL_HEALTH_TIMEOUT:-${HEALTH_TIMEOUT:-45}}"
+MAX_HEARTBEAT_AGE="${MAX_HEARTBEAT_AGE:-12}"
+MAX_SOFT_RETRIES="${MAX_SOFT_RETRIES:-2}"
+SOFT_RETRY_DELAY="${SOFT_RETRY_DELAY:-3}"
 
 log() {
   printf '[safe_run] %s\n' "$*" >&2
 }
+
+to_positive_int() {
+  local value="$1"
+  local fallback="$2"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    echo "$value"
+  else
+    echo "$fallback"
+  fi
+}
+
+INITIAL_HEALTH_TIMEOUT="$(to_positive_int "$INITIAL_HEALTH_TIMEOUT" 45)"
+MAX_HEARTBEAT_AGE="$(to_positive_int "$MAX_HEARTBEAT_AGE" 12)"
+MAX_SOFT_RETRIES="$(to_positive_int "$MAX_SOFT_RETRIES" 2)"
+SOFT_RETRY_DELAY="$(to_positive_int "$SOFT_RETRY_DELAY" 3)"
 
 export PYTHONUNBUFFERED=1
 cd "$APP_DIR"
@@ -29,13 +47,34 @@ fi
 
 smoke_test() { [[ -r "$APP_DIR/main.py" ]]; }
 
+should_force_recovery() {
+  [[ -f "$PERSISTENT_RECOVERY_FLAG" ]] || [[ -f "$TEMP_RECOVERY_FLAG" ]]
+}
+
+start_recovery_target() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl start bascula-recovery.target || true
+  fi
+}
+
+trigger_recovery_exit() {
+  touch "$TEMP_RECOVERY_FLAG" 2>/dev/null || true
+  if should_force_recovery; then
+    log "Forzando bascula-recovery.target"
+    start_recovery_target
+  fi
+  exit 0
+}
+
 if [[ -f "$BOOT_FLAG" ]]; then
-  log "Bandera de recovery detectada"
-  exit 1
+  log "Bandera de recovery detectada en boot"
+  trigger_recovery_exit
 fi
 
-if [[ -f "$RECOVERY_FLAG" ]]; then
-  rm -f "$RECOVERY_FLAG" 2>/dev/null || true
+if should_force_recovery; then
+  log "Flag de recovery detectada; no se relanza la UI"
+  start_recovery_target
+  exit 0
 fi
 
 if ! smoke_test; then
@@ -43,66 +82,98 @@ if ! smoke_test; then
   exit 1
 fi
 
-"$PY" "$APP_DIR/main.py" &
-app_pid=$!
-start_ts=$(date +%s)
-health_ok=0
-health_failed=0
+heartbeat_paths=()
+[[ -n "$HEARTBEAT_FILE" ]] && heartbeat_paths+=("$HEARTBEAT_FILE")
+if [[ -n "$LEGACY_HEARTBEAT_FILE" && "$LEGACY_HEARTBEAT_FILE" != "$HEARTBEAT_FILE" ]]; then
+  heartbeat_paths+=("$LEGACY_HEARTBEAT_FILE")
+fi
 
-trap '[[ -n "${app_pid:-}" ]] && kill "$app_pid" 2>/dev/null || true' TERM INT
+heartbeat_fresh() {
+  local now_ts="$1"
+  local path
+  local last
+  for path in "${heartbeat_paths[@]}"; do
+    [[ -n "$path" ]] || continue
+    if [[ -f "$path" ]]; then
+      last=$(stat -c %Y "$path" 2>/dev/null || echo 0)
+      if (( last > 0 && now_ts - last <= MAX_HEARTBEAT_AGE )); then
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
 
-while kill -0 "$app_pid" >/dev/null 2>&1; do
-  now=$(date +%s)
-  if [[ -f "$ALIVE" ]]; then
-    last=$(stat -c %Y "$ALIVE" 2>/dev/null || echo 0)
-    if (( last > 0 && now - last <= MAX_HEARTBEAT_AGE )); then
+soft_retry_count=0
+
+while :; do
+  attempt=$((soft_retry_count + 1))
+  log "Lanzando UI (intento ${attempt})"
+  "$PY" "$APP_DIR/main.py" &
+  app_pid=$!
+  start_ts=$(date +%s)
+  health_ok=0
+  health_failed=0
+
+  trap '[[ -n "${app_pid:-}" ]] && kill "$app_pid" 2>/dev/null || true' TERM INT
+
+  while kill -0 "$app_pid" >/dev/null 2>&1; do
+    now=$(date +%s)
+    if heartbeat_fresh "$now"; then
       health_ok=1
       if [[ -f "$FAIL_COUNT_FILE" ]]; then
         rm -f "$FAIL_COUNT_FILE" 2>/dev/null || true
       fi
       break
     fi
+
+    if (( now - start_ts >= INITIAL_HEALTH_TIMEOUT )); then
+      log "Heartbeat ausente tras ${INITIAL_HEALTH_TIMEOUT}s; reiniciando UI"
+      health_failed=1
+      kill "$app_pid" 2>/dev/null || true
+      break
+    fi
+    sleep 1
+  done
+
+  set +e
+  wait "$app_pid"
+  status=$?
+  set -e
+  trap - TERM INT
+  unset app_pid
+
+  if (( health_failed )); then
+    if (( soft_retry_count < MAX_SOFT_RETRIES )); then
+      soft_retry_count=$((soft_retry_count + 1))
+      log "Reintento suave ${soft_retry_count}/${MAX_SOFT_RETRIES} tras fallo de heartbeat"
+      sleep "$SOFT_RETRY_DELAY"
+      continue
+    fi
+    log "Healthcheck fallido repetidamente; activando recovery"
+    trigger_recovery_exit
   fi
 
-  if (( now - start_ts >= HEALTH_TIMEOUT )); then
-    log "Heartbeat ausente tras ${HEALTH_TIMEOUT}s; reiniciando UI"
-    rm -f "$RECOVERY_FLAG" 2>/dev/null || true
-    health_failed=1
-    kill "$app_pid" 2>/dev/null || true
-    break
+  if (( status != 0 )); then
+    log "Proceso UI terminó con status=${status}"
+    exit "$status"
   fi
-  sleep 1
+
+  if (( ! health_ok )); then
+    log "Aplicación finalizó antes de señal de vida (no heartbeat observado)"
+    exit 2
+  fi
+
+  if (( ${#heartbeat_paths[@]} )); then
+    now=$(date +%s)
+    if ! heartbeat_fresh "$now"; then
+      log "Heartbeat obsoleto tras finalizar (>${MAX_HEARTBEAT_AGE}s)"
+      exit 3
+    fi
+  fi
+
+  break
 done
-
-set +e
-wait "$app_pid"
-status=$?
-set -e
-
-if (( health_failed )); then
-  log "Healthcheck fallido durante la ejecución (reinicio controlado)"
-  rm -f "$RECOVERY_FLAG" 2>/dev/null || true
-  exit 1
-fi
-
-if (( status != 0 )); then
-  log "Proceso UI terminó con status=${status}"
-  exit "$status"
-fi
-
-if (( ! health_ok )); then
-  log "Aplicación finalizó antes de señal de vida (no heartbeat observado)"
-  exit 2
-fi
-
-if [[ -f "$ALIVE" ]]; then
-  now=$(date +%s)
-  last=$(stat -c %Y "$ALIVE" 2>/dev/null || echo 0)
-  if (( last > 0 && now - last > MAX_HEARTBEAT_AGE )); then
-    log "Heartbeat obsoleto: last=${last} now=${now} (>${MAX_HEARTBEAT_AGE}s)"
-    exit 3
-  fi
-fi
 
 exit 0
 SH

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -19,8 +19,9 @@ EnvironmentFile=/etc/default/bascula
 RuntimeDirectory=bascula-xdg
 RuntimeDirectoryMode=0700
 Environment=XDG_RUNTIME_DIR=/run/bascula-xdg
-ExecStartPre=/bin/bash -c 'if [ -f /boot/bascula-recovery ]; then echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; fi'
-ExecStartPre=/bin/bash -c 'if [ -f /opt/bascula/shared/userdata/force_recovery ]; then echo "Flag force_recovery detectada" >&2; exit 1; fi'
+ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
+ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
+ExecStartPre=/bin/bash -lc 'test -f /tmp/bascula_force_recovery && { echo "Flag temporal force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
 ExecStart=/opt/bascula/current/scripts/run-ui.sh
 


### PR DESCRIPTION
## Summary
- restore recovery gating in `bascula-app.service` and expand safe_run to honor persistent/temporary recovery flags with soft retries
- emit an early Tk heartbeat from the UI and extend the installer to hard-check Python dependencies, including python-prctl
- run the x735 poweroff helper as root with a shell-expanded threshold and add an optional extras script for Piper with improved voice installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d21561c9c483268dc484a6c04d067b