### PR TITLE
Ensure UI stack runs as pi with prepared runtime

### DIFF
--- a/scripts/bascula-app-wrapper.sh
+++ b/scripts/bascula-app-wrapper.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export HOME="/home/pi"
+export USER="pi"
+export XDG_RUNTIME_DIR="/run/user/1000"
+
+if [[ ${EUID:-0} -eq 0 ]]; then
+  echo "bascula-app: no debe ejecutarse como root" >&2
+  exit 1
+fi
+
 APP="${APP:-/opt/bascula/current}"
 SCRIPT="${APP}/scripts/run-ui.sh"
 if [[ ! -x "${SCRIPT}" ]]; then
   echo "bascula-app: no se encontró ${SCRIPT}" >&2
   exit 1
 fi
+
 exec "${SCRIPT}"

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -15,16 +15,16 @@ Group=pi
 WorkingDirectory=/opt/bascula/current
 EnvironmentFile=-/etc/default/bascula
 Environment=HOME=/home/pi
+Environment=USER=pi
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 RuntimeDirectory=bascula
 RuntimeDirectoryMode=0700
-Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=VENV=/opt/bascula/current/.venv
 Environment=APP=/opt/bascula/current
-# Ensure log directory and files exist before launching the UI (option A).
-ExecStartPre=/bin/bash -lc 'install -d -m 0755 -o pi -g pi /var/log/bascula'
-ExecStartPre=/bin/bash -lc 'touch /var/log/bascula/app.log /var/log/bascula/xorg.log'
-ExecStartPre=/bin/bash -lc 'chown pi:pi /var/log/bascula/app.log /var/log/bascula/xorg.log'
-ExecStartPre=/bin/bash -lc 'chmod 0644 /var/log/bascula/app.log /var/log/bascula/xorg.log'
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /run/user/1000
+ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
+ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/xorg.log
 ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg


### PR DESCRIPTION
## Summary
- run the bascula-app systemd service entirely as the pi user with explicit HOME/USER/XDG runtime variables
- prepare the pi-owned runtime and log directories before launching the UI
- export the kiosk environment variables from the wrapper and run-ui scripts while avoiding any sudo usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d41f35d634832694f79e558f2ee37e