### PR TITLE
Ensure Openbox exits reliably from xinitrc

### DIFF
--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -1296,17 +1296,56 @@ PY
 exec /usr/lib/xorg/Xorg.wrap :0 vt1 -keeptty
 EOF
   install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" /dev/stdin "${TARGET_HOME}/.xinitrc" <<'EOF'
-#!/bin/sh
-# Arranca Openbox en segundo plano y guarda su PID
-openbox-session &
-OB_PID=$!
+#!/bin/bash
+set -euo pipefail
 
-# UI en primer plano; al salir, cerrar Openbox y propagar exit code
-/opt/bascula/current/.venv/bin/python -m bascula.ui.app >>/var/log/bascula/app.log 2>&1
-UI_STATUS=$?
+LOG="/var/log/bascula/app.log"
+
+echo "[XINIT] --- start $(date) ---" >>"$LOG"
+echo "[XINIT] lanzando Openbox..." >>"$LOG"
+openbox-session >>"$LOG" 2>&1 &
+OB_PID=$!
+echo "[XINIT] Openbox PID=$OB_PID" >>"$LOG"
+
+echo "[XINIT] lanzando UI..." >>"$LOG"
+RC=0
+if ! /opt/bascula/current/.venv/bin/python -m bascula.ui.app >>"$LOG" 2>&1; then
+  RC=$?
+fi
+
+echo "[XINIT] UI salió con rc=${RC:-0}" >>"$LOG"
+echo "[XINIT] cerrando Openbox (graceful)..." >>"$LOG"
+
+# 1) intento amable
 openbox --exit || true
-wait "${OB_PID}" 2>/dev/null || true
-exit "${UI_STATUS}"
+
+# 2) esperar hasta 5s a que muera
+TIMEOUT=5
+while kill -0 "$OB_PID" 2>/dev/null && [ $TIMEOUT -gt 0 ]; do
+  sleep 1
+  TIMEOUT=$((TIMEOUT-1))
+done
+
+if kill -0 "$OB_PID" 2>/dev/null; then
+  echo "[XINIT] Openbox sigue vivo; enviando SIGTERM..." >>"$LOG"
+  kill -TERM "$OB_PID" 2>/dev/null || true
+
+  TERM_WAIT=3
+  while kill -0 "$OB_PID" 2>/dev/null && [ $TERM_WAIT -gt 0 ]; do
+    sleep 1
+    TERM_WAIT=$((TERM_WAIT-1))
+  done
+fi
+
+if kill -0 "$OB_PID" 2>/dev/null; then
+  echo "[XINIT] Openbox aún vivo; enviando SIGKILL..." >>"$LOG"
+  kill -KILL "$OB_PID" 2>/dev/null || true
+fi
+
+# No bloquees si ya no existe o si wait se quedaría colgado
+wait "$OB_PID" 2>/dev/null || true
+echo "[XINIT] --- end $(date) ---" >>"$LOG"
+exit "${RC:-0}"
 EOF
   install -d -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${TARGET_HOME}/.config/openbox"
   install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" /dev/stdin "${TARGET_HOME}/.config/openbox/autostart" <<'EOF'


### PR DESCRIPTION
## Summary
- update the generated ~/.xinitrc to run under bash with strict mode and detailed logging
- implement staged Openbox shutdown with graceful exit, timeout, SIGTERM, and SIGKILL fallbacks
- log session lifecycle to /var/log/bascula/app.log while preserving helper-only Openbox autostart

## Testing
- bash -n scripts/install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6a668ad2c83268eb5a47a31348da4