### PR TITLE
Ensure CI installs requirements before validating icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
           IFS=$'\n\t'
           PATH="$(pwd)/ci/mocks:$PATH" ci/bin/ci-doctor.sh "install-2"
           PATH="$(pwd)/ci/mocks:$PATH" bash scripts/install-2-app.sh
+      - name: Install Python dependencies
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          python3 -m pip install --upgrade pip
+          pip install -r requirements.txt
       - name: Validate icons
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions step to install Python dependencies from requirements.txt
- ensure Pillow and other packages are available before running the icon validation script

## Testing
- python3 -m scripts.validate_assets *(fails: ModuleNotFoundError: No module named 'PIL' due to pip install being unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a90c7f1c8326bf9f1d9e25540ef5