### PR TITLE
Ensure Pi installs use NumPy 2.2 and enforce dependency checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,12 @@ rapidocr-onnxruntime>=1.3.25
 
 # Machine learning runtime
 # Evita romper CI x86_64 y respeta Pi
-numpy==1.24.4 ; platform_machine == "armv7l" or platform_machine == "aarch64"
-opencv-python-headless==4.8.1.78 ; platform_machine == "armv7l" or platform_machine == "aarch64"
-numpy==2.* ; platform_machine != "armv7l" and platform_machine != "aarch64"
+numpy>=2.2,<2.3
+# Usa headless si no necesitamos ventanas de HighGUI (imshow):
+opencv-python-headless==4.12.0.88
+# O, si ya dependes del paquete con GUI:
+# opencv-python==4.12.0.88
+simplejpeg>=1.6.7
 tflite-runtime==2.14.0 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 
 


### PR DESCRIPTION
## Summary
- pin numpy>=2.2,<2.3 and opencv-python-headless==4.12.0.88 to keep Raspberry Pi builds on a consistent stack
- update the installer to install numpy before the requirements file, reuse the new pins, and fail fast with `pip check`

## Testing
- not run (requires Raspberry Pi environment)


------
https://chatgpt.com/codex/tasks/task_e_68d564929f488326aef582314a30f97d