### PR TITLE
Configure ALSA defaults for USB mic and add check

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -167,8 +167,15 @@ UNIT
 configure_audio() {
   cat > /etc/asound.conf <<'EOF'
 pcm.!default {
-  type hw
-  card 0
+  type asym
+  playback.pcm {
+    type hw
+    card 0
+  }
+  capture.pcm {
+    type hw
+    card 1
+  }
 }
 ctl.!default {
   type hw
@@ -374,6 +381,9 @@ except Exception as exc:  # pragma: no cover
     print(f'[WARN] Piper no disponible: {exc}')
 PY
   fi
+
+  echo "[CHK] USB microphone"
+  arecord -l || true
 
   echo "[DONE] install-2-app completado"
 }


### PR DESCRIPTION
## Summary
- configure `/etc/asound.conf` so playback uses card 0 (MAX98357A) and capture uses card 1 (USB microphone)
- add a post-installation check that lists ALSA capture devices to confirm the USB microphone is visible

## Testing
- pytest *(fails: tests/test_install_script.py::test_install_script_protects_optional_directories — existing expectation for rsync sync block)*

------
https://chatgpt.com/codex/tasks/task_e_68d37d2ed518832690fe7c8ffd7262e2