### PR TITLE
Add bolus guidance and medical disclaimers to food scanner

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -898,7 +898,14 @@ class BasculaAppTk:
             try:
                 config = self.nightscout.get_config()
                 if isinstance(config, dict) and config:
-                    return dict(config)
+                    mapped = dict(config)
+                    if "carb_ratio_g_per_u" not in mapped and "icr" in mapped:
+                        mapped["carb_ratio_g_per_u"] = mapped.get("icr")
+                    if "isf_mgdl_per_u" not in mapped and "isf" in mapped:
+                        mapped["isf_mgdl_per_u"] = mapped.get("isf")
+                    if "target_bg_mgdl" not in mapped and "target" in mapped:
+                        mapped["target_bg_mgdl"] = mapped.get("target")
+                    return mapped
             except Exception:
                 log.debug("No se pudo obtener config de Nightscout", exc_info=True)
 


### PR DESCRIPTION
## Summary
- add a shared medical disclaimer constant and surface it in the food scanner view and summary dialog
- compute optional bolus recommendations using diabetes settings and latest Nightscout glucose data when finishing a food scan
- extend voice summaries and status messaging to announce totals together with bolus guidance when available
- map Nightscout config keys to the bolus helper's expected field names so existing carb ratio, ISF, and target settings are honored

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6d5309c50832682b11f0efd0f14b2