### PR TITLE
Add UI heartbeat writer and improve scale signal handling

### DIFF
--- a/bascula/runtime/__init__.py
+++ b/bascula/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime helpers for the kiosk environment."""
+
+from .heartbeat import HeartbeatWriter
+
+__all__ = ["HeartbeatWriter"]

--- a/bascula/runtime/heartbeat.py
+++ b/bascula/runtime/heartbeat.py
@@ -1,0 +1,90 @@
+"""Utilities for emitting heartbeat signals expected by safe_run."""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+__all__ = ["HeartbeatWriter"]
+
+log = logging.getLogger(__name__)
+
+
+class HeartbeatWriter:
+    """Periodically touch a file so watchdog scripts detect the UI is alive."""
+
+    def __init__(self, file_path: str | os.PathLike[str] = "/run/bascula/heartbeat", interval: float = 2.0) -> None:
+        self._file_path = Path(file_path)
+        self._interval = max(0.1, float(interval))
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._warned = False
+
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start emitting heartbeat touches."""
+
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._ensure_paths()
+            self._write_heartbeat()
+            self._thread = threading.Thread(target=self._run, name="HeartbeatWriter", daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the heartbeat thread."""
+
+        with self._lock:
+            self._stop_event.set()
+            thread = self._thread
+        if thread and thread.is_alive():
+            thread.join(timeout=self._interval * 2)
+        with self._lock:
+            self._thread = None
+
+    # ------------------------------------------------------------------
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._interval):
+            self._write_heartbeat()
+
+    # ------------------------------------------------------------------
+    def _ensure_paths(self) -> None:
+        directory = self._file_path.parent
+        try:
+            directory.mkdir(mode=0o777, parents=True, exist_ok=True)
+            os.chmod(directory, 0o777)
+        except Exception as exc:
+            log.debug("Failed to ensure heartbeat directory %s: %s", directory, exc)
+        if not self._file_path.exists():
+            try:
+                self._touch_file()
+            except Exception as exc:
+                log.debug("Failed to create heartbeat file %s: %s", self._file_path, exc)
+        try:
+            os.chmod(self._file_path, 0o666)
+        except Exception:
+            # Best effort, permissions might not be changeable for non-root user
+            pass
+
+    def _write_heartbeat(self) -> None:
+        try:
+            self._touch_file()
+            if self._warned:
+                self._warned = False
+        except Exception as exc:
+            if not self._warned:
+                log.warning("No se pudo escribir heartbeat en %s: %s", self._file_path, exc)
+                self._warned = True
+
+    def _touch_file(self) -> None:
+        payload = f"{time.time():.6f}\n"
+        with open(self._file_path, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())

--- a/tests/test_heartbeat_writer.py
+++ b/tests/test_heartbeat_writer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from bascula.runtime import HeartbeatWriter
+
+
+def _wait_for_mtime_change(path: os.PathLike[str], baseline: float, timeout: float = 1.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not os.path.exists(path):
+            time.sleep(0.01)
+            continue
+        current = os.stat(path).st_mtime
+        if current > baseline:
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_heartbeat_writer_creates_and_updates(tmp_path: Path) -> None:
+    heartbeat_path = tmp_path / "run" / "bascula" / "heartbeat"
+    writer = HeartbeatWriter(heartbeat_path, interval=0.1)
+    writer.start()
+    try:
+        assert heartbeat_path.exists()
+        initial_mtime = heartbeat_path.stat().st_mtime
+        assert _wait_for_mtime_change(heartbeat_path, initial_mtime, timeout=0.5)
+    finally:
+        writer.stop()
+
+    stopped_mtime = heartbeat_path.stat().st_mtime
+    time.sleep(0.2)
+    assert heartbeat_path.stat().st_mtime == pytest.approx(stopped_mtime, rel=0, abs=0.001)
+
+
+def test_heartbeat_writer_logs_warning_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    heartbeat_path = tmp_path / "hb"
+    writer = HeartbeatWriter(heartbeat_path, interval=0.05)
+
+    call_counter = {"count": 0}
+
+    def fail_touch(self: HeartbeatWriter) -> None:  # type: ignore[override]
+        call_counter["count"] += 1
+        raise PermissionError("disk full")
+
+    monkeypatch.setattr(HeartbeatWriter, "_touch_file", fail_touch)
+    caplog.set_level(logging.WARNING)
+
+    writer.start()
+    time.sleep(0.15)
+    writer.stop()
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "No se pudo escribir heartbeat" in warnings[0].message
+    assert call_counter["count"] >= 2

--- a/tests/test_scale_logs.py
+++ b/tests/test_scale_logs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bascula.services import scale
+
+
+class FakeLgpio:
+    def __init__(self) -> None:
+        self.handle = 12
+
+    def gpiochip_open(self, chip: int) -> int:
+        return self.handle
+
+    def gpio_claim_input(self, handle: int, pin: int) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def gpio_claim_output(self, handle: int, pin: int, value: int) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def gpio_write(self, handle: int, pin: int, value: int) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def gpio_free(self, handle: int, pin: int) -> None:  # pragma: no cover - simple stub
+        return None
+
+    def gpiochip_close(self, handle: int) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+def test_scale_backend_logs_initialisation(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    fake_gpio = FakeLgpio()
+    monkeypatch.setattr(scale, "lgpio", fake_gpio)
+
+    logger = logging.getLogger("test.scale.logs")
+    caplog.set_level(logging.INFO, logger="test.scale.logs")
+
+    backend = scale.HX711GpioBackend(5, 6, logger=logger)
+    try:
+        messages = [record.message for record in caplog.records]
+        assert (
+            "Scale backend: HX711_GPIO (lgpio) inicializado (chip=0, dt=5, sck=6)" in messages
+        )
+    finally:
+        backend.stop()

--- a/tests/test_signal_loss_publish.py
+++ b/tests/test_signal_loss_publish.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import queue
+import time
+
+import pytest
+
+from bascula.config.settings import ScaleSettings
+from bascula.services import scale
+
+
+class AlwaysUnavailableBackend(scale.BaseScaleBackend):
+    name = "ALWAYS_UNAVAILABLE"
+
+    def read(self) -> float:
+        raise scale.BackendUnavailable("no signal")
+
+
+def test_backend_unavailable_publishes_none_with_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = AlwaysUnavailableBackend()
+    monkeypatch.setattr(scale.ScaleService, "_select_backend", lambda self: backend)
+
+    settings = ScaleSettings(smoothing=1, decimals=1)
+    service = scale.ScaleService(settings, logger=scale.LOGGER)
+
+    updates: "queue.Queue[tuple[object, bool, str, float]]" = queue.Queue()
+
+    def callback(value: object, stable: bool, unit: str = "g") -> None:
+        updates.put((value, stable, unit, time.monotonic()))
+
+    service.subscribe(callback)
+
+    try:
+        collected: list[tuple[object, bool, str, float]] = []
+        deadline = time.monotonic() + 5.0
+        while len(collected) < 4 and time.monotonic() < deadline:
+            remaining = max(0.0, deadline - time.monotonic())
+            try:
+                event = updates.get(timeout=remaining)
+            except queue.Empty:
+                break
+            if event[0] is None:
+                collected.append(event)
+
+        assert len(collected) >= 3, "expected repeated None heartbeats"
+        diffs = [b[3] - a[3] for a, b in zip(collected, collected[1:])]
+        # Skip the first diff which may originate from the initial subscribe notification.
+        rate_limited_diffs = diffs[1:] if len(diffs) > 1 else []
+        assert rate_limited_diffs, "no rate limited heartbeats captured"
+        assert all(diff >= 0.45 for diff in rate_limited_diffs)
+    finally:
+        service.stop()


### PR DESCRIPTION
## Summary
- add a runtime heartbeat writer that periodically touches /run/bascula/heartbeat
- integrate the heartbeat lifecycle into the Tk UI startup and shutdown flow
- cover heartbeat behaviour, scale logging, and backend signal loss with targeted tests

## Testing
- pytest tests/test_heartbeat_writer.py tests/test_scale_logs.py tests/test_signal_loss_publish.py

------
https://chatgpt.com/codex/tasks/task_e_68d79f239af08326a2d019172f00a4eb