### PR TITLE
Fix Xorg kiosk launch for Bookworm

### DIFF
--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -15,6 +15,7 @@ WorkingDirectory=/opt/bascula/current
 Environment=HOME=/home/pi
 Environment=USER=pi
 Environment=XDG_RUNTIME_DIR=/run/user/1000
+PermissionsStartOnly=yes
 ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
 ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
 # IMPORTANTE: no pasar -logfile ni -keeptty a Xorg


### PR DESCRIPTION
## Summary
- replace the bascula-app systemd unit with a minimal startx invocation that avoids -logfile/-keeptty arguments
- generate an idempotent ~/.xinitrc that runs the UI in the foreground with best-effort logging and optional cursor hiding
- update installation scripts and wrappers to use the simplified startx flow without Openbox helpers
- restore PermissionsStartOnly so bascula-app.service's ExecStartPre steps run with the required privileges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6adc43dd883269ffbfd0f85131cb9