### PR TITLE
Adjust Tk smoke test to use system Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,31 @@ jobs:
         run: python -m pip install --upgrade pip wheel
       - name: Install app requirements
         run: pip install -r requirements.txt
+      # --- Tk smoke test usando SIEMPRE el Python del sistema ---
+      - name: Install system Tk deps
+        if: ${{ env.CI_TEST_TK == '1' }}
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          sudo apt-get update
+          sudo apt-get install -y python3-tk xvfb
+
+      - name: Install CI extras for system Python (Pillow en /usr/bin/python3)
+        if: ${{ env.CI_TEST_TK == '1' }}
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          /usr/bin/python3 -c "import sys; print('System Python exe:', sys.executable)"
+          /usr/bin/python3 -m pip install --upgrade pip
+          /usr/bin/python3 -m pip install Pillow
+
+      - name: Test icon loader (Tk smoke with system Python)
+        if: ${{ env.CI_TEST_TK == '1' }}
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          IFS=$'\n\t'
+          xvfb-run -a /usr/bin/python3 bascula-cam/scripts/test_icon_loader.py
       - name: Run minimal tests
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- ensure the Tk smoke test installs dependencies with the system Python interpreter
- run the icon loader smoke test under /usr/bin/python3 to avoid Pillow import issues

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2b3c1f4908326be4e2c31ffe233b8