### PR TITLE
Ensure kiosk mode enforces undecorated fullscreen windows

### DIFF
--- a/bascula/ui/focus_screen.py
+++ b/bascula/ui/focus_screen.py
@@ -19,6 +19,7 @@ from bascula.ui.overlay_favorites import FavoritesOverlay
 from bascula.ui.overlay_scanner import ScannerOverlay
 from bascula.ui.overlay_1515 import Protocol1515Overlay
 from bascula.ui.screens import BaseScreen
+from bascula.ui.windowing import apply_kiosk_to_toplevel
 from bascula.services.voice import VoiceService
 from bascula.services.off_lookup import fetch_off
 from bascula.domain.foods import upsert_from_off
@@ -163,10 +164,7 @@ class FocusScreen(BaseScreen):
 
     def _ask_add_to_favorites(self, name: str, macros: dict, entry: dict):
         top = tk.Toplevel(self)
-        try:
-            top.attributes('-topmost', True)
-        except Exception:
-            pass
+        apply_kiosk_to_toplevel(top)
         top.transient(self.winfo_toplevel())
         top.configure(bg=COL_BG)
         top.title('Resultado escáner')

--- a/bascula/ui/overlay_base.py
+++ b/bascula/ui/overlay_base.py
@@ -1,17 +1,15 @@
 import tkinter as tk
+
 from bascula.ui.widgets import COL_BG, COL_CARD, COL_BORDER
+from .windowing import apply_kiosk_to_toplevel
 
 
 class OverlayBase(tk.Toplevel):
     """Base overlay no modal con transición alpha y backdrop."""
     def __init__(self, parent, **kwargs):
         super().__init__(parent)
+        apply_kiosk_to_toplevel(self)
         self.withdraw()
-        self.overrideredirect(True)
-        try:
-            self.attributes('-topmost', True)
-        except Exception:
-            pass
         self.configure(bg=COL_BG)
         self._alpha = 0.0
         self._target_alpha = 0.92

--- a/bascula/ui/overlay_recipe.py
+++ b/bascula/ui/overlay_recipe.py
@@ -13,6 +13,7 @@ from bascula.ui.widgets import (
 )
 from bascula.ui.widgets_mascota import MascotaCanvas
 from bascula.ui.overlay_scanner import ScannerOverlay
+from bascula.ui.windowing import apply_kiosk_to_toplevel
 from bascula.ui.anim_target import TargetLockAnimator
 from bascula.services.off_lookup import fetch_off
 from bascula.services.voice import VoiceService
@@ -264,10 +265,7 @@ class RecipeOverlay(OverlayBase):
 
     def _open_saved_popup(self):
         top = tk.Toplevel(self)
-        try:
-            top.attributes('-topmost', True)
-        except Exception:
-            pass
+        apply_kiosk_to_toplevel(top)
         top.transient(self.winfo_toplevel()); top.configure(bg=COL_BG)
         fr = Card(top, min_width=420, min_height=280)
         fr.pack(fill='both', expand=True, padx=10, pady=10)

--- a/bascula/ui/splash.py
+++ b/bascula/ui/splash.py
@@ -2,7 +2,9 @@
 # -*- coding: utf-8 -*-
 import tkinter as tk
 import itertools
+
 from bascula.ui.widgets import COL_BG, COL_CARD, COL_TEXT, COL_ACCENT, COL_BORDER, FS_TITLE, FS_TEXT
+from bascula.ui.windowing import apply_kiosk_to_toplevel
 
 
 class SplashScreen(tk.Toplevel):
@@ -14,13 +16,9 @@ class SplashScreen(tk.Toplevel):
 
     def __init__(self, master, title="Báscula Digital Pro", subtitle="Iniciando...", *args, **kwargs):
         super().__init__(master, *args, **kwargs)
+        apply_kiosk_to_toplevel(self)
         # Ventana sin bordes, por encima de todo
-        self.overrideredirect(True)
         self.configure(bg=COL_BG)
-        try:
-            self.attributes("-topmost", True)
-        except Exception:
-            pass
 
         # Centrar en pantalla
         sw = self.winfo_screenwidth(); sh = self.winfo_screenheight()

