### PR TITLE
Add holographic theme utilities, TimerPopup widget, and FastAPI miniweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,42 @@ Proyecto para integrar una báscula basada en ESP32+HX711 con una Raspberry Pi 5
 - `bascula/ui/`: aplicación Tkinter (home, temporizador, recetas, ajustes y overlays). 【F:bascula/ui/app.py†L41-L123】【F:bascula/ui/views/home.py†L1-L102】
 - `scripts/`: instaladores, diagnóstico y utilidades para AP, OTA y pruebas rápidas. 【F:scripts/install-1-system.sh†L1-L164】【F:scripts/setup_ap_nm.sh†L1-L73】
 
+## Tema holográfico, TimerPopup y miniweb LAN
+
+- **Tema holográfico**: el módulo `bascula/ui/theme_holo.py` define la nueva paleta (fondo oscuro con acentos cian/magenta) y estilos ttk compatibles con teclados y tablas existentes. Las pantallas principales todavía no lo usan; primero se introduce el tema como dependencia opcional para pruebas rápidas.
+- **TimerPopup independiente**: se puede lanzar el temporizador con teclado numérico sin tocar las pantallas actuales. Ejecuta el siguiente _smoke test_ desde un terminal con entorno gráfico:
+
+  ```bash
+  python3 - <<'PY'
+  from tkinter import Tk
+  from bascula.ui.theme_holo import apply_holo_theme
+  from bascula.ui.widgets import TimerPopup
+  r = Tk(); apply_holo_theme(r)
+  def ok(s): print("OK seconds:", s)
+  TimerPopup(r, initial_seconds=90, on_accept=ok)
+  r.mainloop()
+  PY
+  ```
+
+  Usa `Enter` para aceptar, `Esc` para cancelar y `Backspace` (o el botón **Borrar**) para retroceder dígitos. El botón `:` conmuta la edición hacia los segundos. El teclado completo permite marcar minutos/segundos sin desplegar pantallas nuevas.
+
+- **Miniweb accesible por LAN**: el servicio `bascula.services.miniweb` expone `/health` y `/info` en FastAPI sobre `0.0.0.0:8080`. Para la prueba mínima:
+
+  ```bash
+  python3 -m bascula.services.miniweb & sleep 1
+  curl -s http://127.0.0.1:8080/health | grep -q '"ok": true'
+  ```
+
+  Desde otro dispositivo de la red puedes consultar `http://<ip-de-la-pi>:8080/info` para ver versión y enlaces de documentación. Detén el servidor temporal con `pkill -f bascula.services.miniweb` cuando acabes.
+
+- **Fuentes opcionales**: el tema holográfico intenta usar `Oxanium` y `Share Tech Mono`. En Raspberry Pi OS puedes instalarlas con:
+
+  ```bash
+  sudo apt install fonts-oxanium fonts-share-tech-mono
+  ```
+
+  Si no están disponibles, la UI cae automáticamente a `DejaVu Sans`/`DejaVu Sans Mono` o cualquier fuente `Monospace` detectada, por lo que no es obligatorio instalarlas.
+
 ## Instalación en Raspberry Pi OS Bookworm
 
 1. **Preparar microSD** con Raspberry Pi OS Bookworm (64 bits). Habilita SSH (opcional) y conecta red cableada para la fase inicial.

--- a/bascula/services/miniweb.py
+++ b/bascula/services/miniweb.py
@@ -1,0 +1,64 @@
+"""FastAPI miniweb exposed on the local network."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from fastapi import FastAPI
+
+from bascula import __version__
+
+APP_NAME = "Báscula Miniweb"
+APP_DESCRIPTION = "Endpoints ligeros para supervisión y diagnóstico desde la LAN."
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application."""
+
+    app = FastAPI(
+        title=APP_NAME,
+        description=APP_DESCRIPTION,
+        version=__version__,
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    @app.get("/health", tags=["core"])
+    async def health() -> Dict[str, bool]:
+        """Health probe used por systemd y chequeos ligeros."""
+
+        return {"ok": True}
+
+    @app.get("/info", tags=["core"])
+    async def info() -> Dict[str, Any]:
+        """Return version metadata and runtime details."""
+
+        return {
+            "app": APP_NAME,
+            "description": APP_DESCRIPTION,
+            "version": __version__,
+            "docs": {
+                "openapi": "/openapi.json",
+                "swagger_ui": "/docs",
+                "redoc": "/redoc",
+            },
+        }
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    """Entry point when executed as a module."""
+
+    import uvicorn
+
+    host = os.environ.get("UVICORN_HOST", "0.0.0.0")
+    port = int(os.environ.get("UVICORN_PORT", "8080"))
+    uvicorn.run(app, host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Bascula Miniweb (FastAPI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pi
+WorkingDirectory=/opt/bascula/current
+Environment=UVICORN_HOST=0.0.0.0
+Environment=UVICORN_PORT=8080
+ExecStart=/usr/bin/python3 -m bascula.services.miniweb
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- refresh `theme_holo` with the holographic palette, automatic font fallbacks, and reusable grid/outline helpers
- add the modal `TimerPopup` keypad widget so timers can be tested without touching existing screens
- expose a FastAPI miniweb (with systemd unit) and document LAN smoke tests plus optional font installation steps

## Testing
- python3 - <<'PY' ... (fails headless: no $DISPLAY)
- python3 -m bascula.services.miniweb & curl -s http://127.0.0.1:8080/health


------
https://chatgpt.com/codex/tasks/task_e_68d81ecc00788326a074a5917222b831