### PR TITLE
Finalize Xorg.wrap migration for bascula UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ Los ficheros de `docs/examples/` son sintácticamente válidos y listos para cop
 
 ### Pi OS Lite (Bookworm)
 
-- Asegúrate de instalar `xserver-xorg-legacy` y generar `/etc/X11/Xwrapper.config` con `needs_root_rights=yes` para habilitar `Xorg.wrap` en modo setuid. 【F:scripts/install-1-system.sh†L120-L136】
-- La fase 2 crea `~/.xserverrc` con `Xorg.wrap :0 vt1` y el servicio `bascula-app` reserva `TTY1`, lo que evita conflictos con `getty@tty1` y el modo framebuffer. 【F:scripts/run-ui.sh†L55-L63】【F:systemd/bascula-app.service†L20-L38】
-- Se purga `xserver-xorg-video-fbdev` y se fuerza el driver `modesetting` sobre `/dev/dri/card1` mediante `/etc/X11/xorg.conf.d/20-modesetting.conf`, compatible con Raspberry Pi 5. 【F:scripts/install-1-system.sh†L110-L138】
+- Instala `xserver-xorg-legacy` y genera `/etc/X11/Xwrapper.config` con `allowed_users=anybody` y `needs_root_rights=yes` para habilitar `Xorg.wrap`. 【F:scripts/install-1-system.sh†L193-L210】
+- La fase 2 crea `~/.xserverrc` con `exec /usr/lib/xorg/Xorg.wrap :0 vt1 -nolisten tcp -noreset` y el servicio `bascula-app` reserva `TTY1`, lo que evita conflictos con `getty@tty1` y el modo framebuffer. 【F:scripts/run-ui.sh†L67-L81】【F:systemd/bascula-app.service†L5-L40】
+- Se purga `xserver-xorg-video-fbdev` y se fuerza el driver `modesetting` sobre `/dev/dri/card1` mediante `/etc/X11/xorg.conf.d/20-modesetting.conf`, compatible con Raspberry Pi 5. 【F:scripts/install-1-system.sh†L193-L234】
 - Tras el arranque, comprueba el log de Xorg con `tail -n 200 ~/.local/share/xorg/Xorg.0.log` para validar que detecta `modesetting` y carga la configuración de `/etc/X11/xorg.conf.d`. 【F:scripts/install-2-app.sh†L322-L357】
+- Troubleshooting: si el log muestra `no screens found`, comprueba `ls -l /sys/class/drm/` y, si el HDMI activo corresponde a `card0`, ajusta `kmsdev` a `/dev/dri/card0`. 【F:scripts/install-1-system.sh†L213-L234】
 
 ### Cámara
 

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+LEGACY_DROPIN="/etc/systemd/system/bascula-app.service.d/tty.conf"
+
+if [ -f "$LEGACY_DROPIN" ]; then
+    rm -f "$LEGACY_DROPIN"
+    rmdir "$(dirname "$LEGACY_DROPIN")" 2>/dev/null || true
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl daemon-reload || true
+    fi
+fi
+
+exit 0

--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -226,6 +226,13 @@ exec /usr/lib/xorg/Xorg.wrap :0 vt1 -nolisten tcp -noreset
 EOF
 chmod 0755 "${DESTDIR:-}/etc/bascula/xserverrc"
 
+legacy_dropin="${DESTDIR:-}/etc/systemd/system/bascula-app.service.d/tty.conf"
+if [[ -f "${legacy_dropin}" ]]; then
+  rm -f "${legacy_dropin}" || true
+  dropin_dir="$(dirname "${legacy_dropin}")"
+  rmdir "${dropin_dir}" 2>/dev/null || true
+fi
+
 run_systemctl enable --now NetworkManager.service || true
 run_systemctl disable --now dhcpcd.service 2>/dev/null || true
 run_systemctl disable --now wpa_supplicant.service 2>/dev/null || true

--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -73,7 +73,9 @@ SH
 chmod 0755 "${XINITRC}"
 
 # Forzar uso de Xorg.wrap (legacy setuid) sin -logfile dedicado
-printf '%s\n' 'exec /usr/lib/xorg/Xorg.wrap :0 vt1 -nolisten tcp -noreset' > "${HOME}/.xserverrc"
+cat <<'SH' > "${HOME}/.xserverrc"
+exec /usr/lib/xorg/Xorg.wrap :0 vt1 -nolisten tcp -noreset
+SH
 chmod 0755 "${HOME}/.xserverrc"
 
 exec xinit "${XINITRC}" -- :0


### PR DESCRIPTION
## Summary
- ensure the UI session relies on Xorg.wrap by templating ~/.xserverrc and adjusting the xinit invocation
- remove any legacy bascula-app tty drop-ins during installation/postinst to rely on the service unit settings
- document the updated Raspberry Pi OS Lite guidance for Xorg.wrap and troubleshooting modesetting

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d4c21c7b688326a5b34fdb97678c39