### PR TITLE
Ensure serial backend reliability and improve touchscreen settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ sudo timeout 3s head -c 64 /dev/ttyAMA0 | hexdump -C
 
 La UI mostrará `--` cuando no haya señal y reflejará el peso real en cuanto regresen las líneas `G:…,S:…`.
 
+Con `scale.port` definido, la aplicación fija el backend serie y no vuelve a la simulación ni al lector HX711 por GPIO; si el puerto se interrumpe, la interfaz permanece estable mostrando `--` hasta que se restablecen los datos. El valor configurado en `~/.bascula/config.json` se conserva entre reinicios y no se sustituye por `__dummy__` durante los guardados desde la UI.
+
+Los campos táctiles de Ajustes (Wi-Fi, contraseñas, temporizador) disponen de teclado en pantalla: alfanumérico para texto y numérico para duraciones, accesible desde el propio campo o mediante los botones “Teclado”.
+
 ## Primer arranque y flujos principales
 
 ### Inicio

--- a/bascula/services/scale.py
+++ b/bascula/services/scale.py
@@ -142,33 +142,23 @@ class SerialScaleBackend(BaseScaleBackend):
         now = time.monotonic()
         self._last_valid_ts = now
         if not self._signal_state:
-            if now - self._last_signal_log >= 1.0:
-                self._logger.info("Serial %s: señal recuperada", self._port)
-                self._last_signal_log = now
             self._signal_state = True
+            if now - self._last_signal_log >= 1.0:
+                self._logger.info("serial data recovered (%s)", self._port)
+                self._last_signal_log = now
+        self._last_no_data_log = 0.0
 
     def _handle_no_data(self, payload: Optional[str] = None) -> None:
         now = time.monotonic()
         elapsed = now - self._last_valid_ts
         if self._signal_state and elapsed >= 1.0:
-            if now - self._last_signal_log >= 1.0:
-                self._logger.info("Serial %s: señal perdida", self._port)
-                self._last_signal_log = now
             self._signal_state = False
+            self._last_signal_log = now
         if elapsed >= 1.0 and now - self._last_no_data_log >= 1.0:
             if payload:
-                self._logger.debug(
-                    "Serial %s sin datos válidos (%.1fs): %s",
-                    self._port,
-                    elapsed,
-                    payload,
-                )
+                self._logger.debug("serial no data (%s): %s", self._port, payload)
             else:
-                self._logger.debug(
-                    "Serial %s sin datos válidos (%.1fs)",
-                    self._port,
-                    elapsed,
-                )
+                self._logger.debug("serial no data (%s)", self._port)
             self._last_no_data_log = now
 
     def _send_command(self, command: str) -> None:

--- a/bascula/ui/keyboard.py
+++ b/bascula/ui/keyboard.py
@@ -120,10 +120,10 @@ class TextKeyPopup(_BasePopup):
                 list("zxcvbnm"),
             ],
             "symbols": [
-                list("!@#$%&*()"),
+                list("!@#$%^&*()"),
                 list("-_=+[]{}"),
                 list(";:'\"\\|"),
-                list(".,/?<>~"),
+                list(",./?~`"),
             ],
         }
         rows = layouts.get(self._layout, layouts["letters"])

--- a/bascula/ui/scroll_helpers.py
+++ b/bascula/ui/scroll_helpers.py
@@ -1,0 +1,59 @@
+"""Reusable scrollable container widgets for touch-friendly settings views."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+from .input_helpers import bind_touch_scroll
+
+__all__ = ["ScrollableFrame"]
+
+
+class ScrollableFrame(tk.Frame):
+    """Frame wrapper that adds vertical scrolling to large content blocks."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        *,
+        bg: str = "#ffffff",
+        scrollbar: bool = True,
+        canvas_kwargs: dict | None = None,
+    ) -> None:
+        super().__init__(master, bg=bg)
+        self._canvas = tk.Canvas(
+            self,
+            bg=bg,
+            highlightthickness=0,
+            bd=0,
+            **(canvas_kwargs or {}),
+        )
+        self._canvas.pack(side="left", fill="both", expand=True)
+
+        self._scrollbar = None
+        if scrollbar:
+            self._scrollbar = ttk.Scrollbar(self, orient="vertical", command=self._canvas.yview)
+            self._scrollbar.pack(side="right", fill="y")
+            self._canvas.configure(yscrollcommand=self._scrollbar.set)
+
+        self.content = tk.Frame(self._canvas, bg=bg)
+        self._window_id = self._canvas.create_window((0, 0), window=self.content, anchor="nw")
+
+        self.content.bind("<Configure>", self._on_content_configure)
+        self._canvas.bind("<Configure>", self._on_canvas_configure)
+
+        bind_touch_scroll(self._canvas, units_divisor=2, min_drag_px=3)
+
+    # ------------------------------------------------------------------
+    def _on_content_configure(self, event: tk.Event) -> None:
+        self._canvas.configure(scrollregion=self._canvas.bbox("all"))
+        try:
+            self._canvas.itemconfigure(self._window_id, width=self._canvas.winfo_width())
+        except Exception:
+            pass
+
+    def _on_canvas_configure(self, event: tk.Event) -> None:
+        try:
+            self._canvas.itemconfigure(self._window_id, width=event.width)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- lock the serial backend when a scale port is provided and surface serial recovery/idle states without falling back to GPIO
- preserve user scale.port values when saving settings and document the expected serial behaviour and touch keyboards
- add a reusable scrollable frame plus back/home navigation, Escape shortcut, and on-screen keyboards for Wi-Fi and the timer popup

## Testing
- pytest tests/test_scale_backend_select.py tests/test_backend_unavailable_heartbeat.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f1937ba08326bff17cb086602d37