### PR TITLE
Run bascula UI service as pi user

### DIFF
--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -569,6 +569,17 @@ main() {
     bascula-net-fallback.service \
     bascula-recovery.service \
     bascula-web.service
+  if command -v systemd-analyze >/dev/null 2>&1; then
+    systemd-analyze verify /etc/systemd/system/bascula-app.service
+  else
+    log "systemd-analyze no disponible; omito verificación de bascula-app.service"
+  fi
+  if have_systemd; then
+    sctl daemon-reload
+    sctl enable --now bascula-app.service
+  else
+    log "systemd no disponible; omito enable/arranque de bascula-app.service"
+  fi
   verify_unit_files \
     x735-poweroff.service \
     bascula-app.service \

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 Conflicts=getty@tty1.service
 Conflicts=bascula-recovery.service
-OnFailure=bascula-app-failure@%n.service bascula-recovery.target
+OnFailure=
 StartLimitIntervalSec=120
 StartLimitBurst=3
 
@@ -14,15 +14,13 @@ User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
 EnvironmentFile=-/etc/default/bascula
+Environment=HOME=/home/pi
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 Environment=VENV=/opt/bascula/current/.venv
 Environment=APP=/opt/bascula/current
-# Rootless Xorg runtime
-RuntimeDirectory=bascula-xdg
-RuntimeDirectoryMode=0700
-Environment=XDG_RUNTIME_DIR=/run/bascula-xdg
 ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
-ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi %h/.local/share/xorg
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
 ExecStart=/usr/local/bin/bascula-app
 
 Restart=on-failure


### PR DESCRIPTION
## Summary
- ensure bascula-app.service runs under the pi account with the correct HOME/XDG runtime variables and fixes the Xorg directory setup
- clear the unused OnFailure target reference from the service unit
- have install-2-app.sh verify and enable the bascula-app service right after copying the unit file

## Testing
- systemd-analyze verify systemd/bascula-app.service

------
https://chatgpt.com/codex/tasks/task_e_68d3ef206d308326bc3d0328cce343ab