### PR TITLE
Automate X735 setup and config idempotence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  lint-and-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Shellcheck scripts
+        run: |
+          shellcheck scripts/*.sh overlay/x735/*.sh
+
+      - name: Bash syntax validation
+        run: |
+          bash -n scripts/install-1-system.sh packaging/postinst
+
+      - name: config.txt dry-run
+        run: |
+          tmp_config="$(mktemp)"
+          cat <<'CFG' >"${tmp_config}"
+[all]
+dtoverlay=vc4-kms-v3d
+dtparam=audio=on
+CFG
+          python3 tools/update-config.py "${tmp_config}"
+          first_sum="$(sha256sum "${tmp_config}" | awk '{print $1}')"
+          python3 tools/update-config.py "${tmp_config}"
+          second_sum="$(sha256sum "${tmp_config}" | awk '{print $1}')"
+          if [ "${first_sum}" != "${second_sum}" ]; then
+            echo "Config update is not idempotent" >&2
+            diff -u <(echo "${first_sum}") <(echo "${second_sum}") || true
+            exit 1
+          fi
+          echo "Final config:" >&2
+          cat "${tmp_config}" >&2
+
+      - name: Optional systemd-analyze verify
+        run: |
+          if command -v systemd-analyze >/dev/null 2>&1; then
+            systemd-analyze verify systemd/x735-fan.service systemd/x735-poweroff.service systemd/bascula-app.service || true
+          else
+            echo "systemd-analyze no disponible en runner" >&2
+          fi

--- a/overlay/x735/x735-fan.sh
+++ b/overlay/x735/x735-fan.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAN_GPIO_NAME="${X735_FAN_GPIO_NAME:-GPIO18}"
+FAN_TEMP_ON="${X735_FAN_TEMP_ON:-55}"
+FAN_TEMP_OFF="${X735_FAN_TEMP_OFF:-48}"
+FAN_POLL_INTERVAL="${X735_FAN_POLL_INTERVAL:-5}"
+LOG_TAG="[x735-fan]"
+
+log() {
+  printf '%s %s\n' "${LOG_TAG}" "$*"
+}
+
+warn() {
+  printf '%s WARNING: %s\n' "${LOG_TAG}" "$*" >&2
+}
+
+fatal() {
+  printf '%s ERROR: %s\n' "${LOG_TAG}" "$*" >&2
+  exit 1
+}
+
+require_binary() {
+  local bin="$1"
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    fatal "${bin} no está disponible"
+  fi
+}
+
+parse_gpiofind() {
+  local name="$1"
+  local out
+  if ! out=$(gpiofind "${name}" 2>/dev/null); then
+    fatal "gpiofind no encontró ${name}"
+  fi
+  printf '%s' "${out}"
+}
+
+read_temperature() {
+  local raw
+  if command -v vcgencmd >/dev/null 2>&1; then
+    raw=$(vcgencmd measure_temp 2>/dev/null || true)
+    raw=${raw#temp=}
+    raw=${raw%%'*C'*}
+    raw=${raw//[^0-9.]/}
+    if [[ -n "${raw}" ]]; then
+      printf '%d' "${raw%%.*}"
+      return 0
+    fi
+  fi
+
+  if [[ -f /sys/class/thermal/thermal_zone0/temp ]]; then
+    raw=$(< /sys/class/thermal/thermal_zone0/temp)
+    if [[ -n "${raw}" ]]; then
+      printf '%d' $((raw / 1000))
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+cleanup() {
+  stop_fan || true
+}
+
+start_fan() {
+  if [[ -n "${FAN_PID:-}" ]] && kill -0 "${FAN_PID}" 2>/dev/null; then
+    return 0
+  fi
+
+  gpioset --mode=signal --consumer="x735-fan" "${GPIO_CHIP}" "${GPIO_LINE}=1" &
+  FAN_PID=$!
+  sleep 0.1
+  if ! kill -0 "${FAN_PID}" 2>/dev/null; then
+    wait "${FAN_PID}" || true
+    FAN_PID=""
+    return 1
+  fi
+  return 0
+}
+
+stop_fan() {
+  if [[ -n "${FAN_PID:-}" ]]; then
+    if kill -0 "${FAN_PID}" 2>/dev/null; then
+      kill "${FAN_PID}" 2>/dev/null || true
+      wait "${FAN_PID}" 2>/dev/null || true
+    fi
+    FAN_PID=""
+  fi
+  gpioset "${GPIO_CHIP}" "${GPIO_LINE}=0" >/dev/null 2>&1 || true
+}
+
+require_binary gpioset
+require_binary gpiofind
+
+GPIO_INFO=$(parse_gpiofind "${FAN_GPIO_NAME}")
+GPIO_CHIP=${GPIO_INFO%% *}
+GPIO_LINE=${GPIO_INFO##* }
+
+if [[ -z "${GPIO_CHIP}" || -z "${GPIO_LINE}" ]]; then
+  fatal "No se pudo resolver ${FAN_GPIO_NAME}"
+fi
+
+if ! INIT_OUTPUT=$(gpioset "${GPIO_CHIP}" "${GPIO_LINE}=0" 2>&1); then
+  if [[ "${INIT_OUTPUT}" == *"Device or resource busy"* ]]; then
+    warn "GPIO ${FAN_GPIO_NAME} ocupado. Revisa overlays duplicados en config.txt"
+  else
+    warn "gpioset falló: ${INIT_OUTPUT}"
+  fi
+  exec tail -f /dev/null
+fi
+
+trap cleanup EXIT INT TERM
+
+log "Usando ${GPIO_CHIP} línea ${GPIO_LINE} (on>=${FAN_TEMP_ON}°C, off<=${FAN_TEMP_OFF}°C)"
+
+temp_failures=0
+fan_state=0
+while true; do
+  if ! temp=$(read_temperature); then
+    if (( temp_failures == 0 )); then
+      warn "No se pudo leer temperatura del SoC"
+    fi
+    temp_failures=$((temp_failures + 1))
+    sleep "${FAN_POLL_INTERVAL}"
+    continue
+  fi
+  temp_failures=0
+
+  if (( temp >= FAN_TEMP_ON )); then
+    if (( fan_state == 0 )); then
+      if start_fan; then
+        log "Ventilador activado a ${temp}°C"
+        fan_state=1
+      else
+        warn "No se pudo activar el ventilador"
+      fi
+    fi
+  elif (( fan_state == 1 && temp <= FAN_TEMP_OFF )); then
+    stop_fan
+    log "Ventilador detenido a ${temp}°C"
+    fan_state=0
+  fi
+
+  sleep "${FAN_POLL_INTERVAL}"
+done

--- a/overlay/x735/x735-poweroff.sh
+++ b/overlay/x735/x735-poweroff.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUTTON_GPIO_NAME="${X735_BUTTON_GPIO_NAME:-GPIO17}"
+POWER_COMMAND="${X735_POWER_COMMAND:-/sbin/poweroff}"
+LOG_TAG="[x735-poweroff]"
+
+log() {
+  printf '%s %s\n' "${LOG_TAG}" "$*"
+}
+
+warn() {
+  printf '%s WARNING: %s\n' "${LOG_TAG}" "$*" >&2
+}
+
+fatal() {
+  printf '%s ERROR: %s\n' "${LOG_TAG}" "$*" >&2
+  exit 1
+}
+
+require_binary() {
+  local bin="$1"
+  if ! command -v "${bin}" >/dev/null 2>&1; then
+    fatal "${bin} no está disponible"
+  fi
+}
+
+parse_gpio() {
+  local name="$1"
+  local out
+  if ! out=$(gpiofind "${name}" 2>/dev/null); then
+    fatal "gpiofind no encontró ${name}"
+  fi
+  printf '%s' "${out}"
+}
+
+trigger_poweroff() {
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl poweroff
+  else
+    "${POWER_COMMAND}" || /sbin/poweroff
+  fi
+}
+
+require_binary gpiofind
+require_binary gpiomon
+
+GPIO_INFO=$(parse_gpio "${BUTTON_GPIO_NAME}")
+GPIO_CHIP=${GPIO_INFO%% *}
+GPIO_LINE=${GPIO_INFO##* }
+
+if [[ -z "${GPIO_CHIP}" || -z "${GPIO_LINE}" ]]; then
+  fatal "No se pudo resolver ${BUTTON_GPIO_NAME}"
+fi
+
+log "Monitoreando ${GPIO_CHIP} línea ${GPIO_LINE} para apagado seguro"
+
+while true; do
+  if OUTPUT=$(gpiomon --silent --num-events=1 --falling-edge "${GPIO_CHIP}" "${GPIO_LINE}" 2>&1); then
+    log "Botón presionado, solicitando apagado"
+    trigger_poweroff
+    sleep 2
+  else
+    if [[ "${OUTPUT}" == *"Device or resource busy"* ]]; then
+      warn "GPIO ${BUTTON_GPIO_NAME} ocupado. Probablemente el overlay gpio-shutdown ya maneja el botón"
+      exec tail -f /dev/null
+    fi
+    warn "gpiomon falló: ${OUTPUT}"
+    sleep 2
+  fi
+done

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -12,4 +12,13 @@ if [ -f "$LEGACY_DROPIN" ]; then
     fi
 fi
 
+if command -v loginctl >/dev/null 2>&1 && id pi >/dev/null 2>&1; then
+    loginctl enable-linger pi || true
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    systemctl enable --now bascula-app.service x735-fan.service x735-poweroff.service
+fi
+
 exit 0

--- a/systemd/x735-fan.service
+++ b/systemd/x735-fan.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=Geekworm X735 v3 power button monitor (libgpiod)
+Description=Geekworm X735 v3 fan controller (libgpiod)
 After=multi-user.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/x735-poweroff
+ExecStart=/usr/local/bin/x735-fan
 Restart=on-failure
 RestartSec=5
 

--- a/tools/update-config.py
+++ b/tools/update-config.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Update Raspberry Pi config.txt with Bascula-Cam and X735 blocks."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+from typing import List
+
+BASCULA_BEGIN = "# --- Bascula-Cam (Pi 5): begin ---"
+BASCULA_END = "# --- Bascula-Cam (Pi 5): end ---"
+BASCULA_BLOCK = [
+    BASCULA_BEGIN,
+    "hdmi_force_hotplug=1",
+    "hdmi_group=2",
+    "hdmi_mode=87",
+    "hdmi_cvt=1024 600 60 3 0 0 0",
+    "dtoverlay=vc4-kms-v3d",
+    "dtparam=audio=off",
+    "dtoverlay=i2s-mmap",
+    "dtoverlay=hifiberry-dac",
+    "dtoverlay=pwm-2chan,pin=12,func=4,pin2=13,func2=4",
+    BASCULA_END,
+]
+
+X735_BEGIN = "# --- X735 v3: begin ---"
+X735_END = "# --- X735 v3: end ---"
+X735_BLOCK = [
+    X735_BEGIN,
+    "dtoverlay=gpio-shutdown,gpio_pin=17,active_low=1,gpio_pull=up",
+    "dtoverlay=gpio-poweroff,gpiopin=4,active_low=1",
+    X735_END,
+]
+
+LEGACY_BLOCKS = [
+    ("# --- Bascula-Cam (Pi 5): Video + Audio I2S + PWM ---", "# --- Bascula-Cam (end) ---"),
+    (BASCULA_BEGIN, BASCULA_END),
+    (X735_BEGIN, X735_END),
+]
+
+ENSURE_LINES = [
+    "enable_uart=1",
+    "dtparam=i2c_arm=on",
+    "dtoverlay=disable-bt",
+]
+
+REMOVE_LINES_EXACT = {
+    "dtoverlay=max98357a",
+    "dtoverlay=max98357a,audio=on",
+}
+
+REMOVE_PREFIXES = [
+    "dtparam=audio=on",
+]
+
+
+def drop_block(lines: List[str], begin: str, end: str) -> List[str]:
+    out: List[str] = []
+    i = 0
+    begin_strip = begin.strip()
+    end_strip = end.strip()
+    length = len(lines)
+    while i < length:
+        if lines[i].strip() == begin_strip:
+            j = i + 1
+            while j < length and lines[j].strip() != end_strip:
+                j += 1
+            if j < length:
+                j += 1
+            else:
+                j = i + 1
+            i = j
+            continue
+        out.append(lines[i])
+        i += 1
+    return out
+
+
+def ensure_section(lines: List[str], section: str) -> List[str]:
+    section_lower = section.strip().lower()
+    if any(line.strip().lower() == section_lower for line in lines):
+        return lines
+    if lines and lines[-1].strip():
+        lines.append("")
+    lines.append(section)
+    return lines
+
+
+def insert_block_after_anchor(lines: List[str], block: List[str], anchor: str) -> List[str]:
+    anchor_lower = anchor.strip().lower()
+    anchor_index = None
+    for idx, line in enumerate(lines):
+        if line.strip().lower() == anchor_lower:
+            anchor_index = idx
+            break
+    block_with_spacing = block[:]
+    # ensure blank line between block and following content
+    if block_with_spacing and block_with_spacing[-1].strip():
+        block_with_spacing.append("")
+
+    if anchor_index is None:
+        lines = ensure_section(lines, anchor)
+        anchor_index = next(
+            idx for idx, line in enumerate(lines) if line.strip().lower() == anchor_lower
+        )
+
+    insert_at = anchor_index + 1
+    # collapse multiple blank lines after anchor
+    while insert_at < len(lines) and not lines[insert_at].strip():
+        insert_at += 1
+    # insert block and ensure a blank line before, unless directly after section header
+    if insert_at == anchor_index + 1:
+        block_to_insert = block_with_spacing
+    else:
+        block_to_insert = [""] + block_with_spacing
+
+    return lines[:insert_at] + block_to_insert + lines[insert_at:]
+
+
+def dedupe_line(lines: List[str], value: str) -> List[str]:
+    target = value.strip()
+    seen = False
+    result: List[str] = []
+    for line in lines:
+        if line.strip() == target:
+            if seen:
+                continue
+            seen = True
+        result.append(line)
+    return result
+
+
+def normalize(lines: List[str]) -> List[str]:
+    sanitized: List[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if stripped in REMOVE_LINES_EXACT:
+            continue
+        if any(stripped.startswith(prefix) for prefix in REMOVE_PREFIXES):
+            continue
+        sanitized.append(raw.rstrip())
+    return sanitized
+
+
+
+
+def collapse_blank_lines(lines: List[str]) -> List[str]:
+    result: List[str] = []
+    previous_blank = False
+    for line in lines:
+        if line.strip():
+            result.append(line)
+            previous_blank = False
+        else:
+            if not previous_blank:
+                result.append("")
+            previous_blank = True
+    return result
+def ensure_lines(lines: List[str]) -> List[str]:
+    existing = {line.strip(): idx for idx, line in enumerate(lines)}
+    for entry in ENSURE_LINES:
+        if entry not in existing:
+            lines.append(entry)
+    return lines
+
+
+def update_config(path: pathlib.Path) -> None:
+    if path.exists():
+        content = path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+    else:
+        lines = []
+
+    # drop legacy blocks first
+    for begin, end in LEGACY_BLOCKS:
+        lines = drop_block(lines, begin, end)
+
+    lines = normalize(lines)
+
+    lines = ensure_lines(lines)
+
+    # remove global duplicates before inserting the block
+    lines = [line for line in lines if line.strip() != "dtoverlay=vc4-kms-v3d"]
+
+    lines = drop_block(lines, BASCULA_BEGIN, BASCULA_END)
+    lines = insert_block_after_anchor(lines, BASCULA_BLOCK, "[all]")
+
+    # remove any existing X735 block first
+    lines = drop_block(lines, X735_BEGIN, X735_END)
+
+    # place X735 block after Bascula block if possible
+    try:
+        bascula_end_index = next(
+            idx for idx, line in enumerate(lines) if line.strip() == BASCULA_END.strip()
+        )
+        insertion_point = bascula_end_index + 1
+        block_with_spacing = X735_BLOCK[:]
+        if block_with_spacing and block_with_spacing[-1].strip():
+            block_with_spacing.append("")
+        lines = (
+            lines[:insertion_point]
+            + ([""] if lines[insertion_point:insertion_point + 1] and lines[insertion_point].strip() else [])
+            + block_with_spacing
+            + lines[insertion_point:]
+        )
+    except StopIteration:
+        lines = insert_block_after_anchor(lines, X735_BLOCK, "[all]")
+
+    lines = dedupe_line(lines, "dtoverlay=vc4-kms-v3d")
+    lines = collapse_blank_lines(lines)
+
+    final_text = "\n".join(lines).rstrip() + "\n"
+    path.write_text(final_text, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update Raspberry Pi config.txt")
+    parser.add_argument("config", type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    update_config(args.config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- detect the active DRM device during install-1, rewrite X11 configs safely, and delegate config.txt updates to a new idempotent helper
- vendorize Geekworm X735 fan/poweroff scripts with libgpiod systemd units, expose a smoke checklist script, and update packaging plus documentation
- add a CI workflow covering shellcheck, bash -n, and a config.txt dry-run idempotence check

## Testing
- bash -n scripts/install-1-system.sh scripts/smoke.sh overlay/x735/x735-fan.sh overlay/x735/x735-poweroff.sh packaging/postinst


------
https://chatgpt.com/codex/tasks/task_e_68d4c50e3bf88326a8707826e8f1421a