### PR TITLE
feat: restyle Tk UI with holographic theme

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -17,6 +17,7 @@ from .theme_ctk import (
     create_root,
     font_tuple,
 )
+from .theme_holo import apply_holo_theme, paint_grid_background
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +40,8 @@ class AppShell:
     def __init__(self, root: Optional[tk.Tk] = None):
         self._own_root = root is None
         self.root = root or create_root()
+        apply_holo_theme(self.root)
+        self._grid_canvas = paint_grid_background(self.root)
         self.root.withdraw()
         if CTK_AVAILABLE:
             try:

--- a/bascula/ui/keyboard.py
+++ b/bascula/ui/keyboard.py
@@ -12,6 +12,7 @@ from .theme_ctk import (
     create_label as holo_label,
     font_tuple,
 )
+from .theme_holo import COLOR_ACCENT, COLOR_BG, COLOR_PRIMARY, COLOR_TEXT, FONT_UI, FONT_UI_BOLD
 
 if CTK_AVAILABLE:  # pragma: no cover - optional import at runtime
     try:
@@ -27,16 +28,18 @@ if CTK_AVAILABLE:
     COL_TEXT = HOLO_COLORS["text"]
     COL_ACCENT = HOLO_COLORS["accent"]
     COL_ACCENT_LIGHT = HOLO_COLORS["accent_soft"]
+    TITLE_FONT = font_tuple(16, "bold")
+    BODY_FONT = font_tuple(14)
+    NUM_FONT = font_tuple(20, "bold")
 else:
-    COL_BG = "#111827"
-    COL_CARD = "#1f2937"
-    COL_TEXT = "#f9fafb"
-    COL_ACCENT = "#2563eb"
-    COL_ACCENT_LIGHT = "#3b82f6"
-
-TITLE_FONT = font_tuple(16, "bold") if CTK_AVAILABLE else ("DejaVu Sans", 16, "bold")
-BODY_FONT = font_tuple(14) if CTK_AVAILABLE else ("DejaVu Sans", 14)
-NUM_FONT = font_tuple(20, "bold") if CTK_AVAILABLE else ("DejaVu Sans", 18)
+    COL_BG = COLOR_BG
+    COL_CARD = "#141414"
+    COL_TEXT = COLOR_TEXT
+    COL_ACCENT = COLOR_PRIMARY
+    COL_ACCENT_LIGHT = COLOR_ACCENT
+    TITLE_FONT = (FONT_UI_BOLD[0], 16, "bold")
+    BODY_FONT = (FONT_UI[0], 14)
+    NUM_FONT = ("DejaVu Sans Mono", 18, "bold")
 
 
 class _BasePopup(_BaseToplevel):

