### PR TITLE
Handle simplejpeg wheel with build deps fallback

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -213,8 +213,14 @@ if [[ -x "${BASCULA_VENV_DIR}/bin/pip" ]]; then
   # Paquetes críticos primero para asegurar compatibilidad ABI con simplejpeg
   pip install 'numpy==1.24.4' 'opencv-python-headless==4.8.1.78'
 
-  # Fuerza build desde fuentes dentro del venv, ignorando la versión de APT
-  pip install --ignore-installed --no-binary=:all: simplejpeg
+  echo "[inst] Installing simplejpeg (wheel if available, else build from source)"
+  if ! pip install --only-binary=:all: simplejpeg; then
+    echo "[inst] simplejpeg wheel not available → installing build deps and compiling..."
+    apt-get update
+    apt-get install -y build-essential python3-dev libjpeg-dev
+    # Fuerza build desde fuentes dentro del venv, ignorando la versión de APT
+    pip install --ignore-installed --no-binary=:all: simplejpeg
+  fi
 
   if [[ -f "${BASCULA_CURRENT}/requirements.txt" ]]; then
     pip install -r "${BASCULA_CURRENT}/requirements.txt"


### PR DESCRIPTION
## Summary
- prefer installing the simplejpeg wheel in the OTA virtualenv before building from source
- install build-essential, python3-dev and libjpeg-dev only when the wheel is unavailable
- keep dependency verification to ensure simplejpeg resolves from the virtualenv

## Testing
- not run (automation script change)


------
https://chatgpt.com/codex/tasks/task_e_68d2d227896c8326a3b67b92d767229f