### PR TITLE
system: add patchelf + full build toolchain to install-1-system.sh

### DIFF
--- a/scripts/install-1-system.sh
+++ b/scripts/install-1-system.sh
@@ -250,7 +250,13 @@ apt-get install -y --no-install-recommends \
   i2c-tools libcap-dev curl jq \
   alsa-utils sox espeak-ng libasound2-dev piper \
   xserver-xorg xserver-xorg-legacy xinit openbox x11-xserver-utils unclutter \
-  libzbar0 network-manager gpiod libgpiod-tools
+  libzbar0 network-manager gpiod libgpiod-tools \
+  build-essential patchelf \
+  autoconf automake libtool \
+  pkg-config \
+  cmake ninja-build \
+  python3-dev \
+  libjpeg-dev zlib1g-dev
 
 if dpkg -l xserver-xorg-video-fbdev >/dev/null 2>&1; then
   apt-get purge -y xserver-xorg-video-fbdev || true
@@ -309,5 +315,10 @@ usermod -aG dialout,tty,video,render,input "${TARGET_USER}" || true
 
 install -d -m 0755 "${STATE_DIR}"
 echo ok > "${MARKER}"
+if ! command -v patchelf >/dev/null 2>&1; then
+  echo "[err] patchelf no está instalado tras fase-1" >&2
+  exit 1
+fi
+echo "[inst] Toolchain listo (gcc, cmake, ninja, autoconf, patchelf)"
 echo "[inst] UART configurado. Reboot requerido para aplicar dtoverlay=disable-bt"
 echo "[INFO] Parte 1 completada. Reinicia ahora."


### PR DESCRIPTION
## Summary
- install the native build toolchain and patchelf during phase 1 to support wheel builds on Raspberry Pi OS
- verify patchelf availability at the end of phase 1 and log a ready-toolchain message
- prefer piwheels during the virtualenv setup, logging the selected index and allowing simplejpeg to install from wheels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5886824b88326833b81b7d8502be8