### PR TITLE
Add I2S audio auto-configuration and audio device selection UI

### DIFF
--- a/bascula/services/audio.py
+++ b/bascula/services/audio.py
@@ -31,7 +31,7 @@ class AudioService:
         voice_model: str | None = None,
         tts_enabled: bool = True,
     ) -> None:
-        self.audio_device = audio_device
+        self.audio_device = (audio_device or "default").strip() or "default"
         self.volume = max(0, min(100, int(volume)))
         self.enabled = True
         self.tts_enabled = bool(tts_enabled)
@@ -49,6 +49,14 @@ class AudioService:
             self.volume,
             "yes" if self.backend.piper else "no",
         )
+
+    # ------------------------------------------------------------------
+    def set_device(self, device: str) -> None:
+        new_device = (device or "default").strip() or "default"
+        if new_device == self.audio_device:
+            return
+        self.audio_device = new_device
+        log.info("Audio device switched to %s", self.audio_device)
 
     # ------------------------------------------------------------------
     def set_volume(self, value: int) -> None:

--- a/bascula/system/audio_config.py
+++ b/bascula/system/audio_config.py
@@ -1,0 +1,371 @@
+"""System helpers for configuring ALSA defaults on Raspberry Pi."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+log = logging.getLogger(__name__)
+
+_CARD_RE = re.compile(
+    r"^card\s+(?P<index>\d+):\s+(?P<raw>[^\s]+)\s+\[(?P<name>[^\]]+)\],\s+device\s+(?P<device>\d+):\s+(?P<desc>[^\[]*)",
+    re.IGNORECASE,
+)
+
+_I2S_KEYWORDS = (
+    "hifiberry",
+    "max98357",
+    "sndrpihifiberry",
+    "i2s",
+    "adau",
+    "justboom",
+    "fe-pi",
+    "allo",
+    "pimoroni",
+)
+
+_HDMI_KEYWORDS = ("vc4hdmi", "hdmi")
+
+
+@dataclass(frozen=True)
+class AudioCard:
+    """Representation of an ALSA playback card."""
+
+    index: int
+    raw_id: str
+    name: str
+    description: str
+
+    @property
+    def device_string(self) -> str:
+        return f"hw:{self.index},0"
+
+    @property
+    def pretty_name(self) -> str:
+        base = self.name.strip() or self.raw_id
+        desc = self.description.strip()
+        return f"{base} – {desc}" if desc else base
+
+    @property
+    def fingerprint(self) -> str:
+        return f"{self.raw_id} {self.name} {self.description}".lower()
+
+    @property
+    def is_i2s(self) -> bool:
+        fp = self.fingerprint
+        return (not self.is_hdmi) and any(keyword in fp for keyword in _I2S_KEYWORDS)
+
+    @property
+    def is_hdmi(self) -> bool:
+        fp = self.fingerprint
+        return any(keyword in fp for keyword in _HDMI_KEYWORDS)
+
+
+@dataclass
+class ConfigureReport:
+    selected: Optional[AudioCard]
+    asound_changed: bool
+    asound_path: Path
+    overlays_fixed: List[Path]
+    alsactl_ok: bool
+
+
+def parse_aplay_output(raw: str) -> List[AudioCard]:
+    """Parse the output of ``aplay -l`` into :class:`AudioCard` objects."""
+
+    cards: dict[int, AudioCard] = {}
+    for line in raw.splitlines():
+        match = _CARD_RE.match(line.strip())
+        if not match:
+            continue
+        device_number = int(match.group("device"))
+        index = int(match.group("index"))
+        if device_number != 0:
+            continue
+        if index in cards:
+            continue
+        cards[index] = AudioCard(
+            index=index,
+            raw_id=match.group("raw"),
+            name=match.group("name"),
+            description=match.group("desc").strip(),
+        )
+    return [cards[key] for key in sorted(cards.keys())]
+
+
+def list_cards(aplay_path: str = "aplay") -> List[AudioCard]:
+    """Return available playback cards using ``aplay``."""
+
+    try:
+        result = subprocess_run([aplay_path, "-l"], capture_output=True, text=True, check=True)
+    except FileNotFoundError:
+        log.warning("aplay not found while listing audio cards")
+        return []
+    except Exception as exc:  # pragma: no cover - system dependent
+        log.warning("Could not run aplay: %s", exc)
+        return []
+    return parse_aplay_output(result.stdout)
+
+
+def detect_primary_card(cards: Sequence[AudioCard]) -> Optional[AudioCard]:
+    """Pick the preferred playback card (I2S > non-HDMI > first)."""
+
+    for card in cards:
+        if card.is_i2s:
+            return card
+    for card in cards:
+        if not card.is_hdmi:
+            return card
+    return cards[0] if cards else None
+
+
+def ensure_asound_conf(card: AudioCard, path: Path) -> bool:
+    """Ensure ``/etc/asound.conf`` points to the provided card."""
+
+    desired = (
+        "# Bascula audio defaults (auto-generated)\n"
+        "pcm.!default {\n"
+        "  type plug\n"
+        f"  slave.pcm \"hw:{card.index},0\"\n"
+        "}\n"
+        "ctl.!default {\n"
+        "  type hw\n"
+        f"  card {card.index}\n"
+        "}\n"
+    )
+
+    path = Path(path)
+    current = None
+    if path.exists():
+        try:
+            current = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            current = None
+        except Exception as exc:  # pragma: no cover - filesystem dependent
+            log.warning("Could not read %s: %s", path, exc)
+            current = None
+        else:
+            if "\x00" in current or "pcm.!default" not in current:
+                current = None
+
+    if current is not None and current.strip() == desired.strip():
+        log.info("/etc/asound.conf already points to card %s", card.index)
+        return False
+
+    if path.exists() and current is None:
+        _backup_file(path)
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(desired, encoding="utf-8")
+    except Exception as exc:  # pragma: no cover - filesystem dependent
+        log.error("Failed to write %s: %s", path, exc)
+        return False
+
+    log.info("Updated %s -> card %s", path, card.index)
+    return True
+
+
+def remove_conflicting_overlays(paths: Iterable[Path]) -> List[Path]:
+    """Remove PWM overlays when I2S overlays are present."""
+
+    modified: List[Path] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception:  # pragma: no cover - best effort
+            continue
+        lines = text.splitlines()
+        has_i2s = any(
+            line.strip().startswith("dtoverlay=")
+            and any(keyword in line.lower() for keyword in ("hifiberry", "max98357", "i2s"))
+            for line in lines
+        )
+        if not has_i2s:
+            continue
+        filtered = [
+            line
+            for line in lines
+            if "dtoverlay=pwm-2chan" not in line.replace(" ", "")
+        ]
+        if filtered == lines:
+            continue
+        _backup_file(path)
+        filtered_text = "\n".join(filtered).rstrip() + "\n"
+        path.write_text(filtered_text, encoding="utf-8")
+        modified.append(path)
+        log.info("Removed pwm-2chan overlay from %s", path)
+    return modified
+
+
+def run_alsactl_init(card_index: int) -> bool:
+    """Initialise ALSA mixer state for the selected card."""
+
+    try:
+        result = subprocess_run(
+            ["alsactl", "init", str(card_index)], capture_output=True, text=True, check=True
+        )
+    except FileNotFoundError:
+        log.warning("alsactl not available; skipping mixer initialisation")
+        return False
+    except Exception as exc:  # pragma: no cover - system dependent
+        log.warning("alsactl init for card %s failed: %s", card_index, exc)
+        return False
+
+    output = (result.stdout or "").strip()
+    if output:
+        log.info("alsactl init output: %s", output)
+    return True
+
+
+def configure_system_audio(
+    *,
+    aplay_path: str = "aplay",
+    asound_path: Path | str = "/etc/asound.conf",
+    boot_config_paths: Optional[Sequence[Path | str]] = None,
+    run_alsactl: bool = True,
+) -> ConfigureReport:
+    """Configure ALSA defaults for the detected I2S card."""
+
+    cards = list_cards(aplay_path)
+    if not cards:
+        log.warning("No playback cards detected with %s", aplay_path)
+        return ConfigureReport(None, False, Path(asound_path), [], False)
+
+    selected = detect_primary_card(cards)
+    if selected is None:
+        log.warning("Could not determine a primary audio card")
+        return ConfigureReport(None, False, Path(asound_path), [], False)
+
+    log.info(
+        "Detected audio cards: %s",
+        ", ".join(f"{card.index}:{card.raw_id}" for card in cards),
+    )
+    log.info(
+        "Using card %s (%s)",
+        selected.index,
+        selected.pretty_name,
+    )
+
+    asound_changed = ensure_asound_conf(selected, Path(asound_path))
+    overlays_fixed: List[Path] = []
+    if boot_config_paths:
+        overlays_fixed = remove_conflicting_overlays(Path(p) for p in boot_config_paths)
+
+    alsactl_ok = run_alsactl_init(selected.index) if run_alsactl else False
+
+    return ConfigureReport(selected, asound_changed, Path(asound_path), overlays_fixed, alsactl_ok)
+
+
+def _backup_file(path: Path) -> None:
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    backup_path = Path(f"{path}.bak-{timestamp}")
+    try:
+        shutil.copy2(path, backup_path)
+        log.info("Created backup %s", backup_path)
+    except Exception as exc:  # pragma: no cover - filesystem dependent
+        log.debug("Could not create backup for %s: %s", path, exc)
+
+
+def subprocess_run(*args, **kwargs):
+    """Wrapper around :func:`subprocess.run` for ease of testing."""
+
+    from subprocess import run
+
+    return run(*args, **kwargs)
+
+
+def _default_boot_paths() -> List[Path]:
+    return [
+        path
+        for path in (Path("/boot/firmware/config.txt"), Path("/boot/config.txt"))
+        if path.exists()
+    ]
+
+
+def _setup_logging() -> None:
+    if not logging.getLogger().handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        formatter = logging.Formatter("[audio] %(message)s")
+        handler.setFormatter(formatter)
+        logging.getLogger().addHandler(handler)
+    logging.getLogger().setLevel(logging.INFO)
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Configure ALSA defaults for Bascula")
+    parser.add_argument("--aplay", default="aplay", help="Path to the aplay binary")
+    parser.add_argument("--asound", default="/etc/asound.conf", help="Target asound.conf path")
+    parser.add_argument(
+        "--boot-config",
+        action="append",
+        default=[],
+        help="Boot config file to sanitise (can be passed multiple times)",
+    )
+    parser.add_argument(
+        "--skip-alsactl",
+        action="store_true",
+        help="Skip running alsactl init",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON summary to stdout",
+    )
+    args = parser.parse_args(argv)
+
+    boot_paths = [Path(p) for p in args.boot_config] or _default_boot_paths()
+
+    report = configure_system_audio(
+        aplay_path=args.aplay,
+        asound_path=Path(args.asound),
+        boot_config_paths=boot_paths,
+        run_alsactl=not args.skip_alsactl,
+    )
+
+    if args.json:
+        payload = {
+            "card_index": report.selected.index if report.selected else None,
+            "card_id": report.selected.raw_id if report.selected else None,
+            "card_name": report.selected.pretty_name if report.selected else None,
+            "asound_changed": report.asound_changed,
+            "asound_path": str(report.asound_path),
+            "overlays_fixed": [str(path) for path in report.overlays_fixed],
+            "alsactl_ok": report.alsactl_ok,
+        }
+        json.dump(payload, sys.stdout)
+        sys.stdout.flush()
+
+    return 0 if report.selected else 1
+
+
+def main() -> int:  # pragma: no cover - CLI entry point
+    _setup_logging()
+    return _cli()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())
+
+
+__all__ = [
+    "AudioCard",
+    "ConfigureReport",
+    "configure_system_audio",
+    "detect_primary_card",
+    "ensure_asound_conf",
+    "list_cards",
+    "parse_aplay_output",
+    "remove_conflicting_overlays",
+    "run_alsactl_init",
+]

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -245,6 +245,7 @@ class SettingsScreen(BaseScreen):
         self._wifi_tree: Optional[ttk.Treeview] = None
         self._qr_photo = None
         self.qr_label: Optional[tk.Label] = None
+        self.audio_device_combo: Optional[ttk.Combobox] = None
 
         header = tk.Frame(self, bg=PALETTE["bg"])
         header.pack(fill="x", padx=30, pady=(24, 12))
@@ -358,6 +359,32 @@ class SettingsScreen(BaseScreen):
         ttk.Button(frame, text="Probar beep", command=self.app.audio_service.beep_ok).pack(
             anchor="w", padx=24, pady=(4, 16)
         )
+
+        tk.Label(
+            frame,
+            text="Salida de audio",
+            bg=PALETTE["panel"],
+            fg=PALETTE["text"],
+            font=("DejaVu Sans", 12, "bold"),
+        ).pack(anchor="w", padx=20, pady=(0, 4))
+        audio_row = tk.Frame(frame, bg=PALETTE["panel"])
+        audio_row.pack(fill="x", padx=20, pady=(0, 4))
+        self.audio_device_combo = ttk.Combobox(
+            audio_row,
+            state="readonly",
+            values=self.app.get_audio_device_labels(),
+            textvariable=self.app.audio_device_choice_var,
+        )
+        self.audio_device_combo.pack(side="left", fill="x", expand=True)
+        ttk.Button(audio_row, text="Refrescar", command=self._refresh_audio_devices).pack(
+            side="left", padx=6
+        )
+        tk.Label(
+            frame,
+            textvariable=self.app.audio_device_status_var,
+            bg=PALETTE["panel"],
+            fg=PALETTE["muted"],
+        ).pack(anchor="w", padx=24, pady=(2, 12))
 
     # ------------------------------------------------------------------
     def _build_scale(self, notebook: ttk.Notebook) -> None:
@@ -691,6 +718,11 @@ class SettingsScreen(BaseScreen):
         self.app.apply_scale_settings()
         self._set_status(self.voice_status_var, "")
         self._set_status(self.network_status_var, "")
+
+    def _refresh_audio_devices(self) -> None:
+        labels = self.app.refresh_audio_devices()
+        if self.audio_device_combo is not None:
+            self.audio_device_combo.configure(values=labels)
 
     def _populate_voice_models(self) -> None:
         voices = self.app.discover_voice_models()

--- a/tests/test_audio_config.py
+++ b/tests/test_audio_config.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bascula.system.audio_config import (
+    AudioCard,
+    configure_system_audio,
+    detect_primary_card,
+    ensure_asound_conf,
+    parse_aplay_output,
+    remove_conflicting_overlays,
+)
+
+
+APLAY_SAMPLE = """\
+**** List of PLAYBACK Hardware Devices ****
+card 0: sndrpihifiberry [snd_rpi_hifiberry_dac], device 0: HiFiBerry DAC HiFi pcm5102a-hifi-0 []
+  Subdevices: 1/1
+card 1: vc4hdmi0 [vc4-hdmi-0], device 0: MAI PCM i2s-hifi-0 []
+  Subdevices: 0/1
+"""
+
+
+def test_parse_aplay_output_and_detection() -> None:
+    cards = parse_aplay_output(APLAY_SAMPLE)
+    assert len(cards) == 2
+    assert cards[0].is_i2s
+    assert not cards[1].is_i2s
+    assert detect_primary_card(cards) == cards[0]
+
+
+def test_ensure_asound_conf_writes_and_backups(tmp_path) -> None:
+    card = AudioCard(index=0, raw_id="sndrpihifiberry", name="HifiBerry", description="DAC")
+    path = tmp_path / "asound.conf"
+
+    # first write
+    changed = ensure_asound_conf(card, path)
+    assert changed
+    content = path.read_text(encoding="utf-8")
+    assert "hw:0,0" in content
+
+    # same content -> no change
+    assert not ensure_asound_conf(card, path)
+
+    # corrupted file triggers backup and rewrite
+    path.write_bytes(b"\x00broken")
+    changed = ensure_asound_conf(card, path)
+    assert changed
+    backups = list(tmp_path.glob("asound.conf.bak-*"))
+    assert backups, "expected backup file when repairing corrupt config"
+
+
+def test_remove_conflicting_overlays(tmp_path) -> None:
+    config = tmp_path / "config.txt"
+    config.write_text(
+        "\n".join(
+            [
+                "dtoverlay=i2s-mmap",
+                "dtoverlay=hifiberry-dac",
+                "dtoverlay=pwm-2chan,pin=12,func=4,pin2=13,func2=4",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    modified = remove_conflicting_overlays([config])
+    assert config in modified
+    text = config.read_text(encoding="utf-8")
+    assert "pwm-2chan" not in text
+    backups = list(tmp_path.glob("config.txt.bak-*"))
+    assert backups
+
+
+def test_configure_system_audio(monkeypatch, tmp_path) -> None:
+    asound_path = tmp_path / "asound.conf"
+    boot_config = tmp_path / "config.txt"
+    boot_config.write_text("dtoverlay=hifiberry-dac\ndtoverlay=pwm-2chan\n", encoding="utf-8")
+
+    def fake_run(cmd, capture_output=True, text=True, check=True):
+        if cmd[:2] == ["aplay", "-l"]:
+            return SimpleNamespace(stdout=APLAY_SAMPLE, stderr="", returncode=0)
+        if cmd[:2] == ["alsactl", "init"]:
+            assert cmd[2] == "0"
+            return SimpleNamespace(stdout="init ok", stderr="", returncode=0)
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr("bascula.system.audio_config.subprocess_run", fake_run)
+
+    report = configure_system_audio(
+        aplay_path="aplay",
+        asound_path=asound_path,
+        boot_config_paths=[boot_config],
+        run_alsactl=True,
+    )
+
+    assert report.selected is not None
+    assert report.selected.index == 0
+    assert report.asound_changed
+    assert report.alsactl_ok
+    assert boot_config in report.overlays_fixed
+    assert "hw:0,0" in asound_path.read_text(encoding="utf-8")
+    assert "pwm-2chan" not in boot_config.read_text(encoding="utf-8")

--- a/tools/update-config.py
+++ b/tools/update-config.py
@@ -19,7 +19,6 @@ BASCULA_BLOCK = [
     "dtparam=audio=off",
     "dtoverlay=i2s-mmap",
     "dtoverlay=hifiberry-dac",
-    "dtoverlay=pwm-2chan,pin=12,func=4,pin2=13,func2=4",
     BASCULA_END,
 ]
 


### PR DESCRIPTION
## Summary
- add a reusable system helper that detects the preferred I2S DAC, regenerates /etc/asound.conf, and removes conflicting PWM overlays
- run the helper from the installer, logging the configured card and keeping the DAC-focused boot overlay while warning about PWM
- expose the detected cards in the settings UI so the audio device can be changed, while keeping audio preferences in sync with the ALSA backend

## Testing
- pytest tests/test_audio_config.py
- pytest tests/test_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d7fcb9dbac8326ad7393a37c6ebea6