### PR TITLE
Improve HX711 lgpio backend reliability

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -58,8 +58,9 @@ class HomeScreen(BaseScreen):
             self.weight_display.configure(text="--")
             self.status_label.configure(text="Sin señal")
             return
-        decimals = self.app.settings.scale.decimals
-        formatted = f"{value:.{decimals}f} {unit}"
+        decimals = self.app.scale_service.get_decimals()
+        formatted_value = f"{value:.{decimals}f}" if decimals >= 0 else f"{value}"
+        formatted = f"{formatted_value} {unit}"
         self.weight_display.configure(text=formatted)
         self.status_label.configure(text="Peso estable" if stable else "Midiendo...")
 

--- a/tests/test_hx711_lgpio_init.py
+++ b/tests/test_hx711_lgpio_init.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bascula.services import scale
+
+
+class FakeLgpio:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple]] = []
+        self.handle = 42
+
+    def gpiochip_open(self, chip: int) -> int:
+        self.calls.append(("open", (chip,)))
+        return self.handle
+
+    def gpio_claim_input(self, handle: int, pin: int) -> None:
+        self.calls.append(("claim_input", (handle, pin)))
+
+    def gpio_claim_output(self, handle: int, pin: int, value: int) -> None:
+        self.calls.append(("claim_output", (handle, pin, value)))
+
+    def gpio_write(self, handle: int, pin: int, value: int) -> None:
+        self.calls.append(("write", (handle, pin, value)))
+
+    def gpio_free(self, handle: int, pin: int) -> None:
+        self.calls.append(("free", (handle, pin)))
+
+    def gpiochip_close(self, handle: int) -> None:
+        self.calls.append(("close", (handle,)))
+
+
+def test_hx711_lgpio_initialisation(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    fake_gpio = FakeLgpio()
+    monkeypatch.setattr(scale, "lgpio", fake_gpio)
+
+    logger = logging.getLogger("test.scale.hx711")
+    caplog.set_level(logging.INFO, logger="test.scale.hx711")
+
+    backend = scale.HX711GpioBackend(5, 6, logger=logger)
+
+    try:
+        assert ("open", (0,)) in fake_gpio.calls
+        assert ("claim_input", (fake_gpio.handle, 5)) in fake_gpio.calls
+        assert ("claim_output", (fake_gpio.handle, 6, 0)) in fake_gpio.calls
+
+        messages = [record.message for record in caplog.records]
+        assert (
+            "Scale backend: HX711_GPIO (lgpio) inicializado (chip=0, dt=5, sck=6)" in messages
+        )
+    finally:
+        backend.stop()
+
+    assert ("write", (fake_gpio.handle, 6, 0)) in fake_gpio.calls
+    assert ("free", (fake_gpio.handle, 6)) in fake_gpio.calls
+    assert ("free", (fake_gpio.handle, 5)) in fake_gpio.calls
+    assert ("close", (fake_gpio.handle,)) in fake_gpio.calls

--- a/tests/test_no_signal_heartbeat.py
+++ b/tests/test_no_signal_heartbeat.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import queue
+import time
+
+import pytest
+
+from bascula.config.settings import ScaleSettings
+from bascula.services import scale
+
+
+class NoSignalLgpio:
+    def __init__(self) -> None:
+        self.handle = 21
+
+    def gpiochip_open(self, chip: int) -> int:
+        return self.handle
+
+    def gpio_claim_input(self, handle: int, pin: int) -> None:  # pragma: no cover - simple mock
+        pass
+
+    def gpio_claim_output(self, handle: int, pin: int, value: int) -> None:  # pragma: no cover - simple mock
+        pass
+
+    def gpio_read(self, handle: int, pin: int) -> int:
+        return 1  # DT line never goes low
+
+    def gpio_write(self, handle: int, pin: int, value: int) -> None:  # pragma: no cover - simple mock
+        pass
+
+    def gpio_free(self, handle: int, pin: int) -> None:  # pragma: no cover - simple mock
+        pass
+
+    def gpiochip_close(self, handle: int) -> None:  # pragma: no cover - simple mock
+        pass
+
+
+def test_no_signal_generates_none_heartbeats(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(scale, "lgpio", NoSignalLgpio())
+
+    caplog.set_level(logging.WARNING, logger="bascula.scale")
+    settings = ScaleSettings(hx711_dt=5, hx711_sck=6, smoothing=1, decimals=0)
+    service = scale.ScaleService(settings, logger=scale.LOGGER)
+
+    updates: "queue.Queue[tuple[object, bool, str, float]]" = queue.Queue()
+
+    def callback(value: object, stable: bool, unit: str = "g") -> None:
+        updates.put((value, stable, unit, time.monotonic()))
+
+    service.subscribe(callback)
+
+    try:
+        deadline = time.monotonic() + 2.5
+        collected: list[tuple[object, bool, str, float]] = []
+        while time.monotonic() < deadline and len(collected) < 4:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                collected.append(updates.get(timeout=remaining))
+            except queue.Empty:
+                break
+
+        assert len(collected) >= 3, "expected repeated None heartbeats when HX711 has no data"
+        assert all(item[0] is None for item in collected)
+
+        timestamps = [item[3] for item in collected]
+        diffs = [b - a for a, b in zip(timestamps, timestamps[1:])]
+        assert diffs, "expected more than one heartbeat interval"
+
+        steady_diffs = diffs[1:] if len(diffs) > 1 else diffs
+        assert steady_diffs, "expected at least one rate-limited heartbeat"
+        for diff in steady_diffs:
+            assert diff >= 0.45
+            assert diff <= 0.8
+        lost_messages = [record.message for record in caplog.records if "Scale: signal LOST" in record.message]
+        if lost_messages:
+            assert lost_messages[:1] == ["Scale: signal LOST (hx711 no data)"]
+            assert lost_messages.count(lost_messages[0]) == 1
+    finally:
+        service.stop()

--- a/tests/test_signal_transition.py
+++ b/tests/test_signal_transition.py
@@ -124,6 +124,7 @@ def test_signal_transition(monkeypatch: pytest.MonkeyPatch) -> None:
 
         lost_logs = [msg for level, msg in logger.records if "Scale: signal LOST" in msg]
         assert len(lost_logs) == 1
+        assert lost_logs[0] == "Scale: signal LOST (no signal)"
 
         # No additional logs beyond the single transition entries.
         assert restored_logs.count(restored_logs[0]) == 1


### PR DESCRIPTION
## Summary
- add robust lgpio setup/cleanup, logging, and timeout handling to the HX711 backend with rate-limited heartbeats
- update the home screen weight display to honour service decimals and show `--` when the signal is missing
- cover the behaviour with new tests for lgpio initialisation, heartbeat emission, and signal transition logging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7999496688326989ed87b2560e82d