### PR TITLE
Improve Pi app install robustness

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,11 @@ qrcode[pil]>=7.4
 pyzbar>=0.1.9
 # Optional local AI OCR/Vision helpers
 rapidocr-onnxruntime>=1.3.25
-opencv-python-headless>=4.7,<5 ; platform_machine == "aarch64"
 
 # Machine learning runtime
+# Evita romper CI x86_64 y respeta Pi
 numpy==1.24.4 ; platform_machine == "armv7l" or platform_machine == "aarch64"
+opencv-python-headless==4.8.1.78 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 numpy==2.* ; platform_machine != "armv7l" and platform_machine != "aarch64"
 tflite-runtime==2.14.0 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 

--- a/tools/smoke-rpi.sh
+++ b/tools/smoke-rpi.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+APP_VENV="${APP_VENV:-/opt/bascula/current/.venv}"
+APP_PY="${APP_VENV}/bin/python"
+
+if [[ ! -x "${APP_PY}" ]]; then
+  echo "[ERR] No se encontró el intérprete en ${APP_PY}" >&2
+  exit 1
+fi
+
+export PYTHONNOUSERSITE=1
+
+echo "[smoke] Verificando imports clave en ${APP_VENV}"
+"${APP_PY}" - <<'PY'
+import sys
+import numpy
+import cv2
+import simplejpeg
+from picamera2 import Picamera2
+import tkinter
+
+print("PY", sys.version.split()[0], "NumPy", numpy.__version__, "cv2", cv2.__version__)
+print("simplejpeg", simplejpeg.__file__)
+print("Picamera2 OK", Picamera2)
+print("Tk", tkinter.TkVersion)
+PY
+
+TMP_IMG="/tmp/bascula-smoke-rpi.jpg"
+echo "[smoke] Ejecutando libcamera-still"
+if command -v libcamera-still >/dev/null; then
+  if libcamera-still -n -o "${TMP_IMG}" && [ -s "${TMP_IMG}" ]; then
+    echo "[smoke] libcamera OK (${TMP_IMG})"
+  else
+    echo "[WARN] libcamera-still no generó imagen" >&2
+  fi
+else
+  echo "[WARN] libcamera-still no está instalado" >&2
+fi
+rm -f "${TMP_IMG}" 2>/dev/null || true
+
+have_systemd() {
+  command -v systemctl >/dev/null 2>&1 && [[ -d /run/systemd/system ]]
+}
+
+echo "[smoke] Estado de servicios"
+if have_systemd; then
+  systemctl --no-pager --plain --failed || true
+  for svc in bascula-ui bascula-miniweb ocr-service; do
+    if systemctl list-units --type=service --all | grep -q "${svc}.service"; then
+      if systemctl is-active --quiet "${svc}.service"; then
+        echo "[smoke] ${svc}.service: active"
+      else
+        systemctl status "${svc}.service" --no-pager || true
+      fi
+    else
+      echo "[INFO] ${svc}.service no está definido"
+    fi
+  done
+else
+  echo "[INFO] systemd no disponible"
+fi


### PR DESCRIPTION
## Summary
- endurece install-2-app.sh con logging a /var/log, prerequisitos APT para Bookworm ARM64 y verificación temprana de Picamera2 para evitar instalaciones incompletas
- rehace la gestión del venv para renombrar instalaciones previas, fijar NumPy/OpenCV, reinstalar simplejpeg dentro del entorno y validar que los imports críticos salen del .venv
- añade comprobaciones finales de servicios/libcamera y un script tools/smoke-rpi.sh para soporte, además de alinear los pins de requirements con los binarios que necesitamos en la Pi

## Testing
- bash -n scripts/install-2-app.sh
- bash -n tools/smoke-rpi.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2d9a79e5083269296ce0720500f19