### PR TITLE
Create bascula-app wrapper and update service

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -29,7 +29,7 @@ ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
 Environment=DISPLAY=:0
-ExecStart=/usr/bin/startx
+ExecStart=/usr/local/bin/bascula-app
 
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- add installation steps to provision /usr/local/bin/bascula-app wrapper that launches startx with the venv Python client and handles log ownership
- stop autostart from spawning the UI directly so Openbox only runs ancillary helpers
- point bascula-app.service at the new wrapper to keep the UI under systemd supervision

## Testing
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68d60f975fb88326aae2d583207ff066