### PR TITLE
Bascula web wrapper and install updates

### DIFF
--- a/scripts/bascula-web.sh
+++ b/scripts/bascula-web.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_DIR="/opt/bascula/current"
+VENV="$APP_DIR/.venv"
+ENV_FILE="/etc/default/bascula-web"
+
+# Load env file if present
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+fi
+
+# Defaults
+APP_MODULE="${APP_MODULE:-bascula.web.app:app}"
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8080}"
+WORKERS="${WORKERS:-1}"
+
+export PATH="$VENV/bin:$PATH"
+export PYTHONUNBUFFERED=1
+
+if [ ! -x "$VENV/bin/python" ]; then
+  echo "[err] venv no encontrado en $VENV" >&2
+  exit 1
+fi
+
+cd "$APP_DIR"
+
+# Sanity checks
+"$VENV/bin/python" -c "import importlib; import uvicorn; mod='${APP_MODULE}'.split(':')[0]; importlib.import_module(mod)" || {
+  echo "[err] No se pudo importar uvicorn o el módulo APP_MODULE=$APP_MODULE" >&2
+  "$VENV/bin/python" -c "import sys, pkgutil, platform; print('python', sys.version); print('platform', platform.platform()); import pkg_resources; print('packages', [d.project_name+':'+d.version for d in pkg_resources.working_set])" || true
+  exit 1
+}
+
+exec "$VENV/bin/uvicorn" "$APP_MODULE" --host "$HOST" --port "$PORT" --workers "$WORKERS"

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1064,65 +1064,91 @@ if [[ "${SKIP_INSTALL_ALL_SERVICE_DEPLOY:-0}" != "1" ]]; then
   install -D -m 0644 "${SCRIPT_DIR}/../systemd/bascula-net-fallback.service" /etc/systemd/system/bascula-net-fallback.service
 
   # --- Mini-web service ---
+  bascula_wrapper_src="${SCRIPT_DIR}/../scripts/bascula-web.sh"
+  bascula_wrapper_dest="/usr/local/bin/bascula-web"
+  bascula_env_dest="/etc/default/bascula-web"
   bascula_service_src="${SCRIPT_DIR}/../systemd/bascula-web.service"
   bascula_service_dest="/etc/systemd/system/bascula-web.service"
-  bascula_dropin_dir="/etc/systemd/system/bascula-web.service.d"
   reload_needed=0
-  service_ready=0
 
-  install -d -m 0755 "${bascula_dropin_dir}"
+  if [[ -f "${bascula_wrapper_src}" ]]; then
+    if [[ -f "${bascula_wrapper_dest}" ]] && cmp -s "${bascula_wrapper_src}" "${bascula_wrapper_dest}"; then
+      echo "[info] bascula-web wrapper already up to date"
+    else
+      install -D -m 0755 "${bascula_wrapper_src}" "${bascula_wrapper_dest}"
+      echo "[info] Installed bascula-web wrapper"
+    fi
+  else
+    warn "Missing bascula-web wrapper source (${bascula_wrapper_src})"
+  fi
+
+  if [[ ! -f "${bascula_env_dest}" ]]; then
+    cat > "${bascula_env_dest}" <<'ENV'
+APP_MODULE="bascula.web.app:app"
+HOST="127.0.0.1"
+PORT="8080"
+WORKERS="1"
+ENV
+    chmod 0644 "${bascula_env_dest}"
+    echo "[info] Created /etc/default/bascula-web with defaults"
+  fi
 
   if [[ -f "${bascula_service_src}" ]]; then
-    if [[ -f "${bascula_service_dest}" ]]; then
-      if cmp -s "${bascula_service_src}" "${bascula_service_dest}"; then
-        echo "[info] bascula-web.service already up to date"
-      else
-        install -m 0644 "${bascula_service_src}" "${bascula_service_dest}"
-        echo "[info] Installed bascula-web.service"
-        reload_needed=1
-      fi
+    if [[ -f "${bascula_service_dest}" ]] && cmp -s "${bascula_service_src}" "${bascula_service_dest}"; then
+      echo "[info] bascula-web.service already up to date"
     else
       install -D -m 0644 "${bascula_service_src}" "${bascula_service_dest}"
       echo "[info] Installed bascula-web.service"
       reload_needed=1
     fi
-    service_ready=1
   else
-    echo "[warn] Missing bascula-web.service (skipping)"
+    warn "Missing bascula-web.service source (${bascula_service_src})"
   fi
 
