### PR TITLE
Add safe logger fallback for settings tabs

### DIFF
--- a/bascula/ui/screens_tabs_ext.py
+++ b/bascula/ui/screens_tabs_ext.py
@@ -185,7 +185,9 @@ class TabbedSettingsMenuScreen(BaseScreen):
                 else:
                     self._add_placeholder_tab(title)
             except Exception:
-                self.logger.exception("Fallo creando pestaña %s", title)
+                import logging
+                _log = getattr(self, "logger", getattr(getattr(self, "app", None), "logger", logging.getLogger(__name__)))
+                _log.exception("Fallo creando pestaña %s", title)
                 self._add_placeholder_tab(title)
 
         self._update_tab_borders()

--- a/bascula/ui/utils_logging.py
+++ b/bascula/ui/utils_logging.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+
+def safe_logger(obj: Any) -> logging.Logger:
+    """
+    Devuelve un logger seguro para cualquier objeto de la UI.
+    Prioridad: obj.logger -> obj.app.logger -> module logger.
+    Nunca lanza excepción aunque no existan los atributos.
+    """
+    if hasattr(obj, "logger") and obj.logger:
+        return obj.logger  # type: ignore[return-value]
+    app = getattr(obj, "app", None)
+    if app is not None and getattr(app, "logger", None):
+        return app.logger  # type: ignore[return-value]
+    return logging.getLogger(getattr(obj, "__module__", __name__))


### PR DESCRIPTION
## Summary
- guard the settings tab builder against missing logger attributes
- add a reusable `safe_logger` helper for UI components that lack their own logger

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68d80b8de56083268dd65267cda69c01