### PR TITLE
Restore LAN FastAPI mini web on port 8080

### DIFF
--- a/ci/tests/test_min.sh
+++ b/ci/tests/test_min.sh
@@ -17,7 +17,7 @@ cd "${repo_root}"
 
 ci::log "Verificando unit bascula-miniweb.service"
 if command -v systemd-analyze >/dev/null 2>&1; then
-  temp_exec="/opt/bascula/venv/bin/uvicorn"
+  temp_exec="/opt/bascula/current/.venv/bin/uvicorn"
   cleanup_exec=0
   if [[ ! -x "${temp_exec}" ]]; then
     install -D -m 0755 /bin/true "${temp_exec}"

--- a/scripts/setup-venv-miniweb.sh
+++ b/scripts/setup-venv-miniweb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-VENV=/opt/bascula/venv
+VENV=/opt/bascula/current/.venv
 sudo apt-get update
 sudo apt-get install -y python3-venv python3-full
 if [ ! -d "$VENV" ]; then

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -10,7 +10,7 @@ WorkingDirectory=/opt/bascula/current
 Environment=PYTHONPATH=/opt/bascula/current
 Environment=UVICORN_HOST=0.0.0.0
 Environment=UVICORN_PORT=8080
-ExecStart=/opt/bascula/venv/bin/uvicorn bascula.miniweb:app --host ${UVICORN_HOST} --port ${UVICORN_PORT} --log-level info
+ExecStart=/opt/bascula/current/.venv/bin/uvicorn bascula.miniweb:app --host ${UVICORN_HOST} --port ${UVICORN_PORT} --log-level info
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
## Summary
- restore the FastAPI-based mini web at `bascula/miniweb.py` with `/health` and `/info` endpoints and keep the background server helper
- switch the systemd unit to launch uvicorn from `/opt/bascula/current/.venv`, add a setup script for the venv, and refresh docs/install scripts to use `bascula-miniweb.service`
- update supporting tooling (doctor, OTA, CI checks, UI actions) to point at the new service name while keeping a compatibility shim for legacy imports

## Testing
- python -m compileall bascula/miniweb.py bascula/services/miniweb.py


------
https://chatgpt.com/codex/tasks/task_e_68d82c4409ac8326879e73610e8ea1d3