### PR TITLE
Simplify icon handling in install script

### DIFF
--- a/ci/tests/test_min.sh
+++ b/ci/tests/test_min.sh
@@ -41,6 +41,22 @@ if not hasattr(module, "main"):
 print("wifi_config.main OK")
 PY
 
+ci::log "Verificando sincronización de iconos"
+if [[ -d "${repo_root}/assets/icons" ]]; then
+  dest_icons="${DESTDIR%/}/opt/bascula/shared/assets/icons"
+  if [[ ! -d "${dest_icons}" ]]; then
+    ci::log "[TEST] Directorio de iconos no encontrado en runtime: ${dest_icons}"
+    exit 1
+  fi
+  png_count=$(find "${dest_icons}" -type f -name '*.png' -print | wc -l | tr -d '[:space:]')
+  if [[ "${png_count}" -lt 1 ]]; then
+    ci::log "[TEST] No se encontraron iconos PNG en runtime (${png_count})"
+    exit 1
+  fi
+else
+  ci::log "assets/icons ausente en el repo; omito verificación"
+fi
+
 ci::log "Validando scripts UI"
 grep -q 'exec xinit .* -- /usr/bin/Xorg :0 vt1 -nolisten tcp -noreset' scripts/run-ui.sh
 grep -q 'exec /usr/lib/xorg/Xorg :0 vt1 -nolisten tcp -noreset' scripts/xsession.sh || true


### PR DESCRIPTION
## Summary
- replace the icon repair/hash flow in install-2-app.sh with a deterministic rsync copy and optional Pillow validation
- add a CI smoke check that ensures icons are synced after install-2-app.sh

## Testing
- bash -n scripts/install-2-app.sh
- bash -n ci/tests/test_min.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3f782f2cc8326b1ad2653f7bfb730