### PR TITLE
Refine kiosk X session orchestration

### DIFF
--- a/scripts/bascula-app-wrapper.sh
+++ b/scripts/bascula-app-wrapper.sh
@@ -12,4 +12,4 @@ fi
 : "${HOME:=/home/${USER}}"
 export DISPLAY USER LOGNAME HOME
 
-exec /usr/bin/startx "${HOME}/.xinitrc" -- :0 vt1 >>/var/log/bascula/app.log 2>&1
+exec /usr/bin/startx -- :0 vt1 >>/var/log/bascula/app.log 2>&1

--- a/scripts/install-2-app.sh
+++ b/scripts/install-2-app.sh
@@ -209,19 +209,10 @@ configure_startx_session() {
 exec /usr/lib/xorg/Xorg.wrap :0 vt1
 EOF
 
-  install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" /dev/stdin "${TARGET_HOME}/.xinitrc" <<'EOF'
-#!/bin/sh
-# Log best-effort (no abortar si falla el append)
-LOG=/var/log/bascula/app.log
-echo "[XINIT] starting $(date)" >>"$LOG" 2>/dev/null || true
-# Oculta el cursor si existe unclutter
-if command -v unclutter >/dev/null 2>&1; then
-  "$(command -v unclutter)" -idle 0.5 -root &
-fi
-# Ejecuta la UI en primer plano; si termina, startx saldrá y systemd reiniciará
-cd /opt/bascula/current || exit 1
-exec /opt/bascula/current/.venv/bin/python -m bascula.ui.app run >>"$LOG" 2>&1
-EOF
+  install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" \
+    "${ROOT_DIR}/scripts/xinitrc.kiosk" "${TARGET_HOME}/.xinitrc"
+  install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_USER}" \
+    "${ROOT_DIR}/scripts/openbox-autostart" "${TARGET_HOME}/.config/openbox/autostart"
 }
 
 write_bascula_app_wrapper() {

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -128,19 +128,10 @@ install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" /dev/stdin "${TARGET
 exec /usr/lib/xorg/Xorg.wrap :0 vt1
 EOF
 
-install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" /dev/stdin "${TARGET_HOME}/.xinitrc" <<'EOF'
-#!/bin/sh
-# Log best-effort (no abortar si falla el append)
-LOG=/var/log/bascula/app.log
-echo "[XINIT] starting $(date)" >>"$LOG" 2>/dev/null || true
-# Oculta el cursor si existe unclutter
-if command -v unclutter >/dev/null 2>&1; then
-  "$(command -v unclutter)" -idle 0.5 -root &
-fi
-# Ejecuta la UI en primer plano; si termina, startx saldrá y systemd reiniciará
-cd /opt/bascula/current || exit 1
-exec /opt/bascula/current/.venv/bin/python -m bascula.ui.app run >>"$LOG" 2>&1
-EOF
+install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" \
+  "${SCRIPT_DIR}/../scripts/xinitrc.kiosk" "${TARGET_HOME}/.xinitrc"
+install -D -m 0755 -o "${TARGET_USER}" -g "${TARGET_GROUP}" \
+  "${SCRIPT_DIR}/../scripts/openbox-autostart" "${TARGET_HOME}/.config/openbox/autostart"
 
 # --- Check network connectivity ---
 NET_OK=0

--- a/scripts/openbox-autostart
+++ b/scripts/openbox-autostart
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Ancillary helpers for the kiosk session
+
+if command -v unclutter >/dev/null 2>&1; then
+  unclutter -idle 0.5 -root &
+fi

--- a/scripts/run-ui.sh
+++ b/scripts/run-ui.sh
@@ -65,12 +65,9 @@ PY
 deactivate || true
 
 XINITRC="${HOME}/.xinitrc"
-cat <<'SH' > "${XINITRC}"
-#!/usr/bin/env bash
-set -euo pipefail
-exec /opt/bascula/current/scripts/xsession.sh
-SH
-chmod 0755 "${XINITRC}"
+install -D -m 0755 "${SCRIPT_DIR}/xinitrc.kiosk" "${XINITRC}"
+install -D -m 0755 "${SCRIPT_DIR}/openbox-autostart" \
+  "${HOME}/.config/openbox/autostart"
 
 # Forzar uso de Xorg.wrap (legacy setuid) sin -logfile dedicado
 cat <<'SH' > "${HOME}/.xserverrc"
@@ -78,4 +75,4 @@ exec /usr/lib/xorg/Xorg.wrap :0 vt1 -nolisten tcp -noreset
 SH
 chmod 0755 "${HOME}/.xserverrc"
 
-exec xinit "${XINITRC}" -- :0
+exec xinit -- :0

--- a/scripts/xinitrc.kiosk
+++ b/scripts/xinitrc.kiosk
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+LOG_FILE=${LOG_FILE:-/var/log/bascula/app.log}
+APP_DIR=${APP_DIR:-/opt/bascula/current}
+UI_ENTRY=${UI_ENTRY:-${APP_DIR}/scripts/xsession.sh}
+
+_timestamp() {
+  date '+%Y-%m-%d %H:%M:%S%z'
+}
+
+log() {
+  local msg
+  msg="[XINIT] $(_timestamp) $*"
+  printf '%s\n' "$msg" >>"$LOG_FILE" 2>/dev/null || true
+}
+
+log "session starting (pid $$)"
+
+export DISPLAY="${DISPLAY:-:0}"
+
+for cmd in \
+  "xset s off" \
+  "xset -dpms" \
+  "xset s noblank"
+do
+  if ! eval "$cmd" >/dev/null 2>&1; then
+    log "warn: failed to run '$cmd'"
+  fi
+done
+
+OPENBOX_PID=""
+OPENBOX_CMD=""
+UI_PID=""
+
+start_openbox() {
+  if command -v openbox-session >/dev/null 2>&1; then
+    OPENBOX_CMD="$(command -v openbox-session)"
+  elif command -v openbox >/dev/null 2>&1; then
+    OPENBOX_CMD="$(command -v openbox)"
+  else
+    OPENBOX_CMD=""
+  fi
+
+  if [[ -z "$OPENBOX_CMD" ]]; then
+    log "openbox not available; skipping window manager"
+    return 1
+  fi
+
+  "$OPENBOX_CMD" &
+  OPENBOX_PID=$!
+  log "openbox started (cmd=$OPENBOX_CMD pid=$OPENBOX_PID)"
+  return 0
+}
+
+start_openbox || OPENBOX_PID=""
+
+shutdown_openbox() {
+  local pid="${OPENBOX_PID:-}"
+  [[ -n "$pid" ]] || return 0
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v openbox >/dev/null 2>&1; then
+    log "requesting openbox --exit"
+    openbox --exit >/dev/null 2>&1 || true
+  else
+    log "openbox binary missing for graceful shutdown"
+  fi
+
+  local waited=0
+  while kill -0 "$pid" >/dev/null 2>&1 && (( waited < 5 )); do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    log "openbox still running after ${waited}s; sending SIGTERM"
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+  fi
+
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    log "openbox still running; sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+
+  wait "$pid" 2>/dev/null || true
+  OPENBOX_PID=""
+}
+
+terminate_ui() {
+  local pid="${UI_PID:-}"
+  [[ -n "$pid" ]] || return 0
+  if ! kill -0 "$pid" >/dev/null 2>&1; then
+    UI_PID=""
+    return 0
+  fi
+
+  log "terminating UI process (pid=$pid)"
+  kill "$pid" 2>/dev/null || true
+  local waited=0
+  while kill -0 "$pid" >/dev/null 2>&1 && (( waited < 5 )); do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    log "UI still running; sending SIGKILL"
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+  wait "$pid" 2>/dev/null || true
+  UI_PID=""
+}
+
+handle_signal() {
+  local name="$1"
+  local code="$2"
+  log "received signal ${name}; stopping session"
+  terminate_ui
+  shutdown_openbox
+  log "session terminated by signal ${name}"
+  exit "$code"
+}
+
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
+trap 'handle_signal HUP 129' HUP
+
+run_ui() {
+  if [[ ! -x "$UI_ENTRY" ]]; then
+    log "UI entrypoint not executable: $UI_ENTRY"
+    return 1
+  fi
+
+  log "launching UI via $UI_ENTRY"
+  "$UI_ENTRY" >>"$LOG_FILE" 2>&1 &
+  UI_PID=$!
+  wait "$UI_PID"
+  local status=$?
+  UI_PID=""
+  return "$status"
+}
+
+run_ui
+ui_status=$?
+log "UI exited with status $ui_status"
+
+shutdown_openbox
+log "session ending with status $ui_status"
+exit "$ui_status"

--- a/systemd/bascula-app.service
+++ b/systemd/bascula-app.service
@@ -19,7 +19,8 @@ PermissionsStartOnly=yes
 ExecStartPre=/usr/bin/install -d -m 0755 -o pi -g pi /var/log/bascula
 ExecStartPre=/usr/bin/install -o pi -g pi -m 0644 /dev/null /var/log/bascula/app.log
 # IMPORTANTE: no pasar -logfile ni -keeptty a Xorg
-ExecStart=/usr/bin/startx /home/pi/.xinitrc -- :0 vt1
+ExecStartPre=/usr/bin/install -d -m 0700 -o pi -g pi /home/pi/.local/share/xorg
+ExecStart=/usr/bin/startx -- :0 vt1
 Restart=on-failure
 RestartSec=2
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- add a reusable xinitrc script that starts openbox, runs the UI in the foreground, and handles cleanup with logging
- create an openbox autostart helper for unclutter and wire the installers/run scripts to deploy the new templates
- adjust the systemd unit and startx wrappers to rely on ~/.xinitrc, pre-create required directories, and restart cleanly when the UI exits

## Testing
- bash -n scripts/xinitrc.kiosk scripts/run-ui.sh scripts/install-all.sh scripts/install_all.sh scripts/install-2-app.sh scripts/bascula-app-wrapper.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6c00a165c83269fdd661ddd2ab140