### PR TITLE
Ensure bascula service pre-start runs as root

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -10,6 +10,7 @@ StartLimitBurst=3
 
 [Service]
 Type=simple
+PermissionsStartOnly=yes
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current


### PR DESCRIPTION
## Summary
- add PermissionsStartOnly to the bascula-app service so ExecStart runs as pi but pre/post commands run as root

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d41ff60c1083268c1a565ef80a8f2b