### PR TITLE
Integrate holographic toolbar styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,31 @@ Los ficheros de `docs/examples/` son sintácticamente válidos y listos para cop
 - `scripts/ota.sh` gestiona releases en `/opt/bascula/releases/<versión>` y actualiza el symlink `current`. 【F:scripts/ota.sh†L48-L136】
 - Persiste estado de fallos en `/opt/bascula/shared/userdata` para recuperar la app tras errores repetidos. 【F:scripts/ota.sh†L50-L90】【F:scripts/ota.sh†L176-L214】
 
+### Smoke test de la Toolbar holográfica
+
+```bash
+python3 - <<'PY'
+from tkinter import Tk
+from bascula.ui.theme_holo import apply_holo_theme
+from bascula.ui.toolbar import Toolbar
+from tkinter import ttk
+
+root = Tk()
+root.geometry("900x500")
+apply_holo_theme(root)
+container = ttk.Frame(root, style="Toolbar.TFrame")
+container.pack(fill="both", expand=True)
+toolbar = Toolbar(container, actions=[
+    {"text": "Home", "command": lambda: print("Home")},
+    {"text": "Ajustes", "command": lambda: print("Ajustes")},
+    {"text": "Historial", "command": lambda: print("Historial")},
+])
+toolbar.pack(side="top", fill="x")
+ttk.Label(container, text="Contenido debajo del toolbar", style="Toolbar.TLabel").pack(pady=40)
+root.mainloop()
+PY
+```
+
 ## Descargo de responsabilidad
 
 Este proyecto no sustituye asesoría médica. Verifica toda recomendación nutricional o cálculo de bolo con tu equipo de salud antes de aplicarlo. Usa la báscula y sus servicios bajo tu propio riesgo.

--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -17,11 +17,13 @@ __all__ = [
     "COLOR_ACCENT",
     "COLOR_SURFACE",
     "COLOR_TEXT",
+    "PALETTE",
     "FONT_BODY",
     "FONT_BODY_BOLD",
     "FONT_HEADER",
     "FONT_SUBHEADER",
     "FONT_MONO_LG",
+    "FONT_BUTTON",
 ]
 
 
@@ -30,7 +32,21 @@ COLOR_GRID = "#00cbd6"
 COLOR_PRIMARY = "#18e6ff"
 COLOR_ACCENT = "#ff2db2"
 COLOR_SURFACE = "#0e2230"
+COLOR_SURFACE_HI = "#143447"
 COLOR_TEXT = "#d8f6ff"
+COLOR_TEXT_MUTED = "#93b4c4"
+COLOR_OUTLINE = "#114052"
+
+PALETTE = {
+    "bg": COLOR_BG,
+    "surface": COLOR_SURFACE,
+    "surface_hi": COLOR_SURFACE_HI,
+    "text": COLOR_TEXT,
+    "text_muted": COLOR_TEXT_MUTED,
+    "primary": COLOR_PRIMARY,
+    "accent": COLOR_ACCENT,
+    "outline": COLOR_OUTLINE,
+}
 
 
 @dataclass(frozen=True)
