### PR TITLE
Ensure bascula UI scripts run with fixed runtime env

### DIFF
--- a/scripts/bascula-app-wrapper.sh
+++ b/scripts/bascula-app-wrapper.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 export HOME="/home/pi"
 export USER="pi"
 export XDG_RUNTIME_DIR="/run/user/1000"
+export DISPLAY=":0"
 
 if [[ ${EUID:-0} -eq 0 ]]; then
   echo "bascula-app: no debe ejecutarse como root" >&2

--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 export HOME="/home/pi"
 export USER="pi"
 export XDG_RUNTIME_DIR="/run/user/1000"
+export DISPLAY=":0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -22,8 +23,6 @@ if [[ ${EUID} -eq 0 ]]; then
   exit 1
 fi
 
-mkdir -p "${LOG_DIR}" 2>/dev/null || true
-touch "${LOG_FILE}" "${XORG_LOG_FILE}" 2>/dev/null || true
 exec >>"${LOG_FILE}" 2>&1
 
 start_stamp="$(date --iso-8601=seconds 2>/dev/null || date)"
@@ -32,7 +31,6 @@ log_journal "[run-ui] Iniciando UI ${start_stamp}"
 
 cd "${APP_DIR}"
 
-export DISPLAY=:0
 log_journal "[run-ui] XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
 
 if [[ ! -d .venv ]]; then


### PR DESCRIPTION
## Summary
- export DISPLAY alongside the pi user environment variables in the bascula UI wrapper scripts
- rely on systemd ExecStartPre for log directory creation by removing redundant setup from run-ui.sh

## Testing
- systemctl daemon-reload *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*
- systemctl reset-failed bascula-app.service *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*

------
https://chatgpt.com/codex/tasks/task_e_68d4217ef39c832680b930476ed1fb72