### PR TITLE
Pin CI Python to 3.11 and gate tflite-runtime to ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
           IFS=$'\n\t'
           PATH="$(pwd)/ci/mocks:$PATH" ci/bin/ci-doctor.sh "install-2"
           PATH="$(pwd)/ci/mocks:$PATH" bash scripts/install-2-app.sh
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Install Python dependencies
         run: |
           set -euo pipefail

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ opencv-python-headless>=4.7,<5 ; platform_machine == "aarch64"
 
 # Machine learning runtime
 numpy==2.*
-tflite-runtime==2.14.0
+tflite-runtime==2.14.0 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 


### PR DESCRIPTION
## Summary
- configure the CI unit job to use Python 3.11 via actions/setup-python
- restrict tflite-runtime installation to ARM machines to avoid x86 build failures

## Testing
- ⚠️ `python3 -m venv .venv && source .venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt && python -m scripts.validate_assets` *(fails in this environment due to proxy restrictions and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d2aabf135c8326aca9bf3a7ac187f0