### PR TITLE
Fix UI installer for Raspberry Pi Lite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,15 +19,13 @@ openai>=1.30
 # Imaging, OCR, and barcode helpers
 qrcode[pil]>=7.4
 pyzbar>=0.1.9
+pytesseract>=0.3.10
 # Optional local AI OCR/Vision helpers
 rapidocr-onnxruntime>=1.3.25
 
 # Machine learning runtime (opencv-python 4.12 needs NumPy >=2,<2.3)
 numpy>=2.2,<2.3
-# Usa headless si no necesitamos ventanas de HighGUI (imshow):
-# opencv-python-headless==4.12.0.88
-# O, si ya dependes del paquete con GUI:
-opencv-python==4.12.0.88
+opencv-python-headless==4.12.0.88
 simplejpeg>=1.6.7
 tflite-runtime==2.14.0 ; platform_machine == "armv7l" or platform_machine == "aarch64"
 

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Bascula Digital Pro - UI (Xorg via startx)
-After=network-online.target
+After=graphical.target network-online.target
 Wants=network-online.target
 Conflicts=getty@tty1.service
 Conflicts=bascula-recovery.service
@@ -28,7 +28,8 @@ ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/xor
 ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
-ExecStart=/usr/local/bin/bascula-app
+Environment=DISPLAY=:0
+ExecStart=/usr/bin/startx
 
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- install missing X11 dependencies (python3-xdg/unclutter-startup) and ensure OCR wheels are present in the virtualenv
- generate Xorg/Openbox session files owned by the target user, fix $HOME permissions, and replace the UI wrapper with startx + autostart
- require cv2/pytesseract imports to succeed, switch to opencv-python-headless, and update bascula-app.service to run startx with DISPLAY=:0

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d58da4bc548326b9356f59a5975a20