### PR TITLE
Fix Pi camera venv simplejpeg compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,8 @@ rapidocr-onnxruntime>=1.3.25
 opencv-python-headless>=4.7,<5 ; platform_machine == "aarch64"
 
 # Machine learning runtime
-numpy==2.*
+numpy==1.24.4 ; platform_machine == "armv7l" or platform_machine == "aarch64"
+numpy==2.* ; platform_machine != "armv7l" and platform_machine != "aarch64"
 tflite-runtime==2.14.0 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 
 


### PR DESCRIPTION
## Summary
- adjust install-2-app.sh to build a clean venv, preinstall numpy 1.24.4 and opencv 4.8.1.78, rebuild simplejpeg inside the venv, and assert it comes from the venv
- extend dependency smoke test to verify simplejpeg location and numpy version, ensuring compatibility with Picamera2
- update requirements to pin numpy 1.24.4 on Raspberry Pi architectures while keeping numpy 2.x elsewhere

## Testing
- pytest tests/test_install_script.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c95cf22083269cb406398b0e5e56