### PR TITLE
Fix production paths in bascula web service

### DIFF
--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -7,10 +7,10 @@ Wants=network-online.target
 Type=simple
 User=pi
 Group=pi
-WorkingDirectory=/home/pi/bascula-cam
-EnvironmentFile=-/etc/default/bascula-web
+WorkingDirectory=/opt/bascula/current
+EnvironmentFile=-/etc/default/bascula
 Environment=VENV=/opt/bascula/current/.venv
-Environment=APP=/home/pi/bascula-cam
+Environment=APP=/opt/bascula/current
 ExecStart=/usr/local/bin/bascula-web
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- update bascula-web systemd unit to use the production deployment directory
- reference the shared /etc/default/bascula environment file and align APP path

## Testing
- `systemd-analyze verify systemd/bascula-web.service` *(fails: Command /usr/local/bin/bascula-web is not executable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d377d6158c83269aa876daa5929df0