### PR TITLE
Implement custom keyboard popups and zero via Tare long press

### DIFF
--- a/ci/ui_probe.py
+++ b/ci/ui_probe.py
@@ -25,7 +25,6 @@ from bascula.ui.theme_neo import SPACING, wcag_contrast  # noqa: E402
 
 REQUIRED_BUTTONS: Dict[str, str] = {
     "btn_tare": "TARA",
-    "btn_zero": "CERO",
     "btn_swap": "g↔ml",
     "btn_food": "Alimentos",
     "btn_recipe": "Recetas",


### PR DESCRIPTION
## Summary
- replace the shared keyboard popup base with a borderless window, custom title bar, and keyboard shortcuts
- update the text and numeric popups to render inside the new content frame and use the safer show routine
- remove the Zero shortcut button from the home screens and trigger zeroing through a long press on Tara, adjusting the CI probe accordingly

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68d80155ee488326a66cc27b90aa6c6d