### PR TITLE
Implement Tkinter kiosk window preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ Los servicios también crean `~/.bascula/` para logs y datos históricos. 【F:b
 | `BASCULA_RUNTIME_DIR`, `BASCULA_PREFIX`, `BASCULA_VENV` | Directorios internos utilizados por los servicios systemd y OTA. 【F:scripts/install-2-app.sh†L48-L173】【F:systemd/bascula-alarmd.service†L10-L19】 | `/run/bascula`, `/opt/bascula/current`, `/opt/bascula/current/.venv` |
 | `BASCULA_UI_CURSOR`, `BASCULA_NO_EMOJI` | Controles UI para ocultar cursor o desactivar emoji. 【F:bascula/ui/app_shell.py†L214-L236】【F:bascula/ui/screens.py†L47-L75】 | Desactivados |
 
+### Modo kiosco Tkinter (fullscreen/undecorated)
+
+- La función `apply_kiosk_window_prefs` en `bascula/ui/windowing.py` aplica `-fullscreen`, fija la ventana como `topmost`, bloquea `Escape` y ajusta la geometría al tamaño real de la pantalla al arrancar la UI. 【F:bascula/ui/windowing.py†L1-L78】
+- Si la decoración persiste con el gestor de ventanas, exporta `BASCULA_KIOSK_STRICT=1` para activar `overrideredirect(True)` y suprimir cualquier barra residual. 【F:bascula/ui/windowing.py†L48-L66】
+- Para sesiones de desarrollo se puede definir `BASCULA_DEBUG_KIOSK=1` y alternar fullscreen con `F11` (gestiona `overrideredirect` antes/después del cambio). 【F:bascula/ui/windowing.py†L68-L77】
+- En instalaciones normales basta con el modo `-fullscreen`; el modo estricto sólo debe usarse si Openbox ignora la preferencia.
+
 ## Ejemplos de configuración TOML
 
 Los ficheros de `docs/examples/` son sintácticamente válidos y listos para copiar/editar:

--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -14,6 +14,7 @@ import tkinter as tk
 
 from .app_shell import AppShell
 from .icon_loader import load_icon
+from .windowing import apply_kiosk_window_prefs
 from .views.home import HomeView
 from .views.food_scanner import FoodScannerView
 from .overlays.calibration import CalibrationOverlay
@@ -91,6 +92,10 @@ class BasculaAppTk:
 
         self.ids: Dict[str, tk.Widget] = {}
         self._image_cache: Dict[str, tk.PhotoImage] = {}
+
+        if root is None:
+            root = tk.Tk()
+        apply_kiosk_window_prefs(root)
 
         self.shell = AppShell(root=root)
         self.root = self.shell.root

--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -63,17 +63,27 @@ class AppShell:
     # Window configuration
     # ------------------------------------------------------------------
     def _configure_window(self) -> None:
-        fullscreen = (os.environ.get("BASCULA_UI_FULLSCREEN") or "").strip().lower()
-        enable_fullscreen = fullscreen in {"1", "true", "yes", "on"}
+        fullscreen_env = (os.environ.get("BASCULA_UI_FULLSCREEN") or "").strip().lower()
+        enable_fullscreen = fullscreen_env in {"1", "true", "yes", "on"}
+
+        current_fullscreen = False
         try:
-            self.root.overrideredirect(enable_fullscreen)
-        except Exception as exc:  # pragma: no cover - Tk feature availability
-            log.debug("overrideredirect no soportado: %s", exc)
-        try:
-            self.root.attributes("-fullscreen", enable_fullscreen)
+            current_fullscreen = bool(self.root.attributes("-fullscreen"))
         except Exception:  # pragma: no cover - Tk feature availability
             pass
-        self.root.geometry("1024x600+0+0")
+
+        if enable_fullscreen and not current_fullscreen:
+            try:
+                self.root.overrideredirect(True)
+            except Exception as exc:  # pragma: no cover - Tk feature availability
+                log.debug("overrideredirect no soportado: %s", exc)
+            try:
+                self.root.attributes("-fullscreen", True)
+            except Exception:  # pragma: no cover - Tk feature availability
+                pass
+
+        if not current_fullscreen:
+            self.root.geometry("1024x600+0+0")
         self.root.minsize(1024, 600)
 
     # ------------------------------------------------------------------

