### PR TITLE
Add minimal CI harness with mocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci-min
+on: [push, pull_request]
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dirs
+        run: mkdir -p /tmp/ci-root /tmp/ci-logs && chmod -R 777 /tmp/ci-root /tmp/ci-logs
+      - name: Install shells tooling
+        run: sudo apt-get update && sudo apt-get install -y bash coreutils grep sed findutils
+      - name: CI install-1
+        env:
+          BASCULA_CI: "1"
+          DESTDIR: "/tmp/ci-root"
+        run: bash scripts/install-1-system.sh
+      - name: CI install-2
+        env:
+          BASCULA_CI: "1"
+          DESTDIR: "/tmp/ci-root"
+        run: bash scripts/install-2-app.sh
+      - name: Run minimal tests
+        env:
+          BASCULA_CI: "1"
+          DESTDIR: "/tmp/ci-root"
+        run: bash ci/tests/test_min.sh
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs
+          path: |
+            /tmp/ci-logs
+            /tmp/ci-root/etc/systemd/system

--- a/ci/mocks/systemctl
+++ b/ci/mocks/systemctl
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+name="$(printf "%s" "$*" | sed 's/.* \(.*\.service\|.*\.target\).*/\1/')"
+logdir="${BASCULA_CI_LOGDIR:-/tmp/ci-logs}"; mkdir -p "$logdir"
+printf "[systemctl] %s\n" "$*" >> "${logdir}/systemctl.log"
+# Simula fallo si se pide recovery y no hay “permisos CI”
+if [[ "${CI_REQUIRE_ROOT_FOR_SYSTEMCTL:-0}" = "1" && "$*" =~ bascula-recovery\.target ]]; then
+  exit 1
+fi
+exit 0

--- a/ci/tests/test_min.sh
+++ b/ci/tests/test_min.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[test] start"
+
+# 1) run-ui: no -logfile en xinit y .xserverrc correcto
+grep -q 'exec xinit .* -- /usr/bin/Xorg :0 vt1 -nolisten tcp -noreset' scripts/run-ui.sh
+grep -q 'exec /usr/lib/xorg/Xorg :0 vt1 -nolisten tcp -noreset' scripts/xsession.sh || true
+# .xserverrc lo genera run-ui.sh, aquí sólo validamos plantilla:
+grep -q 'exec /usr/lib/xorg/Xorg :0 vt1 -nolisten tcp -noreset' scripts/run-ui.sh || true
+
+# 2) safe_run: flags y códigos de salida
+TMP=/tmp/bascula_force_recovery
+PERSIST=/opt/bascula/shared/userdata/force_recovery
+BOOT=/boot/bascula-recovery
+DEST="${DESTDIR:-/tmp/ci-root}"
+
+mkdir -p "${DEST}/opt/bascula/current/scripts" "${DEST}/opt/bascula/shared/userdata" "${DEST}/boot" /tmp
+cp scripts/safe_run.sh "${DEST}/opt/bascula/current/scripts/safe_run.sh"
+chmod +x "${DEST}/opt/bascula/current/scripts/safe_run.sh"
+export PATH="$(pwd)/ci/mocks:$PATH"
+export BASCULA_CI=1 CI_REQUIRE_ROOT_FOR_SYSTEMCTL=1
+
+# a) Watchdog ⇒ crea TEMP y falla si systemctl denegado
+rm -f "$TMP" "${DEST}${PERSIST}" "${DEST}${BOOT}"
+if "${DEST}/opt/bascula/current/scripts/safe_run.sh" trigger 2>/tmp/t1.err; then
+  echo "ERROR: se esperaba exit!=0" >&2; exit 1
+fi
+test -f "$TMP"
+
+# b) Persistente ⇒ NO crea TEMP, intenta recovery, exit 0 si mock permite
+> "${DEST}${PERSIST}"
+CI_REQUIRE_ROOT_FOR_SYSTEMCTL=0 "${DEST}/opt/bascula/current/scripts/safe_run.sh" trigger
+test ! -f "$TMP"
+
+# c) Limpieza sticky tras quitar flag persistente
+rm -f "${DEST}${PERSIST}"
+CI_REQUIRE_ROOT_FOR_SYSTEMCTL=0 "${DEST}/opt/bascula/current/scripts/safe_run.sh" trigger 2>/tmp/t2.err || true
+test ! -f "$TMP"
+
+echo "[test] ok"


### PR DESCRIPTION
## Summary
- add CI mode handling to the system and app installers so they use DESTDIR and a configurable systemctl mock
- extend safe_run.sh with a trigger mode for CI checks while preserving the installer behaviour
- create a minimal systemctl mock, smoke test, and GitHub Actions workflow for CI coverage

## Testing
- PATH="$(pwd)/ci/mocks:$PATH" BASCULA_CI=1 DESTDIR=/tmp/ci-root bash ci/tests/test_min.sh


------
https://chatgpt.com/codex/tasks/task_e_68d259815c908326bcd698e0da0d71f4