### PR TITLE
Fix safe_run trigger recovery flag handling

### DIFF
--- a/ci/tests/test_min.sh
+++ b/ci/tests/test_min.sh
@@ -39,15 +39,11 @@ set +e
 "${DEST}/opt/bascula/current/scripts/safe_run.sh" trigger 2>/tmp/t1.err
 status=$?
 set -e
-if [[ ${status} -eq 0 ]]; then
-  echo "ERROR: se esperaba exit!=0" >&2
+if [[ "${status}" != "3" ]]; then
+  echo "ERROR: safe_run.sh trigger expected exit status 3, got ${status}" >&2
   exit 1
 fi
-if [[ "${status}" != "2" && "${status}" != "3" ]]; then
-  echo "ERROR: safe_run.sh trigger expected exit status 2 or 3, got ${status}" >&2
-  exit 1
-fi
-# safe_run intentionally returns 2/3 when recovery is denied or requested; treat that as success for this guard.
+# Debe haberse creado el flag temporal tras el fallo de systemctl.
 test -f "$TMP"
 
 # b) Persistente ⇒ NO crea TEMP, intenta recovery, exit 0 si mock permite


### PR DESCRIPTION
## Summary
- ensure safe_run trigger logic only creates the temporary recovery flag when no persistent flags are present
- clear /tmp/bascula_force_recovery after successfully starting bascula-recovery.target
- update CI test expectations for the new trigger behaviour

## Testing
- BASCULA_CI=1 DESTDIR=/tmp/ci-root bash ci/tests/test_min.sh

------
https://chatgpt.com/codex/tasks/task_e_68d28f4d08f08326acb5ce1e9aecd3c2