-  for dropin in 10-writable-home 20-env-and-exec; do
-    dropin_src="${SCRIPT_DIR}/../systemd/bascula-web.service.d/${dropin}.conf"
-    dropin_dest="${bascula_dropin_dir}/${dropin}.conf"
-    if [[ -f "${dropin_src}" ]]; then
-      if [[ -f "${dropin_dest}" ]] && cmp -s "${dropin_src}" "${dropin_dest}"; then
-        echo "[info] bascula-web drop-in ${dropin}.conf already up to date"
-      else
-        install -D -m 0644 "${dropin_src}" "${dropin_dest}"
-        echo "[info] Installed bascula-web drop-in ${dropin}.conf"
-        reload_needed=1
-      fi
-    else
-      echo "[warn] Missing ${dropin}.conf (skipping)"
-    fi
-  done
-
-  if (( reload_needed )) || (( service_ready )); then
+  if (( reload_needed )); then
     systemctl daemon-reload
   fi
-  install -d -m 0700 -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${TARGET_HOME}/.config/bascula" || true
-  # Preflight: ensure mini-web port is free
-  if [[ -f /etc/default/bascula ]]; then . /etc/default/bascula; fi
-  PORT="${BASCULA_MINIWEB_PORT:-${BASCULA_WEB_PORT:-8080}}"
-  if ss -ltn "( sport = :${PORT} )" | grep -q ":${PORT}"; then
-    warn "Port ${PORT} is already in use. bascula-web will not start. Free the port or adjust /etc/default/bascula."
-  fi
-  if (( service_ready )); then
-    systemctl enable --now bascula-web.service || true
+
+  if [[ -f "${bascula_service_dest}" ]]; then
+    if ! systemctl enable --now bascula-web.service; then
+      err "Failed to enable/start bascula-web.service"
+      systemctl --no-pager -l status bascula-web.service || true
+      journalctl -u bascula-web.service -n 120 --no-pager || true
+      exit 1
+    fi
     echo "[info] bascula-web.service enabled and running"
+
+    if [[ -f "${bascula_env_dest}" ]]; then
+      # shellcheck disable=SC1091
+      . "${bascula_env_dest}"
+    fi
+    HOST="${HOST:-127.0.0.1}"
+    PORT="${PORT:-8080}"
+    CHECK_HOST="${HOST:-127.0.0.1}"
+    if [[ "${CHECK_HOST}" == "0.0.0.0" || "${CHECK_HOST}" == "::" ]]; then
+      CHECK_HOST="127.0.0.1"
+    fi
+    ok=0
+    for _ in {1..10}; do
+      if curl -fsS "http://${CHECK_HOST}:${PORT}/health" >/dev/null 2>&1 || \
+         curl -fsS "http://${CHECK_HOST}:${PORT}/" >/dev/null 2>&1; then
+        echo "[inst] bascula-web: Responding (HTTP 200)"
+        ok=1
+        break
+      fi
+      sleep 1
+    done
+    if (( ok == 0 )); then
+      err "bascula-web no responde en :${PORT}"
+      systemctl --no-pager -l status bascula-web.service || true
+      journalctl -u bascula-web.service -n 120 --no-pager || true
+      exit 1
+    fi
   else
-    echo "[warn] bascula-web.service not available; skipping enable"
+    warn "bascula-web.service not available; skipping enable"
   fi
+
+  install -d -m 0700 -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${TARGET_HOME}/.config/bascula" || true
   su -s /bin/bash -c 'mkdir -p ~/.config/bascula && chmod 700 ~/.config/bascula' "${TARGET_USER}" || true
 
   # --- UI service ---

--- a/systemd/bascula-web.service
+++ b/systemd/bascula-web.service
@@ -8,9 +8,8 @@ Type=simple
 User=pi
 Group=pi
 WorkingDirectory=/opt/bascula/current
-EnvironmentFile=-/etc/default/bascula
-Environment=VENV=/opt/bascula/current/.venv
-Environment=APP=/opt/bascula/current
+Environment=HOME=/home/pi
+EnvironmentFile=-/etc/default/bascula-web
 ExecStart=/usr/local/bin/bascula-web
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- add a venv-aware /usr/local/bin/bascula-web launcher that validates uvicorn/app imports
- update the systemd unit to consume the wrapper and optional environment file
- extend install-all.sh to deploy the wrapper/unit, seed defaults, and enforce service health checks

## Testing
- bash -n scripts/bascula-web.sh
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68d56320e5748326ac27b534af348ba1