--- a/bascula/ui/views/food_scanner.py
+++ b/bascula/ui/views/food_scanner.py
@@ -18,6 +18,7 @@ from ...services.nutrition_ai import (
     analyze_food,
 )
 from ..theme_neo import COLORS, SPACING, font_sans
+from ..windowing import apply_kiosk_to_toplevel
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ class FoodScannerView(tk.Toplevel):
 
     def __init__(self, controller, scale, camera=None, tts=None) -> None:
         super().__init__(controller.root if hasattr(controller, "root") else controller)
+        apply_kiosk_to_toplevel(self)
         self.title("Escáner de alimentos")
         self.configure(bg=COLORS["bg"], padx=SPACING["lg"], pady=SPACING["lg"])
         self.transient(controller.root if hasattr(controller, "root") else controller)
@@ -489,6 +491,7 @@ class SummaryDialog(tk.Toplevel):
 
     def __init__(self, parent, totals: Dict[str, Optional[float]], items: List[FoodItem]) -> None:
         super().__init__(parent)
+        apply_kiosk_to_toplevel(self)
         self.title("Resumen de alimentos")
         self.configure(bg=COLORS["surface"], padx=SPACING["lg"], pady=SPACING["lg"])
         self.resizable(False, False)

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -4,6 +4,8 @@ import tkinter as tk
 from tkinter import ttk
 import tkinter.font as tkfont
 
+from bascula.ui.windowing import apply_kiosk_to_toplevel
+
 # Paleta
 COL_BG = "#0a0e1a"; COL_CARD = "#141823"; COL_CARD_HOVER = "#1a1f2e"; COL_TEXT = "#f0f4f8"
 COL_MUTED = "#8892a0"; COL_ACCENT = "#00d4aa"; COL_ACCENT_LIGHT = "#00ffcc"; COL_SUCCESS = "#00d4aa"
@@ -267,10 +269,9 @@ class SoftKeyboard(tk.Frame):
 class KeypadPopup(tk.Toplevel):
     def __init__(self, parent, title="Introducir valor", initial="", allow_dot=True, on_accept=None, on_cancel=None):
         super().__init__(parent.winfo_toplevel())
+        apply_kiosk_to_toplevel(self)
         self.withdraw(); self.configure(bg=COL_BG); self.transient(parent.winfo_toplevel()); self.grab_set(); self.title(title)
         self.resizable(False, False)
-        try: self.attributes("-topmost", True)
-        except Exception: pass
         card = Card(self, min_width=380, min_height=480); card.pack(fill="both", expand=True, padx=10, pady=10)
         tk.Label(card, text=title, bg=COL_CARD, fg=COL_ACCENT, font=("DejaVu Sans", FS_CARD_TITLE, "bold")).pack(anchor="w")
         self._var = tk.StringVar(value=str(initial) if initial is not None else "")
@@ -312,9 +313,8 @@ class KeypadPopup(tk.Toplevel):
 class TextKeyPopup(tk.Toplevel):
     def __init__(self, parent, title="Introducir texto", initial="", on_accept=None, on_cancel=None, password: bool=False):
         super().__init__(parent.winfo_toplevel())
+        apply_kiosk_to_toplevel(self)
         self.withdraw(); self.configure(bg=COL_BG); self.transient(parent.winfo_toplevel()); self.grab_set(); self.title(title)
-        try: self.attributes("-topmost", True)
-        except Exception: pass
         card = Card(self, min_width=400, min_height=420); card.pack(fill="both", expand=True, padx=10, pady=10)
 
         tk.Label(card, text=title, bg=COL_CARD, fg=COL_ACCENT, font=("DejaVu Sans", FS_CARD_TITLE, "bold")).pack(anchor="w", pady=(0,4))
@@ -352,7 +352,8 @@ class TextKeyPopup(tk.Toplevel):
 class Toast(tk.Toplevel):
     def __init__(self, parent):
         super().__init__(parent)
-        self.withdraw(); self.overrideredirect(True); self.configure(bg=COL_BG)
+        apply_kiosk_to_toplevel(self)
+        self.withdraw(); self.configure(bg=COL_BG)
         self._lbl = tk.Label(self, text="", bg=COL_ACCENT, fg=COL_BG, font=("DejaVu Sans", FS_ENTRY, "bold"),
                              padx=get_scaled_size(10), pady=get_scaled_size(6))
         self._lbl.pack()
