### PR TITLE
Fix serial UART scale backend and stabilize UI heartbeat

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -229,6 +229,7 @@ class SettingsScreen(BaseScreen):
             anchor="w", padx=20, pady=(20, 0)
         )
         ttk.Entry(frame, textvariable=self.app.scale_density_var).pack(anchor="w", padx=20)
+        ttk.Button(frame, text="Aplicar", command=self.app.apply_scale_settings).pack(anchor="w", padx=20, pady=(20, 10))
 
     def _build_network(self, notebook: ttk.Notebook) -> None:
         frame = tk.Frame(notebook, bg=PALETTE["panel"])

--- a/tests/test_no_signal_heartbeat.py
+++ b/tests/test_no_signal_heartbeat.py
@@ -72,9 +72,9 @@ def test_no_signal_generates_none_heartbeats(monkeypatch: pytest.MonkeyPatch, ca
         for diff in steady_diffs:
             assert diff >= 0.45
             assert diff <= 0.8
-        lost_messages = [record.message for record in caplog.records if "Scale: signal LOST" in record.message]
+        lost_messages = [record.message for record in caplog.records if "señal perdida" in record.message]
         if lost_messages:
-            assert lost_messages[:1] == ["Scale: signal LOST (hx711 no data)"]
+            assert lost_messages[:1] == ["HX711_GPIO (lgpio): señal perdida (hx711 no data)"]
             assert lost_messages.count(lost_messages[0]) == 1
     finally:
         service.stop()

--- a/tests/test_serial_backend_parser.py
+++ b/tests/test_serial_backend_parser.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from bascula.services import scale
+
+
+class FakeSerial:
+    read_queue: list[bytes] = []
+
+    def __init__(self, path: str, baudrate: int, timeout: float) -> None:
+        self.path = path
+        self.baudrate = baudrate
+        self.timeout = timeout
+
+    def readline(self) -> bytes:
+        if FakeSerial.read_queue:
+            return FakeSerial.read_queue.pop(0)
+        return b""
+
+    def write(self, payload: bytes) -> int:
+        return len(payload)
+
+    def close(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _patch_serial(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(scale, "serial", SimpleNamespace(Serial=FakeSerial))
+    monkeypatch.setattr(scale, "SerialException", Exception)
+
+
+def test_serial_backend_parses_line(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+    device = tmp_path / "ttyFAKE"
+    device.touch()
+    FakeSerial.read_queue = [b"  G: 12.34 , S:1  \r\n"]
+    caplog.set_level(logging.INFO, logger="bascula.scale")
+    backend = scale.SerialScaleBackend(str(device), 115200, logger=scale.LOGGER)
+    try:
+        value = backend.read()
+        assert value == pytest.approx(12.34)
+        assert backend.signal_hint is True
+        records = [record.message for record in caplog.records if "Serial" in record.message]
+        assert any("señal recuperada" in message for message in records)
+    finally:
+        backend.stop()
+
+
+def test_serial_backend_logs_loss_after_gap(tmp_path, caplog: pytest.LogCaptureFixture) -> None:
+    device = tmp_path / "ttyFAKE"
+    device.touch()
+    FakeSerial.read_queue = [b"G:1.0,S:1\n"]
+    caplog.set_level(logging.DEBUG, logger="bascula.scale")
+    backend = scale.SerialScaleBackend(str(device), 9600, logger=scale.LOGGER)
+    try:
+        assert backend.read() == pytest.approx(1.0)
+        backend._last_valid_ts -= 2.0  # type: ignore[attr-defined]
+        backend._last_signal_log -= 2.0  # type: ignore[attr-defined]
+        FakeSerial.read_queue = [b"noise\n"]
+        assert backend.read() is None
+        messages = [record.message for record in caplog.records]
+        assert any("señal perdida" in message for message in messages)
+        assert any("sin datos válidos" in message for message in messages)
+    finally:
+        backend.stop()

--- a/tests/test_signal_transition.py
+++ b/tests/test_signal_transition.py
@@ -111,7 +111,7 @@ def test_signal_transition(monkeypatch: pytest.MonkeyPatch) -> None:
         value_update = _next_update(updates, lambda item: isinstance(item[0], float) and item[0] > 0)
         assert value_update[0] == pytest.approx(50.0)
 
-        restored_logs = [msg for level, msg in logger.records if "Scale: signal RESTORED" in msg]
+        restored_logs = [msg for level, msg in logger.records if "señal recuperada" in msg]
         assert len(restored_logs) == 1
 
         # Ensure no stale None events immediately after signal restoration.
@@ -122,9 +122,9 @@ def test_signal_transition(monkeypatch: pytest.MonkeyPatch) -> None:
         second_none = _next_update(updates, lambda item: item[0] is None)
         assert second_none[0] is None
 
-        lost_logs = [msg for level, msg in logger.records if "Scale: signal LOST" in msg]
+        lost_logs = [msg for level, msg in logger.records if "señal perdida" in msg]
         assert len(lost_logs) == 1
-        assert lost_logs[0] == "Scale: signal LOST (no signal)"
+        assert lost_logs[0] == "TOGGLE: señal perdida (no signal)"
 
         # No additional logs beyond the single transition entries.
         assert restored_logs.count(restored_logs[0]) == 1


### PR DESCRIPTION
## Summary
- add a robust UART serial backend that parses `G:<peso>,S:<estado>` frames, logs signal transitions, and avoids simulation fallbacks
- start the heartbeat writer as soon as the Tk window boots and expose an explicit “Aplicar” flow for calibration/densidad settings
- document the symlink-based deployment workflow and UART configuration in the README and add tests for serial parsing and signal logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d7dae58de08326837ddd4f0b4e1fe0