--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -1,0 +1,319 @@
+"""Custom holographic ttk theme utilities for the Báscula UI."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import Canvas, Misc, ttk
+from typing import Optional
+
+COLOR_BG = "#0A0A0A"
+COLOR_PRIMARY = "#00E5FF"
+COLOR_ACCENT = "#FF00DC"
+COLOR_TEXT = "#FFFFFF"
+COLOR_MUTED = "#7F7F7F"
+GRID_COLOR = "#05363D"
+
+FONT_UI = ("DejaVu Sans", 12)
+FONT_UI_BOLD = ("DejaVu Sans", 12, "bold")
+FONT_DIGITS = ("DejaVu Sans Mono", 54, "bold")
+
+
+def _safe_style(root: Misc) -> ttk.Style:
+    try:
+        return ttk.Style(root)
+    except Exception:
+        return ttk.Style()
+
+
+def apply_holo_theme(root: Optional[Misc] = None) -> None:
+    """Register and apply the holographic ttk theme."""
+
+    style = _safe_style(root)
+    if "holo" not in style.theme_names():
+        settings = {
+            "TFrame": {
+                "configure": {
+                    "background": COLOR_BG,
+                }
+            },
+            "TLabelframe": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "foreground": COLOR_TEXT,
+                    "bordercolor": COLOR_PRIMARY,
+                }
+            },
+            "TLabelframe.Label": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "foreground": COLOR_TEXT,
+                    "font": FONT_UI_BOLD,
+                }
+            },
+            "TLabel": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "foreground": COLOR_TEXT,
+                    "font": FONT_UI,
+                }
+            },
+            "TButton": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "foreground": COLOR_TEXT,
+                    "font": FONT_UI_BOLD,
+                    "padding": (16, 8),
+                    "borderwidth": 1,
+                    "focuscolor": COLOR_ACCENT,
+                    "bordercolor": COLOR_PRIMARY,
+                    "relief": "flat",
+                },
+                "map": {
+                    "foreground": [
+                        ("disabled", "#555555"),
+                        ("pressed", COLOR_BG),
+                        ("active", COLOR_TEXT),
+                    ],
+                    "background": [
+                        ("pressed", COLOR_ACCENT),
+                        ("active", "#141414"),
+                    ],
+                    "bordercolor": [
+                        ("pressed", COLOR_ACCENT),
+                        ("active", COLOR_ACCENT),
+                    ],
+                },
+            },
+            "Holo.Circular.TButton": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "foreground": COLOR_TEXT,
+                    "font": FONT_UI_BOLD,
+                    "padding": (18, 12),
+                    "borderwidth": 2,
+                    "relief": "flat",
+                    "focuscolor": COLOR_ACCENT,
+                    "bordercolor": COLOR_PRIMARY,
+                },
+                "map": {
+                    "foreground": [
+                        ("pressed", COLOR_BG),
+                        ("active", COLOR_TEXT),
+                    ],
+                    "background": [
+                        ("pressed", COLOR_ACCENT),
+                        ("active", "#141414"),
+                    ],
+                    "bordercolor": [
+                        ("pressed", COLOR_ACCENT),
+                        ("active", COLOR_ACCENT),
+                    ],
+                },
+            },
+            "TNotebook": {
+                "configure": {
+                    "background": COLOR_BG,
+                    "borderwidth": 0,
+                    "tabmargins": (16, 8, 16, 0),
+                    "padding": 4,
+                }
+            },
+            "TNotebook.Tab": {
+                "configure": {
+                    "font": FONT_UI_BOLD,
+                    "foreground": COLOR_PRIMARY,
+                    "background": COLOR_BG,
+                    "padding": (20, 10),
+                },
+                "map": {
+                    "foreground": [("selected", COLOR_ACCENT)],
+                    "background": [("selected", "#141414")],
+                    "bordercolor": [
+                        ("selected", COLOR_ACCENT),
+                        ("!selected", COLOR_PRIMARY),
+                    ],
+                },
+            },
+            "TEntry": {
+                "configure": {
+                    "fieldbackground": "#141414",
+                    "foreground": COLOR_TEXT,
+                    "bordercolor": COLOR_PRIMARY,
+                    "lightcolor": COLOR_PRIMARY,
+                    "darkcolor": COLOR_PRIMARY,
+                    "insertcolor": COLOR_ACCENT,
+                    "padding": 6,
+                    "relief": "flat",
+                },
+                "map": {
+                    "bordercolor": [("focus", COLOR_ACCENT)],
+                    "lightcolor": [("focus", COLOR_ACCENT)],
+                    "darkcolor": [("focus", COLOR_ACCENT)],
+                },
+            },
+            "Horizontal.TProgressbar": {
+                "configure": {
+                    "background": COLOR_PRIMARY,
+                    "troughcolor": "#101010",
+                    "bordercolor": COLOR_BG,
+                    "lightcolor": COLOR_PRIMARY,
+                    "darkcolor": COLOR_PRIMARY,
+                },
+            },
+            "Vertical.TScrollbar": {
+                "configure": {
+                    "gripcount": 0,
+                    "background": "#141414",
+                    "troughcolor": "#101010",
+                    "bordercolor": COLOR_BG,
+                    "lightcolor": COLOR_PRIMARY,
+                    "darkcolor": COLOR_PRIMARY,
+                    "arrowcolor": COLOR_PRIMARY,
+                },
+                "map": {
+                    "background": [("active", COLOR_ACCENT)],
+                    "arrowcolor": [("active", COLOR_ACCENT)],
+                },
+            },
+        }
+        style.theme_create("holo", parent="clam", settings=settings)
+
+    style.theme_use("holo")
+
+    root_widget = root or style.master
+    if isinstance(root_widget, tk.Tk) or isinstance(root_widget, tk.Toplevel):
+        try:
+            root_widget.configure(bg=COLOR_BG)
+        except Exception:
+            pass
+
+    if root_widget is not None:
+        try:
+            root_widget.option_add("*Font", FONT_UI)
+            root_widget.option_add("*Label.Font", FONT_UI)
+            root_widget.option_add("*Button.Font", FONT_UI_BOLD)
+            root_widget.option_add("*Entry.Font", FONT_UI)
+            root_widget.option_add("*foreground", COLOR_TEXT)
+        except Exception:
+            pass
+
+
+def paint_grid_background(target: Misc, *, spacing: int = 40) -> Optional[Canvas]:
+    """Paint a subtle cyan grid behind the given widget."""
+
+    try:
+        canvas = Canvas(target, bg=COLOR_BG, highlightthickness=0, bd=0)
+    except Exception:
+        return None
+
+    canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
+    canvas.lower()
+
+    def _draw(_event=None) -> None:
+        try:
+            width = max(1, target.winfo_width())
+            height = max(1, target.winfo_height())
+        except Exception:
+            return
+        canvas.delete("grid")
+        for x in range(0, width, spacing):
+            canvas.create_line(x, 0, x, height, fill=GRID_COLOR, width=1, tags="grid")
+        for y in range(0, height, spacing):
+            canvas.create_line(0, y, width, y, fill=GRID_COLOR, width=1, tags="grid")
+
+    try:
+        target.bind("<Configure>", _draw, add=True)
+    except Exception:
+        pass
+    _draw()
+    return canvas
+
+
+def neon_border(widget: Misc, *, padding: int = 6, radius: int = 18, color: str = COLOR_PRIMARY) -> Optional[Canvas]:
+    """Draw a neon-style rounded border behind the provided widget."""
+
+    master = widget.master
+    if master is None:
+        return None
+
+    try:
+        border_canvas = Canvas(master, highlightthickness=0, bd=0, bg=COLOR_BG)
+    except Exception:
+        return None
+
+    def _rounded_rect(canvas: Canvas, x1: int, y1: int, x2: int, y2: int, rad: int) -> None:
+        rad = max(4, min(rad, int(min(x2 - x1, y2 - y1) / 2)))
+        points = [
+            x1 + rad,
+            y1,
+            x2 - rad,
+            y1,
+            x2,
+            y1,
+            x2,
+            y1 + rad,
+            x2,
+            y2 - rad,
+            x2,
+            y2,
+            x2 - rad,
+            y2,
+            x1 + rad,
+            y2,
+            x1,
+            y2,
+            x1,
+            y2 - rad,
+            x1,
+            y1 + rad,
+            x1,
+            y1,
+            x1 + rad,
+            y1,
+        ]
+        canvas.create_polygon(
+            points,
+            smooth=True,
+            outline=color,
+            fill="",
+            width=2,
+            tags="border",
+        )
+
+    def _update(_event=None) -> None:
+        try:
+            x = widget.winfo_x()
+            y = widget.winfo_y()
+            w = widget.winfo_width()
+            h = widget.winfo_height()
+        except Exception:
+            return
+        if w <= 1 and h <= 1:
+            widget.after(50, _update)
+            return
+        border_canvas.place(x=max(0, x - padding), y=max(0, y - padding), width=w + padding * 2, height=h + padding * 2)
+        border_canvas.lower(widget)
+        border_canvas.delete("border")
+        _rounded_rect(border_canvas, 2, 2, max(4, w + padding * 2 - 2), max(4, h + padding * 2 - 2), radius)
+
+    try:
+        widget.bind("<Configure>", _update, add=True)
+        master.bind("<Configure>", _update, add=True)
+    except Exception:
+        pass
+    widget.after(10, _update)
+    return border_canvas
+
+
+__all__ = [
+    "apply_holo_theme",
+    "paint_grid_background",
+    "neon_border",
+    "FONT_UI",
+    "FONT_UI_BOLD",
+    "FONT_DIGITS",
+    "COLOR_BG",
+    "COLOR_PRIMARY",
+    "COLOR_ACCENT",
+    "COLOR_TEXT",
+    "COLOR_MUTED",
+]

--- a/bascula/ui/views/home.py
+++ b/bascula/ui/views/home.py
@@ -3,10 +3,19 @@ from __future__ import annotations
 
 import logging
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, ttk
 from typing import Callable, Dict
 
-from ..theme_neo import COLORS, FONTS, SPACING, font_sans
+from ..theme_neo import SPACING
+from ..theme_holo import (
+    COLOR_ACCENT,
+    COLOR_BG,
+    COLOR_PRIMARY,
+    COLOR_TEXT,
+    FONT_DIGITS,
+    FONT_UI_BOLD,
+    neon_border,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -16,7 +25,7 @@ class HomeView(tk.Frame):
     """Main landing view displaying current weight and shortcuts."""
 
     def __init__(self, parent: tk.Misc, controller: object, **kwargs: object) -> None:
-        background = kwargs.pop("bg", COLORS["bg"])
+        background = kwargs.pop("bg", COLOR_BG)
         super().__init__(parent, bg=background, **kwargs)
 
         self.controller = controller
@@ -39,17 +48,30 @@ class HomeView(tk.Frame):
         weight_container = tk.Frame(self, bg=background, height=180)
         weight_container.pack(fill="x", pady=(0, SPACING["lg"]))
         weight_container.pack_propagate(False)
+        glow = tk.Label(
+            weight_container,
+            textvariable=self._weight_var,
+            font=FONT_DIGITS,
+            fg="#006F7B",
+            bg=background,
+        )
+        glow.place(relx=0.5, rely=0.52, anchor="center")
+        glow.lower()
+        self._weight_glow = glow
+
         self._weight_label = tk.Label(
             weight_container,
             textvariable=self._weight_var,
-            font=FONTS["display"],
-            fg=COLORS["fg"],
+            font=FONT_DIGITS,
+            fg=COLOR_PRIMARY,
             bg=background,
         )
-        self._weight_label.pack(expand=True)
+        self._weight_label.place(relx=0.5, rely=0.5, anchor="center")
         self._weight_label.name = "weight_display"  # type: ignore[attr-defined]
         if hasattr(self.controller, "register_widget"):
             self.controller.register_widget("weight_display", self._weight_label)
+
+        self._weight_border = neon_border(weight_container)
 
         status_frame = tk.Frame(self, bg=background)
         status_frame.pack(anchor="center", pady=(0, SPACING["md"]))
@@ -58,8 +80,8 @@ class HomeView(tk.Frame):
         self._stable_label = tk.Label(
             status_frame,
             textvariable=self._stable_var,
-            font=font_sans(16, "bold"),
-            fg=COLORS["danger"],
+            font=FONT_UI_BOLD,
+            fg=COLOR_ACCENT,
             bg=background,
         )
         self._stable_label.pack(side="left", padx=(0, SPACING["md"]))
@@ -70,20 +92,21 @@ class HomeView(tk.Frame):
             text="1 decimal",
             variable=self._decimals_var,
             command=self._handle_decimals_toggle,
-            font=font_sans(14, "bold"),
-            fg=COLORS["fg"],
-            selectcolor=COLORS["accent"],
+            font=FONT_UI_BOLD,
+            fg=COLOR_TEXT,
+            selectcolor=COLOR_ACCENT,
             bg=background,
             activebackground=background,
-            activeforeground=COLORS["fg"],
+            activeforeground=COLOR_TEXT,
             highlightthickness=0,
         )
         decimals_switch.pack(side="left")
 
         buttons_frame = tk.Frame(self, bg=background)
         buttons_frame.pack(fill="both", expand=True)
+        self._buttons_border = neon_border(buttons_frame, padding=8, radius=24)
 
-        self.buttons: Dict[str, tk.Button] = {}
+        self.buttons: Dict[str, tk.Misc] = {}
         self._tara_long_press_job: str | None = None
         self._tara_long_press_triggered = False
 
@@ -113,20 +136,12 @@ class HomeView(tk.Frame):
                     sticky="nsew",
                 )
             if button is None:
-                button = tk.Button(
+                button = ttk.Button(
                     buttons_frame,
                     text=label,
-                    font=FONTS["btn"],
-                    fg=COLORS["fg"],
-                    bg=COLORS["surface"],
-                    activebackground=COLORS["accent"],
-                    activeforeground=COLORS["bg"],
-                    relief="flat",
-                    highlightthickness=1,
-                    bd=1,
-                    padx=SPACING["md"],
-                    pady=SPACING["md"],
                     command=command,
+                    style="Holo.Circular.TButton",
+                    padding=SPACING["sm"],
                 )
                 button.grid(
                     row=index // 3,
@@ -152,7 +167,7 @@ class HomeView(tk.Frame):
     def update_weight(self, grams: float, stable: bool) -> None:
         self._last_grams = float(grams)
         self._stable_var.set("Estable" if stable else "Inestable")
-        self._stable_label.configure(fg=COLORS["primary"] if stable else COLORS["danger"])
+        self._stable_label.configure(fg=COLOR_PRIMARY if stable else COLOR_ACCENT)
         self._refresh_display()
 
     def toggle_units(self) -> str:


### PR DESCRIPTION
## Summary
- introduce a reusable `holo` ttk theme with neon grid and border helpers
- apply the theme at startup and refresh the home view with holographic styles
- update keyboard fallbacks to use the new palette and fonts

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68d815c608c083268b09b83a37c8d9df