@@ -407,9 +408,8 @@ class TouchScrollableFrame(tk.Frame):
 class TimerPopup(tk.Toplevel):
     def __init__(self, parent, title="Temporizador", presets=(5,10,15,30), on_finish=None, on_accept=None):
         super().__init__(parent.winfo_toplevel())
+        apply_kiosk_to_toplevel(self)
         self.withdraw(); self.configure(bg=COL_BG); self.transient(parent.winfo_toplevel()); self.grab_set(); self.title(title)
-        try: self.attributes("-topmost", True)
-        except Exception: pass
         self.running = False; self.remaining = 0; self._after = None
         self.on_finish = on_finish
         self.on_accept = on_accept
@@ -553,9 +553,8 @@ def bind_text_popup(entry_widget, *, title="Introducir texto", password=False):
 class SoftKeyPopup(tk.Toplevel):
     def __init__(self, parent, title="Introducir texto", initial="", password=False, on_accept=None, on_cancel=None):
         super().__init__(parent.winfo_toplevel())
+        apply_kiosk_to_toplevel(self)
         self.withdraw(); self.configure(bg=COL_BG); self.transient(parent.winfo_toplevel()); self.grab_set(); self.title(title)
-        try: self.attributes("-topmost", True)
-        except Exception: pass
         card = Card(self, min_width=520, min_height=520); card.pack(fill="both", expand=True, padx=10, pady=10)
         tk.Label(card, text=title, bg=COL_CARD, fg=COL_ACCENT, font=("DejaVu Sans", FS_CARD_TITLE, "bold")).pack(anchor="w", pady=(0,4))
         self._var = tk.StringVar(value=str(initial) if initial is not None else "")
@@ -670,10 +669,10 @@ class ScrollingBanner(tk.Frame):
 # ================= Teclado numérico emergente unificado =================
 def _open_numeric_keypad_for(entry: tk.Entry, decimals:int=0):
     top = tk.Toplevel(entry.winfo_toplevel())
+    apply_kiosk_to_toplevel(top)
     top.transient(entry.winfo_toplevel())
     top.title("Teclado")
     top.configure(bg=COL_CARD)
-    top.attributes("-topmost", True)
     try: top.grab_set()
     except Exception: pass
 

--- a/bascula/ui/windowing.py
+++ b/bascula/ui/windowing.py
@@ -1,12 +1,32 @@
 """Windowing helpers for configuring the Tk kiosk mode."""
 from __future__ import annotations
 
+import logging
 import os
 import tkinter as tk
-from typing import Callable
+import weakref
+from dataclasses import dataclass, field
+from typing import Callable, Optional
 
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass
+class _KioskConfig:
+    """Runtime configuration of kiosk windowing preferences."""
+
+    strict: bool
+    force: bool
+    hard: bool
+    debug: bool
+    enforce_override: bool
+    root: Optional[tk.Tk]
+    logger: logging.Logger
+    windows: "weakref.WeakSet[tk.Misc]" = field(default_factory=weakref.WeakSet)
+
+
+_CONFIG: Optional[_KioskConfig] = None
 
 
 def _env_flag(name: str) -> bool:
@@ -24,7 +44,31 @@ def _safe_apply(call: Callable[..., object], *args: object) -> None:
         pass
 
 
-def _is_fullscreen(root: tk.Tk) -> bool:
+def _ensure_config(window: tk.Misc | None = None) -> _KioskConfig:
+    """Return the active kiosk configuration, creating a default one if needed."""
+
+    global _CONFIG
+    if _CONFIG is not None:
+        return _CONFIG
+
+    logger = logging.getLogger("bascula.ui.windowing")
+    strict = _env_flag("BASCULA_KIOSK_STRICT")
+    force = _env_flag("BASCULA_KIOSK_FORCE")
+    hard = _env_flag("BASCULA_KIOSK_HARD")
+    debug = _env_flag("BASCULA_DEBUG_KIOSK") and not hard
+    _CONFIG = _KioskConfig(
+        strict=strict,
+        force=force,
+        hard=hard,
+        debug=debug,
+        enforce_override=strict or force or hard,
+        root=window.winfo_toplevel() if window is not None else None,
+        logger=logger,
+    )
+    return _CONFIG
+
+
+def _is_fullscreen(root: tk.Misc) -> bool:
     """Best-effort detection of the current fullscreen state."""
 
     for attr in ("attributes", "wm_attributes"):
