### PR TITLE
Ensure videocore dependency installed

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -95,7 +95,7 @@ echo "[inst] Instalando paquetes APT base"
 apt-get update
 apt-get install -y \
   python3-venv python3-pip python3-tk \
-  python3-picamera2 python3-libcamera python3-simplejpeg libcamera-tools \
+  python3-picamera2 python3-videocore python3-libcamera python3-simplejpeg libcamera-tools \
   build-essential python3-dev libjpeg-dev pkg-config \
   libcap-dev curl jq xinit fonts-dejavu-core
 


### PR DESCRIPTION
## Summary
- add python3-videocore to install-2-app apt dependency list to satisfy Picamera2

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d2e62299108326843ac21e30a0b562