### PR TITLE
Fix startx launch flow for UI

### DIFF
--- a/scripts/bascula-app-wrapper.sh
+++ b/scripts/bascula-app-wrapper.sh
@@ -6,11 +6,10 @@ if [[ ${EUID:-0} -eq 0 ]]; then
   exit 1
 fi
 
-APP="${APP:-/opt/bascula/current}"
-SCRIPT="${APP}/scripts/run-ui.sh"
-if [[ ! -x "${SCRIPT}" ]]; then
-  echo "bascula-app: no se encontró ${SCRIPT}" >&2
-  exit 1
-fi
+: "${DISPLAY:=:0}"
+: "${USER:=pi}"
+: "${LOGNAME:=${USER}}"
+: "${HOME:=/home/${USER}}"
+export DISPLAY USER LOGNAME HOME
 
-exec "${SCRIPT}"
+exec /usr/bin/startx -- -keeptty -logfile /var/log/bascula/xorg.log >>/var/log/bascula/app.log 2>&1

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -28,7 +28,6 @@ ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/xor
 ExecStartPre=/bin/bash -lc 'test -f /boot/bascula-recovery && { echo "Flag /boot/bascula-recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/bin/bash -lc 'test -f /opt/bascula/shared/userdata/force_recovery && { echo "Flag force_recovery detectada" >&2; exit 1; } || true'
 ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
-Environment=DISPLAY=:0
 ExecStart=/usr/local/bin/bascula-app
 
 Restart=on-failure


### PR DESCRIPTION
## Summary
- ensure .xinitrc launches Openbox in the background, disables DPMS, and runs the UI in the foreground before shutting down the WM
- update installers to leave Openbox autostart for helpers only and create the sessions cache directory
- switch the bascula-app wrapper to exec startx directly and drop DISPLAY from the systemd unit so ~/.xinitrc is honored

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66b6ac9848326ba60a65ff889c5fb