@@ -40,49 +84,215 @@ def _is_fullscreen(root: tk.Tk) -> bool:
     return False
 
 
+def _window_label(window: tk.Misc, fallback: str) -> str:
+    """Build a human readable label for ``window`` for logging purposes."""
+
+    name = getattr(window, "name", "") or ""
+    try:
+        if not name:
+            name = window.winfo_name()
+    except tk.TclError:
+        name = ""
+    prefix = window.__class__.__name__
+    if fallback:
+        prefix = fallback
+    return f"{prefix}:{name}" if name else prefix
+
+
+def _set_fullscreen(root: tk.Misc, enabled: bool) -> None:
+    """Toggle fullscreen for ``root`` across Tk variants."""
+
+    for attr in ("attributes", "wm_attributes"):
+        setter = getattr(root, attr, None)
+        if setter is None:
+            continue
+        _safe_apply(setter, "-fullscreen", enabled)
+    if enabled:
+        _safe_apply(root.state, "zoomed")
+    else:
+        _safe_apply(root.state, "normal")
+
+
+def _set_topmost(window: tk.Misc, enabled: bool = True) -> None:
+    """Apply the ``-topmost`` attribute consistently."""
+
+    for attr in ("attributes", "wm_attributes"):
+        setter = getattr(window, attr, None)
+        if setter is None:
+            continue
+        _safe_apply(setter, "-topmost", enabled)
+
+
+def _log_window_state(window: tk.Misc, label: str, *, include_fullscreen: bool = False) -> None:
+    """Emit a log line summarising the window decoration state."""
+
+    config = _ensure_config(window)
+    try:
+        override = bool(window.overrideredirect())
+    except tk.TclError:
+        override = False
+    try:
+        topmost = bool(window.attributes("-topmost"))
+    except tk.TclError:
+        topmost = False
+
+    if include_fullscreen:
+        fullscreen = _is_fullscreen(window)
+        config.logger.info(
+            "Kiosk %s state: fullscreen=%s overrideredirect=%s topmost=%s",
+            label,
+            fullscreen,
+            override,
+            topmost,
+        )
+    else:
+        config.logger.info(
+            "Kiosk %s state: overrideredirect=%s topmost=%s",
+            label,
+            override,
+            topmost,
+        )
+
+
+def _enforce_override(window: tk.Misc, label: str, *, log_state: bool = True) -> None:
+    """Ensure ``overrideredirect(True)`` sticks with a delayed reaffirmation."""
+
+    config = _ensure_config(window)
+    if not config.enforce_override:
+        return
+
+    _safe_apply(window.overrideredirect, True)
+
+    def _finalise() -> None:
+        _safe_apply(window.overrideredirect, True)
+        _set_topmost(window, True)
+        if log_state:
+            _log_window_state(window, label, include_fullscreen=False)
+
+    try:
+        window.after(200, _finalise)
+    except tk.TclError:
+        _finalise()
+
+
+def _bind_reapply(window: tk.Misc, label: str) -> None:
+    """Bind events so decorations cannot return after mapping/unmapping."""
+
+    def _reapply(_event: tk.Event | None = None) -> None:
+        _set_topmost(window, True)
+        _enforce_override(window, label, log_state=False)
+
+    for sequence in ("<Map>", "<Visibility>", "<Expose>"):
+        try:
+            window.bind(sequence, _reapply, add="+")
+        except tk.TclError:
+            continue
+
+
 def apply_kiosk_window_prefs(root: tk.Tk) -> None:
     """Configure ``root`` for the fullscreen/undecorated kiosk experience."""
 
-    strict_mode = _env_flag("BASCULA_KIOSK_STRICT")
-    debug_mode = _env_flag("BASCULA_DEBUG_KIOSK")
+    config = _ensure_config(root)
+    config.root = root
 
     width = max(1, int(getattr(root, "winfo_screenwidth", lambda: 0)() or 0))
     height = max(1, int(getattr(root, "winfo_screenheight", lambda: 0)() or 0))
     if width and height:
+        config.logger.info("Detected screen resolution: %sx%s", width, height)
         root.geometry(f"{width}x{height}+0+0")
 
