### PR TITLE
Use lgpio HX711 backend and surface no-signal state

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -5,6 +5,7 @@ import logging
 import os
 import tkinter as tk
 from tkinter import messagebox
+from typing import Optional
 
 from ..config.settings import Settings
 from ..services.audio import AudioService
@@ -147,7 +148,7 @@ class BasculaApp:
         log.info("Pantalla activa: %s", route)
 
     # ------------------------------------------------------------------
-    def _on_weight(self, value: float, stable: bool, unit: str) -> None:
+    def _on_weight(self, value: Optional[float], stable: bool, unit: str) -> None:
         self.root.after(0, lambda: self.screens["home"].update_weight(value, stable, unit))
 
     def _on_glucose(self, reading) -> None:

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from ..services.nutrition import FoodEntry
 from .widgets import PALETTE, PrimaryButton, TotalsTable, WeightDisplay
@@ -53,8 +53,13 @@ class HomeScreen(BaseScreen):
         btn.grid(row=0, column=column, padx=10, pady=10, sticky="nsew")
         frame.grid_columnconfigure(column, weight=1)
 
-    def update_weight(self, value: float, stable: bool, unit: str) -> None:
-        formatted = f"{value:.{self.app.settings.scale.decimals}f} {unit}"
+    def update_weight(self, value: Optional[float], stable: bool, unit: str) -> None:
+        if value is None:
+            self.weight_display.configure(text="--")
+            self.status_label.configure(text="Sin señal")
+            return
+        decimals = self.app.settings.scale.decimals
+        formatted = f"{value:.{decimals}f} {unit}"
         self.weight_display.configure(text=formatted)
         self.status_label.configure(text="Peso estable" if stable else "Midiendo...")
 

--- a/bascula/ui/views/food_scanner.py
+++ b/bascula/ui/views/food_scanner.py
@@ -42,6 +42,7 @@ class FoodScannerView(tk.Toplevel):
 
         self._current_weight: float = 0.0
         self._stable: bool = False
+        self._has_signal: bool = False
         self._items: Dict[str, FoodItem] = {}
         self._busy = False
         self._barcode_icon = _create_barcode_icon()
@@ -213,15 +214,25 @@ class FoodScannerView(tk.Toplevel):
         self._disclaimer_label = disclaimer
 
     # ------------------------------------------------------------------
-    def _on_scale_update(self, weight: float, stable: bool) -> None:
-        self._current_weight = float(weight)
-        self._stable = bool(stable)
+    def _on_scale_update(self, weight: Optional[float], stable: bool) -> None:
+        if weight is None:
+            self._has_signal = False
+            self._current_weight = 0.0
+            self._stable = False
+        else:
+            self._has_signal = True
+            self._current_weight = float(weight)
+            self._stable = bool(stable)
         try:
             self.after(0, self._update_weight_label)
         except Exception:
             pass
 
     def _update_weight_label(self) -> None:
+        if not self._has_signal:
+            self._weight_var.set("--")
+            self._stable_var.set("Sin señal")
+            return
         self._weight_var.set(f"{self._current_weight:.1f} g")
         self._stable_var.set("Estable" if self._stable else "Inestable")
 


### PR DESCRIPTION
## Summary
- replace the Raspberry Pi GPIO HX711 backend with an lgpio-based implementation and remove the simulator fallback
- propagate no-signal conditions as `None`, log "Scale: no signal", and keep the Tk heartbeat active
- update Tk screens to display `--` when the scale has no signal and adjust tests for the new behaviour

## Testing
- pytest tests/test_scale_backend_select.py

------
https://chatgpt.com/codex/tasks/task_e_68d7882af33483268c745d509239cad3