@@ -81,6 +97,9 @@ def _get_font_specs(style: ttk.Style) -> dict[str, tuple[str, int] | tuple[str, 
         "body_bold": _FontSpec(("Oxanium",), ("DejaVu Sans", "TkDefaultFont"), 12, "bold").resolve(available),
         "header": _FontSpec(("Oxanium",), ("DejaVu Sans", "TkDefaultFont"), 24, "bold").resolve(available),
         "subheader": _FontSpec(("Oxanium",), ("DejaVu Sans", "TkDefaultFont"), 16).resolve(available),
+        "button": _FontSpec(("Oxanium",), ("DejaVu Sans", "TkDefaultFont"), 13, "bold").resolve(
+            available
+        ),
         "mono_lg": _FontSpec(
             ("Share Tech Mono",),
             ("DejaVu Sans Mono", "Monospace", "TkFixedFont"),
@@ -96,6 +115,7 @@ FONT_BODY_BOLD: tuple[str, int] | tuple[str, int, str] = ("DejaVu Sans", 12, "bo
 FONT_HEADER: tuple[str, int] | tuple[str, int, str] = ("DejaVu Sans", 24, "bold")
 FONT_SUBHEADER: tuple[str, int] | tuple[str, int, str] = ("DejaVu Sans", 16)
 FONT_MONO_LG: tuple[str, int] | tuple[str, int, str] = ("DejaVu Sans Mono", 36, "bold")
+FONT_BUTTON: tuple[str, int] | tuple[str, int, str] = ("DejaVu Sans", 12, "bold")
 
 
 def apply_holo_theme(root: Optional[Misc] = None) -> None:
@@ -106,12 +126,13 @@ def apply_holo_theme(root: Optional[Misc] = None) -> None:
         style.theme_use("clam")
 
     fonts = _get_font_specs(style)
-    global FONT_BODY, FONT_BODY_BOLD, FONT_HEADER, FONT_SUBHEADER, FONT_MONO_LG
+    global FONT_BODY, FONT_BODY_BOLD, FONT_HEADER, FONT_SUBHEADER, FONT_MONO_LG, FONT_BUTTON
     FONT_BODY = fonts["body"]
     FONT_BODY_BOLD = fonts["body_bold"]
     FONT_HEADER = fonts["header"]
     FONT_SUBHEADER = fonts["subheader"]
     FONT_MONO_LG = fonts["mono_lg"]
+    FONT_BUTTON = fonts.get("button", FONT_BODY_BOLD)
 
     style.configure("TFrame", background=COLOR_SURFACE)
     style.configure(
@@ -149,6 +170,43 @@ def apply_holo_theme(root: Optional[Misc] = None) -> None:
         background=[("active", COLOR_BG), ("pressed", COLOR_ACCENT)],
         foreground=[("active", COLOR_TEXT), ("pressed", COLOR_TEXT)],
         bordercolor=[("focus", COLOR_PRIMARY)],
+    )
+
+    style.configure(
+        "Toolbar.TFrame",
+        background=PALETTE["bg"],
+        borderwidth=0,
+        relief="flat",
+        padding=(24, 12, 24, 8),
+    )
+    style.configure(
+        "Toolbar.TLabel",
+        background=PALETTE["bg"],
+        foreground=PALETTE["text_muted"],
+        font=FONT_BODY,
+    )
+    style.configure(
+        "Toolbar.Separator.TFrame",
+        background=PALETTE["outline"],
+        borderwidth=0,
+        height=1,
+        relief="flat",
+    )
+    style.configure(
+        "Toolbutton.TButton",
+        background=PALETTE["bg"],
+        foreground=PALETTE["text_muted"],
+        borderwidth=0,
+        focusthickness=0,
+        relief="flat",
+        padding=(10, 8),
+        font=FONT_BUTTON,
+    )
+    style.map(
+        "Toolbutton.TButton",
+        foreground=[("active", PALETTE["primary"]), ("pressed", PALETTE["accent"])],
+        background=[("active", PALETTE["surface_hi"]), ("pressed", PALETTE["surface"])],
+        bordercolor=[("focus", PALETTE["primary"])],
     )
 
     style.configure(

--- a/bascula/ui/toolbar.py
+++ b/bascula/ui/toolbar.py
@@ -1,0 +1,98 @@
+"""Reusable holographic toolbar component."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping, MutableSequence, Optional
+
+from tkinter import ttk
+
+__all__ = ["Toolbar"]
+
+
+ActionSpec = Mapping[str, object]
+
+
+class Toolbar(ttk.Frame):
+    """Flat toolbar styled for the holographic theme."""
+
+    def __init__(
+        self,
+        master: Optional[ttk.Widget] = None,
+        *,
+        actions: Optional[Iterable[ActionSpec]] = None,
+        padding: tuple[int, int, int, int] | tuple[int, int] | None = None,
+        **kwargs,
+    ) -> None:
+        kwargs.setdefault("style", "Toolbar.TFrame")
+        if padding is None:
+            super().__init__(master, **kwargs)
+        else:
+            super().__init__(master, padding=padding, **kwargs)
+
+        self.columnconfigure(0, weight=1)
+        self._content = ttk.Frame(self, style="Toolbar.TFrame")
+        self._content.grid(row=0, column=0, sticky="nsew")
+        self._content.columnconfigure(0, weight=1)
+
+        self._button_container = ttk.Frame(self._content, style="Toolbar.TFrame")
+        self._button_container.pack(side="left", fill="x")
+
+        self._buttons: MutableSequence[ttk.Button] = []
+
+        self._bottom_line = ttk.Frame(self, style="Toolbar.Separator.TFrame")
+        self._bottom_line.grid(row=1, column=0, sticky="ew")
+
+        if actions:
+            for action in actions:
+                self.add_action(action)
+
+    @property
+    def buttons(self) -> tuple[ttk.Button, ...]:
+        """Return the tuple of created action buttons."""
+
+        return tuple(self._buttons)
+
+    @property
+    def content(self) -> ttk.Frame:
+        """Expose the internal content frame for extra widgets."""
+
+        return self._content
+
+    @property
+    def button_container(self) -> ttk.Frame:
+        """Frame where action buttons are packed."""
+
+        return self._button_container
+
+    def clear_actions(self) -> None:
+        """Remove all current buttons from the toolbar."""
+
+        while self._buttons:
+            button = self._buttons.pop()
+            try:
+                button.destroy()
+            except Exception:
+                pass
+
+    def add_action(self, action: ActionSpec) -> ttk.Button:
+        """Create a new tool button and pack it to the left."""
+
+        text = str(action.get("text", ""))
+        command = action.get("command")
+        extra = {k: v for k, v in action.items() if k not in {"text", "command"}}
+
+        button = ttk.Button(
+            self._button_container,
+            text=text,
+            command=command,  # type: ignore[arg-type]
+            style="Toolbutton.TButton",
+            **extra,
+        )
+        button.pack(side="left", padx=(0, 12))
+        try:
+            button.configure(cursor="hand2")
+        except Exception:
+            pass
+        self._buttons.append(button)
+        return button
+


### PR DESCRIPTION
## Summary
- add holographic toolbar palette entries and widget styles to the Tk theme
- introduce a reusable ttk-based Toolbar component and embed it into the app shell layout
- document a smoke-test snippet to preview the holographic toolbar

## Testing
- python -m compileall bascula/ui/app_shell.py bascula/ui/toolbar.py bascula/ui/theme_holo.py

------
https://chatgpt.com/codex/tasks/task_e_68d8235eb78883269a49033a127e5dc7