### PR TITLE
Add bolus guidance and medical disclaimers to food scanner

### DIFF
--- a/bascula/ui/messages.py
+++ b/bascula/ui/messages.py
@@ -1,0 +1,10 @@
+"""Shared text snippets for the Báscula UI."""
+
+MEDICAL_DISCLAIMER = (
+    "Estimación nutricional y de bolos. No es un consejo médico. "
+    "Consulta siempre con tu profesional sanitario antes de actuar."
+)
+
+
+__all__ = ["MEDICAL_DISCLAIMER"]
+


### PR DESCRIPTION
## Summary
- add a shared medical disclaimer constant and surface it in the food scanner view and summary dialog
- compute optional bolus recommendations using diabetes settings and latest Nightscout glucose data when finishing a food scan
- extend voice summaries and status messaging to announce totals together with bolus guidance when available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d0e0eed4832693111230636cc2b4