-    def _set_fullscreen(enabled: bool) -> None:
-        for attr in ("attributes", "wm_attributes"):
-            setter = getattr(root, attr, None)
-            if setter is None:
-                continue
-            _safe_apply(setter, "-fullscreen", enabled)
-        if enabled:
-            _safe_apply(root.state, "zoomed")
-        else:
-            _safe_apply(root.state, "normal")
+    config.logger.info(
+        "Kiosk flags: strict=%s force=%s hard=%s debug=%s",
+        config.strict,
+        config.force,
+        config.hard,
+        config.debug,
+    )
 
-    _set_fullscreen(True)
-    _safe_apply(root.attributes, "-topmost", True)
+    _set_fullscreen(root, True)
+    _set_topmost(root, True)
+    _bind_reapply(root, "root")
 
     def _escape_override(_event: tk.Event) -> str:
         return "break"
 
-    root.bind("<Escape>", _escape_override, add="+")
+    try:
+        root.bind_all("<Escape>", _escape_override, add="+")
+    except tk.TclError:
+        pass
 
-    if strict_mode:
-        _safe_apply(root.overrideredirect, True)
+    if config.enforce_override:
+        _enforce_override(root, "root")
+    else:
+        _log_window_state(root, "root", include_fullscreen=True)
 
-    if debug_mode:
+    def _log_root_state() -> None:
+        _log_window_state(root, "root", include_fullscreen=True)
+
+    try:
+        root.after(300, _log_root_state)
+    except tk.TclError:
+        _log_root_state()
+
+    if config.debug:
 
         def _toggle_fullscreen(_event: tk.Event | None = None) -> str:
             currently_fullscreen = _is_fullscreen(root)
-            if currently_fullscreen and strict_mode:
+            if currently_fullscreen and config.enforce_override:
                 _safe_apply(root.overrideredirect, False)
-            _set_fullscreen(not currently_fullscreen)
-            if strict_mode and not currently_fullscreen:
-                _safe_apply(root.overrideredirect, True)
+            _set_fullscreen(root, not currently_fullscreen)
+            if not currently_fullscreen:
+                _set_topmost(root, True)
+                if config.enforce_override:
+                    _enforce_override(root, "root")
+            else:
+                _log_window_state(root, "root", include_fullscreen=True)
+            config.logger.info(
+                "F11 toggle processed: fullscreen=%s overrideredirect=%s",
+                not currently_fullscreen,
+                bool(root.overrideredirect()) if hasattr(root, "overrideredirect") else False,
+            )
             return "break"
 
-        root.bind("<F11>", _toggle_fullscreen, add="+")
+        try:
+            root.bind("<F11>", _toggle_fullscreen, add="+")
+        except tk.TclError:
+            pass
+
+
+def apply_kiosk_to_toplevel(window: tk.Toplevel) -> None:
+    """Apply kiosk preferences to secondary toplevel windows."""
+
+    if not isinstance(window, tk.Toplevel):  # Defensive guard for duck typed widgets
+        return
+
+    if getattr(window, "_bascula_kiosk_applied", False):
+        return
+
+    config = _ensure_config(window)
+    if config.hard:
+        config.debug = False
+
+    setattr(window, "_bascula_kiosk_applied", True)
+    try:
+        config.windows.add(window)
+    except Exception:
+        pass
+
+    label = _window_label(window, window.__class__.__name__)
+    _set_topmost(window, True)
+    _bind_reapply(window, label)
+
+    if config.enforce_override:
+        _enforce_override(window, label)
+    else:
+        _log_window_state(window, label, include_fullscreen=False)
+
+    def _final_log() -> None:
+        _log_window_state(window, label, include_fullscreen=False)
+
+    try:
+        window.after(300, _final_log)
+    except tk.TclError:
+        _final_log()
 


### PR DESCRIPTION
## Summary
- configure the UI logger to write kiosk startup diagnostics, including fullscreen and override flags.
- overhaul kiosk windowing helpers to force fullscreen/topmost behavior, manage overrideredirect for root/toplevels, and support debug toggling.
- apply the shared kiosk helper across overlays, popups, dialogs, and splash screens so every Toplevel inherits the kiosk configuration.

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68d6c927bae08326b16e0ebfa134ae6e