### PR TITLE
Ensure bascula-app service prepares log directory

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -20,6 +20,11 @@ RuntimeDirectoryMode=0700
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=VENV=/opt/bascula/current/.venv
 Environment=APP=/opt/bascula/current
+# Ensure log directory and files exist before launching the UI (option A).
+ExecStartPre=/bin/bash -lc 'install -d -m 0755 -o pi -g pi /var/log/bascula'
+ExecStartPre=/bin/bash -lc 'touch /var/log/bascula/app.log /var/log/bascula/xorg.log'
+ExecStartPre=/bin/bash -lc 'chown pi:pi /var/log/bascula/app.log /var/log/bascula/xorg.log'
+ExecStartPre=/bin/bash -lc 'chmod 0644 /var/log/bascula/app.log /var/log/bascula/xorg.log'
 ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg


### PR DESCRIPTION
## Summary
- ensure bascula-app.service creates /var/log/bascula before launching the UI
- touch and set ownership for app.log and xorg.log so run-ui.sh redirections succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d41e6ffa388326a24e8de538d67db0