### PR TITLE
Expand kmsdev when writing modesetting config

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -79,7 +79,8 @@ configure_modesetting() {
   local kmsdev="/dev/dri/${kms_card}"
   local conf_path="${dest_root%/}/etc/X11/xorg.conf.d/20-modesetting.conf"
   local content
-  read -r -d '' content <<'EOF'
+  # Escribimos expandiendo ${kmsdev}; si no cambia, no tocamos el archivo.
+  content=$(cat <<EOF
 Section "Device"
   Identifier "GPU0"
   Driver "modesetting"
@@ -87,6 +88,7 @@ Section "Device"
   Option "kmsdev" "${kmsdev}"
 EndSection
 EOF
+)
   write_file_if_changed "${conf_path}" "${content}\n"
 }
 


### PR DESCRIPTION
## Summary
- ensure configure_modesetting expands the kmsdev path when writing the modesetting configuration
- reuse the existing write_file_if_changed helper so the file is only updated when the content actually changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4d004ae4c832694fb15b32443d0bf