--- a/bascula/ui/windowing.py
+++ b/bascula/ui/windowing.py
@@ -1,0 +1,88 @@
+"""Windowing helpers for configuring the Tk kiosk mode."""
+from __future__ import annotations
+
+import os
+import tkinter as tk
+from typing import Callable
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_flag(name: str) -> bool:
+    """Return ``True`` when the named environment variable is truthy."""
+
+    return (os.environ.get(name) or "").strip().lower() in _TRUE_VALUES
+
+
+def _safe_apply(call: Callable[..., object], *args: object) -> None:
+    """Run ``call`` with ``args`` swallowing ``tk.TclError`` exceptions."""
+
+    try:
+        call(*args)
+    except tk.TclError:
+        pass
+
+
+def _is_fullscreen(root: tk.Tk) -> bool:
+    """Best-effort detection of the current fullscreen state."""
+
+    for attr in ("attributes", "wm_attributes"):
+        getter = getattr(root, attr, None)
+        if getter is None:
+            continue
+        try:
+            value = bool(getter("-fullscreen"))
+        except tk.TclError:
+            continue
+        else:
+            return value
+    return False
+
+
+def apply_kiosk_window_prefs(root: tk.Tk) -> None:
+    """Configure ``root`` for the fullscreen/undecorated kiosk experience."""
+
+    strict_mode = _env_flag("BASCULA_KIOSK_STRICT")
+    debug_mode = _env_flag("BASCULA_DEBUG_KIOSK")
+
+    width = max(1, int(getattr(root, "winfo_screenwidth", lambda: 0)() or 0))
+    height = max(1, int(getattr(root, "winfo_screenheight", lambda: 0)() or 0))
+    if width and height:
+        root.geometry(f"{width}x{height}+0+0")
+
+    def _set_fullscreen(enabled: bool) -> None:
+        for attr in ("attributes", "wm_attributes"):
+            setter = getattr(root, attr, None)
+            if setter is None:
+                continue
+            _safe_apply(setter, "-fullscreen", enabled)
+        if enabled:
+            _safe_apply(root.state, "zoomed")
+        else:
+            _safe_apply(root.state, "normal")
+
+    _set_fullscreen(True)
+    _safe_apply(root.attributes, "-topmost", True)
+
+    def _escape_override(_event: tk.Event) -> str:
+        return "break"
+
+    root.bind("<Escape>", _escape_override, add="+")
+
+    if strict_mode:
+        _safe_apply(root.overrideredirect, True)
+
+    if debug_mode:
+
+        def _toggle_fullscreen(_event: tk.Event | None = None) -> str:
+            currently_fullscreen = _is_fullscreen(root)
+            if currently_fullscreen and strict_mode:
+                _safe_apply(root.overrideredirect, False)
+            _set_fullscreen(not currently_fullscreen)
+            if strict_mode and not currently_fullscreen:
+                _safe_apply(root.overrideredirect, True)
+            return "break"
+
+        root.bind("<F11>", _toggle_fullscreen, add="+")
+

--- a/tests/test_ui_windowing.py
+++ b/tests/test_ui_windowing.py
@@ -1,0 +1,19 @@
+"""Tests for the Tkinter kiosk window configuration helpers."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(not os.environ.get("DISPLAY"), reason="requires X server")
+def test_apply_kiosk_window_prefs() -> None:
+    tkinter = pytest.importorskip("tkinter")
+
+    from bascula.ui.windowing import apply_kiosk_window_prefs
+
+    root = tkinter.Tk()
+    try:
+        apply_kiosk_window_prefs(root)
+    finally:
+        root.destroy()


### PR DESCRIPTION
## Summary
- add a dedicated Tkinter kiosk helper that drives fullscreen, topmost and strict overrideredirect handling
- integrate the helper in the UI bootstrap while keeping existing shell wiring untouched and adjusting AppShell to respect preset fullscreen
- document the kiosk flags and add a smoke test that instantiates Tk and applies the new preferences

## Testing
- `pytest tests/test_ui_windowing.py`

## Cómo verificar
```bash
# 1) Arrancar kiosco
sudo systemctl restart bascula-app
systemctl status bascula-app --no-pager

# 2) Log de la app (ver que se aplican prefs)
tail -n 80 /var/log/bascula/app.log

# 3) Procesos Xorg/openbox/Tk
pgrep -af "Xorg|startx|openbox|python"

# 4) Modo estricto (si aún hubiera decoración)
sudo sh -c 'echo BASCULA_KIOSK_STRICT=1 >> /etc/default/bascula-app'
sudo systemctl restart bascula-app

# 5) Debug opcional (en desarrollo, no en producción)
sudo sh -c 'echo BASCULA_DEBUG_KIOSK=1 >> /etc/default/bascula-app'
sudo systemctl restart bascula-app
# (Probar F11 para alternar fullscreen)
```


------
https://chatgpt.com/codex/tasks/task_e_68d6c684ca808326bf3822fc271f76c1