### PR TITLE
feat: deliver secure LAN mini web console

### DIFF
--- a/bascula/miniweb.py
+++ b/bascula/miniweb.py
@@ -1,66 +1,451 @@
-"""FastAPI mini web exposed on the local network and UI helper server."""
+"""FastAPI mini web service for configuration, recovery, OTA, and diagnostics.
+
+This module provides the LAN mini web specified for the Raspberry Pi based scale.
+It intentionally does *not* touch the Tk UI or the core scale logic – the service
+exposes HTTP endpoints that can be consumed from other devices on the local
+network.
+
+Key features implemented here:
+
+* Token and PIN based authentication with signed cookies.
+* Configuration management (Wi-Fi, OpenAI, Nightscout, export/reload).
+* OTA helpers (status, check, channel selection, updates, rollback).
+* Recovery helpers (restarts, rollback, logs, diagnostics, factory reset).
+* Simple HTML UI rendered via Jinja templates.
+
+The implementation tries to be resilient in environments that do not provide the
+exact tooling available on the production Raspberry Pi (for example when running
+the unit tests on CI or during local development).  Commands that are not
+available will return a helpful message instead of crashing the web service.
+"""
 
 from __future__ import annotations
 
+import base64
+import dataclasses
+import datetime as dt
+import ipaddress
+import json
 import logging
 import os
+from pathlib import Path
+import secrets
 import socket
+import subprocess
 import threading
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, Response, status
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from itsdangerous import BadSignature, BadTimeSignature, URLSafeTimedSerializer
+import requests
 import uvicorn
+import yaml
 
 from bascula import __version__
 
-from .config.settings import Settings
-
 APP_NAME = "Báscula Miniweb"
-APP_DESCRIPTION = "Endpoints ligeros para supervisión y diagnóstico desde la LAN."
+APP_DESCRIPTION = "Mini web LAN para configuración, OTA y recuperación"
 
 log = logging.getLogger(__name__)
 
 
-def create_app() -> FastAPI:
-    """Create and configure the FastAPI application."""
+# ---------------------------------------------------------------------------
+# Paths and constants
+# ---------------------------------------------------------------------------
 
-    app = FastAPI(
-        title=APP_NAME,
-        description=APP_DESCRIPTION,
-        version=__version__,
-        docs_url="/docs",
-        redoc_url="/redoc",
-    )
+SESSION_COOKIE = "bascula_session"
+SESSION_TTL_SECONDS = 30 * 60  # 30 minutos
+SESSION_RENEW_THRESHOLD = 10 * 60  # renovar cuando queden 10 minutos
 
-    core_router = APIRouter(tags=["core"])
+AUTH_STATE_PATH = Path("/var/lib/bascula/miniweb_auth.json")
+CONFIG_YAML_PATH = Path("/etc/bascula/config.yaml")
+SECRETS_ENV_PATH = Path("/etc/bascula/secrets.env")
+OTA_LOG_PATH = Path("/var/log/bascula/ota.log")
 
-    @core_router.get("/", include_in_schema=False)
-    async def root() -> Dict[str, Any]:
-        """Return a friendly landing payload for the mini web."""
+DEFAULT_ROLLBACK_COMMIT = "cec388edb25b95fa3e52c639355d03370b791c01"
 
-        info_payload = await info()
-        return {
-            "ok": True,
-            "message": "Báscula Miniweb en ejecución",
-            "endpoints": {
-                "health": "/health",
-                "info": "/info",
-                "docs": "/docs",
-                "openapi": "/openapi.json",
-            },
-            "instance": info_payload,
+
+def _default_repo_root() -> Path:
+    env = os.environ.get("MINIWEB_REPO")
+    if env:
+        repo = Path(env)
+        if repo.exists():
+            return repo
+
+    # Prefer production path when available, otherwise fall back to the project root.
+    prod = Path("/opt/bascula/current")
+    if prod.exists():
+        return prod
+
+    return Path(__file__).resolve().parent.parent
+
+
+REPO_ROOT = _default_repo_root()
+
+
+TEMPLATE_DIR = Path(__file__).resolve().parent / "miniweb_templates"
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helper classes
+# ---------------------------------------------------------------------------
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_text_file(path: Path, data: str, *, mode: int | None = None) -> None:
+    _ensure_parent(path)
+    path.write_text(data, encoding="utf-8")
+    if mode is not None:
+        try:
+            path.chmod(mode)
+        except PermissionError:  # pragma: no cover - best effort on dev machines
+            log.debug("Cannot chmod %s", path)
+
+
+def _read_json_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        log.warning("Failed to load JSON file %s", path)
+        return {}
+
+
+def _write_json_file(path: Path, payload: Dict[str, Any]) -> None:
+    _ensure_parent(path)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _coerce_port(value: Any, default: int = 8080) -> int:
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        port = default
+    return port if 0 < port < 65536 else default
+
+
+def _looks_like_ip(candidate: str) -> bool:
+    try:
+        ipaddress.ip_address(candidate)
+        return True
+    except ValueError:
+        return False
+
+
+def load_config_yaml() -> Dict[str, Any]:
+    if not CONFIG_YAML_PATH.exists():
+        return {}
+    try:
+        with CONFIG_YAML_PATH.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if not isinstance(data, dict):
+            return {}
+        return data
+    except Exception as exc:  # pragma: no cover - defensive
+        log.error("Failed to read %s: %s", CONFIG_YAML_PATH, exc)
+        return {}
+
+
+def save_config_yaml(config: Dict[str, Any]) -> None:
+    _ensure_parent(CONFIG_YAML_PATH)
+    with CONFIG_YAML_PATH.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(config, fh, sort_keys=True)
+    try:
+        CONFIG_YAML_PATH.chmod(0o644)
+    except PermissionError:  # pragma: no cover - best effort
+        pass
+
+
+def load_secrets_env() -> Dict[str, str]:
+    if not SECRETS_ENV_PATH.exists():
+        return {}
+    secrets_data: Dict[str, str] = {}
+    for line in SECRETS_ENV_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        secrets_data[key.strip()] = value.strip()
+    return secrets_data
+
+
+def save_secrets_env(data: Dict[str, str]) -> None:
+    lines = [f"{key}={value}" for key, value in sorted(data.items())]
+    _write_text_file(SECRETS_ENV_PATH, "\n".join(lines) + "\n", mode=0o600)
+
+
+def mask_secret(secret: Optional[str]) -> Optional[str]:
+    if not secret:
+        return secret
+    if len(secret) <= 4:
+        return "*" * len(secret)
+    return secret[:2] + "***" + secret[-2:]
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(tz=dt.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Authentication helpers
+# ---------------------------------------------------------------------------
+
+
+class RateLimiter:
+    """Persist per-IP login attempts to avoid brute force attacks."""
+
+    def __init__(self, path: Path, limit: int = 5, window_seconds: int = 300, block_seconds: int = 600) -> None:
+        self._path = path
+        self._limit = limit
+        self._window = window_seconds
+        self._block = block_seconds
+
+    def _prune(self, attempts: List[float]) -> List[float]:
+        threshold = _now() - self._window
+        return [stamp for stamp in attempts if stamp >= threshold]
+
+    def check(self, ip: str) -> None:
+        state = _read_json_file(self._path)
+        entry = state.get(ip, {}) if isinstance(state, dict) else {}
+        blocked_until = entry.get("blocked_until")
+        if isinstance(blocked_until, (int, float)) and blocked_until > _now():
+            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Intentos bloqueados temporalmente")
+
+        attempts = entry.get("attempts", [])
+        if isinstance(attempts, list):
+            entry["attempts"] = self._prune([float(x) for x in attempts])
+        else:
+            entry["attempts"] = []
+        state[ip] = entry
+        _write_json_file(self._path, state)
+
+    def register(self, ip: str, success: bool) -> None:
+        state = _read_json_file(self._path)
+        entry = state.get(ip, {}) if isinstance(state, dict) else {}
+        attempts = entry.get("attempts", [])
+        if not isinstance(attempts, list):
+            attempts = []
+
+        now = _now()
+        attempts = self._prune([float(x) for x in attempts])
+        if not success:
+            attempts.append(now)
+            if len(attempts) >= self._limit:
+                entry["blocked_until"] = now + self._block
+        else:
+            attempts = []
+            entry["blocked_until"] = None
+
+        entry["attempts"] = attempts
+        state[ip] = entry
+        _write_json_file(self._path, state)
+
+
+@dataclasses.dataclass
+class AuthContext:
+    authenticated: bool
+    via: str
+    expires_at: Optional[dt.datetime] = None
+    should_refresh: bool = False
+
+
+class AuthManager:
+    def __init__(self) -> None:
+        token = os.environ.get("MINIWEB_TOKEN")
+        self._token = token.strip() if token else None
+
+        secret = os.environ.get("MINIWEB_SECRET") or self._token
+        if not secret:
+            secret = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
+        self._secret = secret
+
+        self._serializer = URLSafeTimedSerializer(self._secret, salt="bascula-miniweb-session")
+        self._rate_limiter = RateLimiter(AUTH_STATE_PATH)
+
+    # ------------------------------------------------------------------
+    def _load_pin(self) -> Optional[str]:
+        env_pin = os.environ.get("MINIWEB_PIN")
+        if env_pin:
+            return env_pin.strip()
+
+        config = load_config_yaml()
+        network = config.get("network") if isinstance(config, dict) else None
+        if isinstance(network, dict):
+            pin = network.get("pin") or network.get("miniweb_pin")
+            if pin:
+                return str(pin).strip()
+        return None
+
+    # ------------------------------------------------------------------
+    def require_auth(self, request: Request) -> AuthContext:
+        token_header = request.headers.get("X-API-Token")
+        if self._token and token_header and secrets.compare_digest(token_header, self._token):
+            return AuthContext(authenticated=True, via="token")
+
+        cookie = request.cookies.get(SESSION_COOKIE)
+        if not cookie:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Autenticación requerida")
+
+        try:
+            data = self._serializer.loads(cookie, max_age=SESSION_TTL_SECONDS)
+        except BadTimeSignature:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sesión expirada")
+        except BadSignature:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sesión inválida")
+
+        expires = dt.datetime.fromtimestamp(data.get("expires", 0), tz=dt.timezone.utc)
+        now = _utcnow()
+        if expires <= now:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sesión expirada")
+
+        should_refresh = (expires - now).total_seconds() <= SESSION_RENEW_THRESHOLD
+        return AuthContext(authenticated=True, via=str(data.get("via", "pin")), expires_at=expires, should_refresh=should_refresh)
+
+    # ------------------------------------------------------------------
+    def refresh_cookie(self, response: Response, via: str) -> None:
+        payload = {
+            "via": via,
+            "issued": _utcnow().timestamp(),
+            "expires": (_utcnow() + dt.timedelta(seconds=SESSION_TTL_SECONDS)).timestamp(),
         }
+        cookie = self._serializer.dumps(payload)
+        response.set_cookie(
+            key=SESSION_COOKIE,
+            value=cookie,
+            httponly=True,
+            samesite="lax",
+            max_age=SESSION_TTL_SECONDS,
+            secure=False,
+        )
 
-    @core_router.get("/health")
+    # ------------------------------------------------------------------
+    def clear_cookie(self, response: Response) -> None:
+        response.delete_cookie(SESSION_COOKIE)
+
+    # ------------------------------------------------------------------
+    def login(self, request: Request, response: Response, pin: str) -> AuthContext:
+        ip = self._peer_ip(request)
+        self._rate_limiter.check(ip)
+
+        stored_pin = self._load_pin()
+        if not stored_pin:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="PIN no configurado")
+
+        if not secrets.compare_digest(str(pin).strip(), str(stored_pin)):
+            self._rate_limiter.register(ip, success=False)
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="PIN incorrecto")
+
+        self._rate_limiter.register(ip, success=True)
+        ctx = AuthContext(authenticated=True, via="pin", expires_at=_utcnow() + dt.timedelta(seconds=SESSION_TTL_SECONDS))
+        self.refresh_cookie(response, via="pin")
+        return ctx
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _peer_ip(request: Request) -> str:
+        client = request.client
+        if client:
+            return client.host
+        return "unknown"
+
+    # ------------------------------------------------------------------
+    def auth_status(self, request: Request) -> AuthContext:
+        try:
+            ctx = self.require_auth(request)
+        except HTTPException:
+            return AuthContext(authenticated=False, via="none")
+        return ctx
+
+
+auth_manager = AuthManager()
+
+
+def auth_dependency(request: Request, response: Response) -> AuthContext:
+    ctx = auth_manager.require_auth(request)
+    if ctx.should_refresh:
+        auth_manager.refresh_cookie(response, via=ctx.via)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Command helpers
+# ---------------------------------------------------------------------------
+
+
+class CommandError(RuntimeError):
+    pass
+
+
+def run_command(args: Iterable[str], *, check: bool = True, timeout: int = 30, env: Optional[Dict[str, str]] = None, cwd: Optional[Path] = None) -> subprocess.CompletedProcess[str]:
+    log.debug("Running command: %s", " ".join(args))
+    try:
+        result = subprocess.run(
+            list(args),
+            check=check,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=env,
+            cwd=str(cwd) if cwd else None,
+        )
+    except FileNotFoundError as exc:
+        raise CommandError(f"Comando no disponible: {args[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise CommandError(exc.stderr.strip() or exc.stdout.strip() or "Error de comando") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CommandError(f"Comando expirado tras {timeout}s") from exc
+    return result
+
+
+def run_repo_git(args: Iterable[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    git_args = ["git", "-C", str(REPO_ROOT)] + list(args)
+    return run_command(git_args, check=check)
+
+
+def append_ota_log(message: str) -> None:
+    timestamp = _utcnow().strftime("%Y-%m-%d %H:%M:%S %Z")
+    entry = f"[{timestamp}] {message}\n"
+    try:
+        _ensure_parent(OTA_LOG_PATH)
+        with OTA_LOG_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(entry)
+    except Exception:  # pragma: no cover - logging best effort
+        log.debug("Unable to append to OTA log")
+
+
+# ---------------------------------------------------------------------------
+# Mini web application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title=APP_NAME, description=APP_DESCRIPTION, version=__version__)
+
+    # ------------------------------------------------------------------
+    @app.get("/health")
     async def health() -> Dict[str, bool]:
-        """Basic liveness probe used by systemd and manual checks."""
-
         return {"ok": True}
 
-    @core_router.get("/info")
-    async def info() -> Dict[str, Any]:
-        """Return metadata about the mini web instance."""
+    # ------------------------------------------------------------------
+    @app.get("/info")
+    async def info(request: Request) -> Dict[str, Any]:
+        hide = os.environ.get("MINIWEB_HIDE_INFO") == "1"
+        if hide:
+            auth_manager.require_auth(request)
 
         host = socket.gethostname()
         host_env = os.environ.get("UVICORN_HOST", "0.0.0.0")
@@ -70,18 +455,446 @@ def create_app() -> FastAPI:
             "description": APP_DESCRIPTION,
             "version": __version__,
             "hostname": host,
-            "listen": {
-                "host": host_env,
-                "port": int(port_env) if port_env.isdigit() else port_env,
-            },
-            "docs": {
-                "openapi": "/openapi.json",
-                "swagger_ui": "/docs",
-                "redoc": "/redoc",
-            },
+            "listen": {"host": host_env, "port": port_env},
         }
 
-    app.include_router(core_router)
+    # ------------------------------------------------------------------
+    @app.get("/config", response_class=HTMLResponse)
+    async def config_page(request: Request) -> HTMLResponse:
+        status_ctx = auth_manager.auth_status(request)
+        return templates.TemplateResponse("config.html", {"request": request, "auth": status_ctx})
+
+    # Routers -----------------------------------------------------------
+    auth_router = APIRouter(prefix="/auth", tags=["auth"])
+    config_router = APIRouter(prefix="/config", tags=["config"])
+    ota_router = APIRouter(prefix="/ota", tags=["ota"], dependencies=[Depends(auth_dependency)])
+    recovery_router = APIRouter(prefix="/recovery", tags=["recovery"], dependencies=[Depends(auth_dependency)])
+
+    # ------------------------------------------------------------------
+    @auth_router.post("/login")
+    async def auth_login(payload: Dict[str, Any], request: Request, response: Response) -> Dict[str, Any]:
+        pin = str(payload.get("pin", ""))
+        ctx = auth_manager.login(request, response, pin)
+        return {"authenticated": ctx.authenticated, "via": ctx.via, "expires_at": ctx.expires_at.isoformat() if ctx.expires_at else None}
+
+    # ------------------------------------------------------------------
+    @auth_router.post("/logout")
+    async def auth_logout(response: Response) -> Dict[str, bool]:
+        auth_manager.clear_cookie(response)
+        return {"ok": True}
+
+    # ------------------------------------------------------------------
+    @auth_router.get("/status")
+    async def auth_status_endpoint(request: Request, response: Response) -> Dict[str, Any]:
+        ctx = auth_manager.auth_status(request)
+        if ctx.authenticated and ctx.should_refresh:
+            auth_manager.refresh_cookie(response, via=ctx.via)
+        return {"authenticated": ctx.authenticated, "via": ctx.via, "expires_at": ctx.expires_at.isoformat() if ctx.expires_at else None}
+
+    app.include_router(auth_router)
+
+    # ------------------------------------------------------------------
+    # Config helpers
+    # ------------------------------------------------------------------
+
+    @config_router.get("/export", dependencies=[Depends(auth_dependency)])
+    async def config_export() -> Dict[str, Any]:
+        config = load_config_yaml()
+        secrets_data = load_secrets_env()
+        secrets_masked = {key: mask_secret(value) for key, value in secrets_data.items()}
+        return {"config": config, "secrets": secrets_masked}
+
+    @config_router.post("/reload", dependencies=[Depends(auth_dependency)])
+    async def config_reload() -> Dict[str, Any]:
+        return {"accepted": True}
+
+    # Wi-Fi -------------------------------------------------------------
+    wifi_router = APIRouter(prefix="/wifi", tags=["wifi"], dependencies=[Depends(auth_dependency)])
+
+    @wifi_router.get("/status")
+    async def wifi_status() -> Dict[str, Any]:
+        status_payload: Dict[str, Any] = {"ssid": None, "ip": None, "signal": None}
+
+        try:
+            ssid = run_command(["iwgetid", "-r"]).stdout.strip()
+            status_payload["ssid"] = ssid or None
+        except CommandError as exc:
+            status_payload["ssid_error"] = str(exc)
+
+        try:
+            ip_output = run_command(["hostname", "-I"]).stdout.strip()
+            ips = [token for token in ip_output.split() if _looks_like_ip(token)]
+            status_payload["ip"] = ips[0] if ips else None
+        except CommandError as exc:
+            status_payload["ip_error"] = str(exc)
+
+        try:
+            signal = _current_signal_strength()
+            if signal is not None:
+                status_payload["signal"] = signal
+        except CommandError as exc:
+            status_payload["signal_error"] = str(exc)
+
+        return status_payload
+
+    def _current_signal_strength() -> Optional[int]:
+        try:
+            result = run_command(["nmcli", "-t", "-f", "IN-USE,SIGNAL", "dev", "wifi"])
+        except CommandError as exc:
+            raise exc
+
+        for line in result.stdout.splitlines():
+            parts = line.split(":")
+            if not parts:
+                continue
+            if parts[0] == "*" and len(parts) > 1:
+                try:
+                    return int(parts[1])
+                except ValueError:
+                    return None
+        return None
+
+    @wifi_router.get("/scan")
+    async def wifi_scan() -> Dict[str, Any]:
+        try:
+            result = run_command(["nmcli", "-t", "-f", "SSID,SIGNAL", "dev", "wifi"])
+            entries = []
+            for line in result.stdout.splitlines():
+                if not line:
+                    continue
+                ssid, _, signal = line.partition(":")
+                entries.append({"ssid": ssid, "signal": int(signal) if signal.isdigit() else None})
+            return {"networks": entries, "method": "nmcli"}
+        except CommandError as exc:
+            return {"networks": [], "method": "nmcli", "error": str(exc)}
+
+    @wifi_router.post("/connect")
+    async def wifi_connect(payload: Dict[str, Any]) -> Dict[str, Any]:
+        ssid = str(payload.get("ssid", "")).strip()
+        psk = str(payload.get("psk", "")).strip()
+        if not ssid:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="SSID requerido")
+
+        try:
+            run_command(["nmcli", "dev", "wifi", "connect", ssid, "password", psk, "ifname", "wlan0"])
+            return {"ok": True, "method": "nmcli", "note": "Conexión solicitada"}
+        except CommandError as exc:
+            return {"ok": False, "method": "nmcli", "note": str(exc)}
+
+    config_router.include_router(wifi_router)
+
+    # OpenAI ------------------------------------------------------------
+    @config_router.get("/openai", dependencies=[Depends(auth_dependency)])
+    async def config_openai_get() -> Dict[str, Any]:
+        secrets_data = load_secrets_env()
+        return {"api_key": mask_secret(secrets_data.get("OPENAI_API_KEY"))}
+
+    @config_router.post("/openai", dependencies=[Depends(auth_dependency)])
+    async def config_openai_set(payload: Dict[str, Any]) -> Dict[str, Any]:
+        api_key = str(payload.get("api_key", "")).strip()
+        secrets_data = load_secrets_env()
+        if api_key:
+            secrets_data["OPENAI_API_KEY"] = api_key
+        else:
+            secrets_data.pop("OPENAI_API_KEY", None)
+        save_secrets_env(secrets_data)
+        return {"ok": True}
+
+    @config_router.post("/openai/test", dependencies=[Depends(auth_dependency)])
+    async def config_openai_test() -> Dict[str, Any]:
+        try:
+            response = requests.head("https://api.openai.com/v1/models", timeout=3)
+            ok = response.status_code in {200, 401}
+        except requests.RequestException as exc:
+            return {"ok": False, "error": str(exc)}
+        return {"ok": ok, "status": response.status_code}
+
+    # Nightscout --------------------------------------------------------
+    @config_router.get("/nightscout", dependencies=[Depends(auth_dependency)])
+    async def config_nightscout_get() -> Dict[str, Any]:
+        config = load_config_yaml()
+        secrets_data = load_secrets_env()
+        nightscout = config.get("nightscout") if isinstance(config, dict) else {}
+        url = None
+        if isinstance(nightscout, dict):
+            url = nightscout.get("url")
+        return {"url": url, "token": mask_secret(secrets_data.get("NIGHTSCOUT_TOKEN"))}
+
+    @config_router.post("/nightscout", dependencies=[Depends(auth_dependency)])
+    async def config_nightscout_set(payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = str(payload.get("url", "")).strip() or None
+        token = str(payload.get("token", "")).strip() or None
+
+        config = load_config_yaml()
+        nightscout = config.setdefault("nightscout", {}) if isinstance(config, dict) else {}
+        if url:
+            nightscout["url"] = url
+        else:
+            nightscout.pop("url", None)
+        config["nightscout"] = nightscout
+        save_config_yaml(config)
+
+        secrets_data = load_secrets_env()
+        if token:
+            secrets_data["NIGHTSCOUT_TOKEN"] = token
+        else:
+            secrets_data.pop("NIGHTSCOUT_TOKEN", None)
+        save_secrets_env(secrets_data)
+        return {"ok": True}
+
+    @config_router.post("/nightscout/test", dependencies=[Depends(auth_dependency)])
+    async def config_nightscout_test(payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = str(payload.get("url") or "").strip()
+        token = str(payload.get("token") or "").strip()
+        if not url:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="URL requerida")
+        headers = {}
+        if token:
+            headers["API-SECRET"] = token
+        try:
+            response = requests.get(url.rstrip("/") + "/api/v1/status", timeout=3, headers=headers)
+            ok = response.ok
+        except requests.RequestException as exc:
+            return {"ok": False, "error": str(exc)}
+        return {"ok": ok, "status": response.status_code}
+
+    app.include_router(config_router)
+
+    # ------------------------------------------------------------------
+    # OTA helpers
+    # ------------------------------------------------------------------
+
+    def _ota_remote_branch() -> Tuple[str, str]:
+        remote = os.environ.get("OTA_REMOTE") or os.environ.get("MINIWEB_OTA_REMOTE")
+        branch = os.environ.get("OTA_BRANCH") or os.environ.get("MINIWEB_OTA_BRANCH")
+
+        config = load_config_yaml()
+        ota_conf = config.get("ota") if isinstance(config, dict) else {}
+        if isinstance(ota_conf, dict):
+            remote = remote or ota_conf.get("remote")
+            branch = branch or ota_conf.get("branch")
+
+        return remote or "origin", branch or "main"
+
+    def _ensure_clean_worktree(force: bool = False) -> None:
+        result = run_repo_git(["status", "--porcelain"])
+        if result.stdout.strip() and not force:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cambios locales detectados; use force para continuar")
+
+    def _restart_service(service: str) -> str:
+        try:
+            run_command(["sudo", "systemctl", "restart", service], check=True)
+            return "ok"
+        except CommandError as exc:
+            return f"no se pudo reiniciar {service}: {exc}"
+
+    @ota_router.get("/status")
+    async def ota_status() -> Dict[str, Any]:
+        remote, branch = _ota_remote_branch()
+        status_payload: Dict[str, Any] = {"remote": remote, "branch": branch}
+
+        head = run_repo_git(["rev-parse", "--short", "HEAD"]).stdout.strip()
+        status_payload["head"] = head
+
+        dirty = run_repo_git(["status", "--porcelain"]).stdout.strip()
+        status_payload["dirty"] = bool(dirty)
+
+        try:
+            run_repo_git(["fetch", remote, branch], check=True)
+        except CommandError as exc:
+            status_payload["fetch_error"] = str(exc)
+            return status_payload
+
+        ahead_behind = run_repo_git(["rev-list", "--left-right", "--count", f"HEAD...{remote}/{branch}"]).stdout.strip()
+        ahead, behind = (int(token) for token in ahead_behind.split()) if ahead_behind else (0, 0)
+        status_payload["ahead"] = ahead
+        status_payload["behind"] = behind
+
+        latest_remote = run_repo_git(["rev-parse", "--short", f"{remote}/{branch}"]).stdout.strip()
+        status_payload["latest_remote"] = latest_remote
+        return status_payload
+
+    @ota_router.post("/check")
+    async def ota_check() -> Dict[str, Any]:
+        remote, branch = _ota_remote_branch()
+        run_repo_git(["fetch", "--all", "--prune"])
+        log_output = run_repo_git([
+            "log",
+            "--pretty=format:%h %ad %s",
+            "--date=short",
+            f"HEAD..{remote}/{branch}",
+            "-n",
+            "50",
+        ]).stdout.splitlines()
+        ahead_behind = run_repo_git(["rev-list", "--left-right", "--count", f"HEAD...{remote}/{branch}"]).stdout.strip()
+        ahead, behind = (int(token) for token in ahead_behind.split()) if ahead_behind else (0, 0)
+        latest_remote = run_repo_git(["rev-parse", "--short", f"{remote}/{branch}"]).stdout.strip()
+        return {"remote": remote, "branch": branch, "behind": behind, "ahead": ahead, "latest_remote": latest_remote, "pending": log_output}
+
+    @ota_router.get("/channels")
+    async def ota_channels() -> Dict[str, Any]:
+        result = run_repo_git(["branch", "-r"])
+        branches = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if "->" in line:
+                continue
+            if not line:
+                continue
+            if "/" in line:
+                remote, name = line.split("/", 1)
+                branches.append({"remote": remote, "branch": name})
+        return {"channels": branches}
+
+    @ota_router.post("/set-channel")
+    async def ota_set_channel(payload: Dict[str, Any]) -> Dict[str, Any]:
+        branch = str(payload.get("branch", "")).strip()
+        if not branch:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rama requerida")
+
+        remote, _ = _ota_remote_branch()
+        config = load_config_yaml()
+        ota_section = config.setdefault("ota", {}) if isinstance(config, dict) else {}
+        ota_section["branch"] = branch
+        ota_section["remote"] = remote
+        config["ota"] = ota_section
+        save_config_yaml(config)
+        return {"remote": remote, "branch": branch}
+
+    def _apply_reset(target: str, remote: str, branch: str) -> Dict[str, Any]:
+        append_ota_log(f"Reset a {target}")
+        run_repo_git(["fetch", "--all", "--prune"])
+        run_repo_git(["reset", "--hard", target])
+        note = _restart_service("bascula-app")
+        return {"ok": True, "to": target, "branch": branch, "note": note}
+
+    def _confirm(payload: Dict[str, Any]) -> None:
+        confirm = payload.get("confirm")
+        if confirm != "QUIERO CONTINUAR":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Confirmación requerida")
+
+    @ota_router.post("/update")
+    async def ota_update(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        remote, branch = _ota_remote_branch()
+        _ensure_clean_worktree(force=payload.get("force") is True)
+        target = f"{remote}/{branch}"
+        response = _apply_reset(target, remote, branch)
+        response["note"] = response.get("note", "") + " (la app puede reiniciarse)"
+        return response
+
+    @ota_router.post("/update-to")
+    async def ota_update_to(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        ref = str(payload.get("ref", "")).strip()
+        if not ref:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Referencia requerida")
+        remote, branch = _ota_remote_branch()
+        _ensure_clean_worktree(force=payload.get("force") is True)
+        response = _apply_reset(ref, remote, branch)
+        return response
+
+    @ota_router.post("/rollback")
+    async def ota_rollback(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        remote, branch = _ota_remote_branch()
+        _ensure_clean_worktree(force=payload.get("force") is True)
+        response = _apply_reset(DEFAULT_ROLLBACK_COMMIT, remote, branch)
+        return response
+
+    app.include_router(ota_router)
+
+    # ------------------------------------------------------------------
+    # Recovery helpers
+    # ------------------------------------------------------------------
+
+    def _restart_payload(service: str) -> Dict[str, Any]:
+        note = _restart_service(service)
+        return {"ok": note == "ok", "note": note}
+
+    @recovery_router.post("/rollback")
+    async def recovery_rollback(payload: Dict[str, Any]) -> Dict[str, Any]:
+        return await ota_rollback(payload)
+
+    @recovery_router.post("/restart")
+    async def recovery_restart(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        return _restart_payload("bascula-app")
+
+    @recovery_router.post("/restart-miniweb")
+    async def recovery_restart_miniweb(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        return _restart_payload("bascula-miniweb")
+
+    @recovery_router.post("/reset-wifi")
+    async def recovery_reset_wifi(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        try:
+            run_command(["nmcli", "device", "disconnect", "wlan0"])
+            run_command(["nmcli", "connection", "delete", "wlan0"], check=False)
+            return {"ok": True, "note": "Wi-Fi reiniciado"}
+        except CommandError as exc:
+            return {"ok": False, "note": str(exc)}
+
+    @recovery_router.post("/factory")
+    async def recovery_factory(payload: Dict[str, Any]) -> Dict[str, Any]:
+        _confirm(payload)
+        if SECRETS_ENV_PATH.exists():
+            try:
+                SECRETS_ENV_PATH.unlink()
+            except Exception as exc:  # pragma: no cover - best effort
+                return {"ok": False, "note": f"No se pudo borrar secrets: {exc}"}
+        note = _restart_service("bascula-miniweb")
+        return {"ok": True, "note": note}
+
+    @recovery_router.get("/logs")
+    async def recovery_logs() -> Dict[str, Any]:
+        logs_payload: Dict[str, str] = {}
+        for service in ("bascula-app", "bascula-miniweb"):
+            try:
+                result = run_command(["journalctl", "-u", service, "-n", "200", "--no-pager"], check=True)
+                logs_payload[service] = result.stdout
+            except CommandError as exc:
+                logs_payload[service] = f"No disponible: {exc}"
+        return logs_payload
+
+    @recovery_router.get("/diagnostics")
+    async def recovery_diagnostics() -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "time": _utcnow().isoformat(),
+        }
+        try:
+            payload["git_head"] = run_repo_git(["rev-parse", "--short", "HEAD"]).stdout.strip()
+        except CommandError as exc:
+            payload["git_head_error"] = str(exc)
+
+        try:
+            ss_result = run_command(["ss", "-lntp"])
+            payload["ports"] = ss_result.stdout
+        except CommandError as exc:
+            payload["ports_error"] = str(exc)
+
+        try:
+            ip_result = run_command(["hostname", "-I"])
+            payload["ips"] = ip_result.stdout.strip()
+        except CommandError as exc:
+            payload["ips_error"] = str(exc)
+
+        try:
+            uptime_result = run_command(["uptime", "-p"])
+            payload["uptime"] = uptime_result.stdout.strip()
+        except CommandError as exc:
+            payload["uptime_error"] = str(exc)
+
+        try:
+            df_result = run_command(["df", "-h", "/"])
+            payload["disk"] = df_result.stdout
+        except CommandError as exc:
+            payload["disk_error"] = str(exc)
+
+        return payload
+
+    app.include_router(recovery_router)
 
     return app
 
@@ -89,94 +902,61 @@ def create_app() -> FastAPI:
 app = create_app()
 
 
+# ---------------------------------------------------------------------------
+# Backwards compatible threaded server used by other parts of the project
+# ---------------------------------------------------------------------------
+
+
 class MiniwebServer:
     """Run the FastAPI mini web in a background uvicorn thread."""
 
-    def __init__(
-        self,
-        settings: Optional[Settings] = None,
-        app_path: str = "bascula.miniweb:app",
-    ) -> None:
-        self._settings = settings
+    def __init__(self, app_path: str = "bascula.miniweb:app") -> None:
         self._app_path = app_path
         self._lock = threading.Lock()
-
         self._thread: Optional[threading.Thread] = None
         self._server: Optional[uvicorn.Server] = None
         self._stopped_event: Optional[threading.Event] = None
-
         self._startup_error: Optional[BaseException] = None
-        self._started_logged = False
-
-        self._host = "0.0.0.0"
-        self._port = 8080
-        self._pin = ""
 
     # ------------------------------------------------------------------
     def start(self) -> bool:
-        """Start the mini-web server in a daemon thread."""
-
         with self._lock:
             if self._thread and self._thread.is_alive():
                 return True
 
-            settings = self._settings or Settings.load()
-            network = getattr(settings, "network", None)
-            enabled = True if network is None else bool(getattr(network, "miniweb_enabled", True))
-            if not enabled:
-                log.info("Miniweb disabled via configuration; not starting")
-                return False
-
-            host = "0.0.0.0"
-            port = self._coerce_port(getattr(network, "miniweb_port", 8080) if network else 8080)
-            pin = str(getattr(network, "miniweb_pin", "") if network else "").strip()
-
-            config = uvicorn.Config(
-                self._app_path,
-                host=host,
-                port=port,
-                log_level="info",
-                proxy_headers=True,
-                server_header=False,
-            )
+            host = os.environ.get("UVICORN_HOST", "0.0.0.0")
+            port = _coerce_port(os.environ.get("UVICORN_PORT"), 8080)
+            config = uvicorn.Config(self._app_path, host=host, port=port, log_level="info")
 
             server = uvicorn.Server(config)
             server.install_signal_handlers = False
 
             self._server = server
-            self._host = host
-            self._port = port
-            self._pin = pin
-            self._startup_error = None
-            self._started_logged = False
             self._stopped_event = threading.Event()
+            self._startup_error = None
 
             thread = threading.Thread(target=self._run, name="MiniwebServer", daemon=True)
             self._thread = thread
             thread.start()
 
         self._wait_for_start(timeout=5.0)
-        if self._startup_error is not None:
-            return False
-        return self.is_running
+        return self._startup_error is None
 
     # ------------------------------------------------------------------
     def stop(self, timeout: float = 5.0) -> None:
-        """Request shutdown and wait for the background thread."""
-
         with self._lock:
             server = self._server
             thread = self._thread
-            stopped = self._stopped_event
+            event = self._stopped_event
 
-        if not thread:
+        if thread is None:
             return
 
         if server is not None:
             server.should_exit = True
 
-        if stopped is not None:
-            stopped.wait(timeout=timeout)
+        if event is not None:
+            event.wait(timeout=timeout)
 
         thread.join(timeout=timeout)
 
@@ -185,12 +965,9 @@ class MiniwebServer:
             self._server = None
             self._stopped_event = None
             self._startup_error = None
-            self._started_logged = False
 
     # ------------------------------------------------------------------
-    def wait(self, timeout: float | None = None) -> bool:
-        """Wait until the server thread finishes (used by CLI entry points)."""
-
+    def wait(self, timeout: Optional[float] = None) -> bool:
         event = self._stopped_event
         if event is None:
             return True
@@ -211,10 +988,10 @@ class MiniwebServer:
             server.run()
         except OSError as exc:
             self._startup_error = exc
-            log.error("Miniweb failed to bind to %s:%d: %s", self._host, self._port, exc)
+            log.error("Miniweb failed to bind: %s", exc)
         except Exception as exc:  # pragma: no cover - defensive logging
             self._startup_error = exc
-            log.exception("Miniweb server crashed: %s", exc)
+            log.exception("Miniweb crashed: %s", exc)
         finally:
             event = self._stopped_event
             if event is not None:
@@ -228,46 +1005,17 @@ class MiniwebServer:
                 return
             server = self._server
             if server and server.started.is_set():
-                self._log_started_once()
                 return
             thread = self._thread
             if thread and not thread.is_alive():
                 return
             time.sleep(0.05)
 
-        server = self._server
-        if server and server.started.is_set():
-            self._log_started_once()
-
-    # ------------------------------------------------------------------
-    def _log_started_once(self) -> None:
-        with self._lock:
-            if self._started_logged:
-                return
-            self._started_logged = True
-
-        if self._pin:
-            log.info("Miniweb listening on %s:%d (PIN %s)", self._host, self._port, self._pin)
-        else:
-            log.info("Miniweb listening on %s:%d", self._host, self._port)
-
-    # ------------------------------------------------------------------
-    @staticmethod
-    def _coerce_port(value: object) -> int:
-        try:
-            port = int(value)
-        except (TypeError, ValueError):
-            port = 8080
-        return port if 0 < port < 65536 else 8080
-
 
 def main() -> None:
-    """CLI entry point used by the systemd wrapper."""
-
     server = MiniwebServer()
     if not server.start():
         return
-
     try:
         server.wait()
     except KeyboardInterrupt:  # pragma: no cover - manual shutdown

--- a/bascula/miniweb_templates/config.html
+++ b/bascula/miniweb_templates/config.html
@@ -1,0 +1,668 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Báscula Miniweb</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #121212;
+        --panel: #1f1f1f;
+        --border: #2c2c2c;
+        --accent: #00bcd4;
+        --text: #f5f5f5;
+        --muted: #9e9e9e;
+        font-family: "Inter", "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+      }
+      header {
+        padding: 1.5rem 1rem 0.5rem;
+        text-align: center;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.8rem;
+        font-weight: 600;
+      }
+      header p {
+        margin: 0.25rem 0 0;
+        color: var(--muted);
+      }
+      .container {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 1rem;
+      }
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+      }
+      label {
+        display: block;
+        margin-bottom: 0.35rem;
+        font-weight: 600;
+      }
+      input, textarea, select {
+        width: 100%;
+        padding: 0.65rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text);
+        font-size: 1rem;
+      }
+      button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.65rem 1.2rem;
+        border-radius: 999px;
+        border: 1px solid transparent;
+        font-weight: 600;
+        cursor: pointer;
+        background: var(--accent);
+        color: #041014;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+      button.secondary {
+        background: transparent;
+        border-color: var(--border);
+        color: var(--text);
+      }
+      button:hover {
+        transform: translateY(-1px);
+      }
+      .grid {
+        display: grid;
+        gap: 1rem;
+      }
+      .tabs {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+        gap: 0.5rem;
+      }
+      .tab-btn {
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--text);
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+      .tab-btn.active {
+        background: var(--accent);
+        color: #041014;
+      }
+      .tab {
+        display: none;
+      }
+      .tab.active {
+        display: block;
+      }
+      .status {
+        margin-top: 0.75rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 0.5rem;
+      }
+      th, td {
+        padding: 0.55rem;
+        border-bottom: 1px solid var(--border);
+        text-align: left;
+      }
+      pre {
+        background: rgba(255, 255, 255, 0.05);
+        border-radius: 8px;
+        padding: 0.75rem;
+        overflow-x: auto;
+        font-size: 0.9rem;
+      }
+      .two-col {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1rem;
+      }
+      .danger {
+        background: #ff5252;
+        color: #1a0505;
+      }
+      .notice {
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        background: rgba(0, 188, 212, 0.12);
+        border: 1px solid rgba(0, 188, 212, 0.2);
+        margin-bottom: 1rem;
+      }
+      .hidden {
+        display: none !important;
+      }
+      @media (max-width: 640px) {
+        header h1 {
+          font-size: 1.5rem;
+        }
+        button {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Báscula Miniweb</h1>
+      <p>Config · Recovery · OTA</p>
+    </header>
+    <main class="container">
+      <section id="login-panel" class="card hidden">
+        <h2>Acceso</h2>
+        <p class="status" id="login-status">Introduce el PIN de la báscula.</p>
+        <form id="login-form" class="grid" autocomplete="off">
+          <div>
+            <label for="pin">PIN</label>
+            <input id="pin" name="pin" type="password" minlength="4" maxlength="12" required />
+          </div>
+          <div class="two-col">
+            <div>
+              <label for="token">Token (opcional)</label>
+              <input id="token" name="token" type="text" placeholder="X-API-Token" />
+            </div>
+            <div>
+              <label>&nbsp;</label>
+              <button type="submit">Entrar</button>
+            </div>
+          </div>
+        </form>
+      </section>
+
+      <section id="app-panel" class="card hidden">
+        <div class="notice" id="auth-info"></div>
+        <div class="tabs">
+          <button class="tab-btn" data-tab="wifi">Wi-Fi</button>
+          <button class="tab-btn" data-tab="openai">OpenAI</button>
+          <button class="tab-btn" data-tab="nightscout">Nightscout</button>
+          <button class="tab-btn" data-tab="ota">OTA</button>
+          <button class="tab-btn" data-tab="recovery">Recovery</button>
+        </div>
+
+        <div id="tab-wifi" class="tab">
+          <h2>Wi-Fi</h2>
+          <button id="wifi-refresh" class="secondary">Actualizar estado</button>
+          <div class="status" id="wifi-status"></div>
+          <h3>Redes cercanas</h3>
+          <button id="wifi-scan" class="secondary">Escanear</button>
+          <table id="wifi-table">
+            <thead>
+              <tr><th>SSID</th><th>Señal</th></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <h3>Conectar</h3>
+          <form id="wifi-connect" class="grid">
+            <div>
+              <label for="ssid">SSID</label>
+              <input id="ssid" name="ssid" required />
+            </div>
+            <div>
+              <label for="psk">Contraseña</label>
+              <input id="psk" name="psk" type="password" />
+            </div>
+            <button type="submit">Conectar</button>
+          </form>
+          <div class="status" id="wifi-connect-status"></div>
+        </div>
+
+        <div id="tab-openai" class="tab">
+          <h2>OpenAI</h2>
+          <form id="openai-form" class="grid">
+            <div>
+              <label for="openai-key">API Key</label>
+              <input id="openai-key" name="api_key" placeholder="sk-..." />
+            </div>
+            <div class="two-col">
+              <button type="submit">Guardar</button>
+              <button type="button" class="secondary" id="openai-test">Probar</button>
+            </div>
+          </form>
+          <div class="status" id="openai-status"></div>
+        </div>
+
+        <div id="tab-nightscout" class="tab">
+          <h2>Nightscout</h2>
+          <form id="nightscout-form" class="grid">
+            <div>
+              <label for="nightscout-url">URL</label>
+              <input id="nightscout-url" name="url" placeholder="https://mi-nightscout" />
+            </div>
+            <div>
+              <label for="nightscout-token">Token</label>
+              <input id="nightscout-token" name="token" />
+            </div>
+            <div class="two-col">
+              <button type="submit">Guardar</button>
+              <button type="button" class="secondary" id="nightscout-test">Probar</button>
+            </div>
+          </form>
+          <div class="status" id="nightscout-status"></div>
+        </div>
+
+        <div id="tab-ota" class="tab">
+          <h2>Actualizaciones OTA</h2>
+          <div class="two-col">
+            <button id="ota-status" class="secondary">Estado</button>
+            <button id="ota-check" class="secondary">Comprobar</button>
+          </div>
+          <div class="status" id="ota-status-info"></div>
+          <h3>Cambiar canal</h3>
+          <form id="ota-channel" class="grid">
+            <div>
+              <label for="ota-branch">Rama remota</label>
+              <input id="ota-branch" name="branch" placeholder="main" />
+            </div>
+            <button type="submit">Guardar canal</button>
+          </form>
+          <h3>Actualizar</h3>
+          <div class="grid">
+            <button id="ota-update">Actualizar a HEAD</button>
+            <form id="ota-update-to" class="grid">
+              <div>
+                <label for="ota-ref">Commit/Tag</label>
+                <input id="ota-ref" name="ref" placeholder="abcd123" />
+              </div>
+              <button type="submit">Actualizar a ref</button>
+            </form>
+            <button id="ota-rollback" class="danger">Rollback estable</button>
+          </div>
+          <div class="status" id="ota-action-status"></div>
+          <h3>Commits pendientes</h3>
+          <pre id="ota-pending"></pre>
+        </div>
+
+        <div id="tab-recovery" class="tab">
+          <h2>Recovery</h2>
+          <div class="grid">
+            <button id="recovery-restart">Reiniciar aplicación</button>
+            <button id="recovery-miniweb">Reiniciar miniweb</button>
+            <button id="recovery-reset-wifi">Reset Wi-Fi</button>
+            <button id="recovery-factory" class="danger">Factory (solo secretos)</button>
+            <button id="recovery-rollback" class="danger">Rollback estable</button>
+          </div>
+          <div class="status" id="recovery-status"></div>
+          <h3>Logs</h3>
+          <pre id="recovery-logs"></pre>
+          <h3>Diagnóstico</h3>
+          <pre id="recovery-diagnostics"></pre>
+        </div>
+      </section>
+    </main>
+
+    <script>
+      const state = {
+        token: localStorage.getItem('miniweb_token') || '',
+        pending: []
+      };
+
+      function setStatus(element, message, isError = false) {
+        const el = document.getElementById(element);
+        if (!el) return;
+        if (!message) {
+          el.textContent = '';
+          return;
+        }
+        el.textContent = message;
+        el.style.color = isError ? '#ff8a80' : 'var(--muted)';
+      }
+
+      function togglePanels(authenticated, via, expires) {
+        const loginPanel = document.getElementById('login-panel');
+        const appPanel = document.getElementById('app-panel');
+        const info = document.getElementById('auth-info');
+        if (authenticated) {
+          loginPanel.classList.add('hidden');
+          appPanel.classList.remove('hidden');
+          const exp = expires ? new Date(expires).toLocaleTimeString() : 'desconocido';
+          info.textContent = `Autenticado via ${via}. Sesión expira a las ${exp}.`;
+        } else {
+          appPanel.classList.add('hidden');
+          loginPanel.classList.remove('hidden');
+          info.textContent = '';
+        }
+      }
+
+      function withAuthHeaders(opts = {}) {
+        const headers = new Headers(opts.headers || {});
+        if (state.token) {
+          headers.set('X-API-Token', state.token);
+        }
+        return { ...opts, headers };
+      }
+
+      async function api(path, opts = {}) {
+        const options = withAuthHeaders(opts);
+        if (options.body && !options.headers.has('Content-Type')) {
+          options.headers.set('Content-Type', 'application/json');
+        }
+        const response = await fetch(path, options);
+        if (!response.ok) {
+          let detail = `${response.status} ${response.statusText}`;
+          try {
+            const payload = await response.json();
+            detail = payload.detail || JSON.stringify(payload);
+          } catch (err) {
+            // ignore
+          }
+          throw new Error(detail);
+        }
+        const text = await response.text();
+        try {
+          return JSON.parse(text);
+        } catch (err) {
+          return text;
+        }
+      }
+
+      async function refreshAuth() {
+        try {
+          const status = await api('/auth/status');
+          togglePanels(status.authenticated, status.via, status.expires_at);
+          if (!status.authenticated) {
+            setStatus('login-status', 'Introduce el PIN de la báscula.');
+          }
+        } catch (err) {
+          togglePanels(false);
+        }
+      }
+
+      function bindTabs() {
+        const buttons = document.querySelectorAll('.tab-btn');
+        buttons.forEach(btn => {
+          btn.addEventListener('click', () => {
+            buttons.forEach(b => b.classList.remove('active'));
+            document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
+            btn.classList.add('active');
+            const tab = document.getElementById(`tab-${btn.dataset.tab}`);
+            if (tab) tab.classList.add('active');
+          });
+        });
+        if (buttons.length) {
+          buttons[0].click();
+        }
+      }
+
+      async function handleLogin(event) {
+        event.preventDefault();
+        const form = event.target;
+        const pin = form.pin.value.trim();
+        const token = form.token.value.trim();
+        if (token) {
+          state.token = token;
+          localStorage.setItem('miniweb_token', token);
+        }
+        try {
+          await api('/auth/login', { method: 'POST', body: JSON.stringify({ pin }) });
+          form.reset();
+          setStatus('login-status', 'PIN correcto.');
+          await refreshAuth();
+          await loadAll();
+        } catch (err) {
+          setStatus('login-status', err.message, true);
+        }
+      }
+
+      async function loadWifiStatus() {
+        try {
+          const status = await api('/config/wifi/status');
+          const parts = [];
+          if (status.ssid) parts.push(`SSID: ${status.ssid}`);
+          if (status.ip) parts.push(`IP: ${status.ip}`);
+          if (status.signal) parts.push(`Señal: ${status.signal}%`);
+          setStatus('wifi-status', parts.join(' · '));
+        } catch (err) {
+          setStatus('wifi-status', err.message, true);
+        }
+      }
+
+      async function loadWifiScan() {
+        try {
+          const result = await api('/config/wifi/scan');
+          const tbody = document.querySelector('#wifi-table tbody');
+          tbody.innerHTML = '';
+          result.networks.forEach(net => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td>${net.ssid || '(oculta)'}</td><td>${net.signal ?? ''}</td>`;
+            tr.addEventListener('click', () => {
+              document.getElementById('ssid').value = net.ssid;
+            });
+            tbody.appendChild(tr);
+          });
+          if (result.error) {
+            setStatus('wifi-status', result.error, true);
+          }
+        } catch (err) {
+          setStatus('wifi-status', err.message, true);
+        }
+      }
+
+      async function submitWifiConnect(event) {
+        event.preventDefault();
+        const form = event.target;
+        const payload = {
+          ssid: form.ssid.value.trim(),
+          psk: form.psk.value
+        };
+        try {
+          const res = await api('/config/wifi/connect', { method: 'POST', body: JSON.stringify(payload) });
+          setStatus('wifi-connect-status', res.note || 'Comando enviado.');
+        } catch (err) {
+          setStatus('wifi-connect-status', err.message, true);
+        }
+      }
+
+      async function loadOpenAI() {
+        try {
+          const res = await api('/config/openai');
+          document.getElementById('openai-key').placeholder = res.api_key || '(sin configurar)';
+        } catch (err) {
+          setStatus('openai-status', err.message, true);
+        }
+      }
+
+      async function submitOpenAI(event) {
+        event.preventDefault();
+        const key = event.target['api_key'].value.trim();
+        try {
+          await api('/config/openai', { method: 'POST', body: JSON.stringify({ api_key: key }) });
+          setStatus('openai-status', 'Guardado.');
+          event.target.reset();
+          await loadOpenAI();
+        } catch (err) {
+          setStatus('openai-status', err.message, true);
+        }
+      }
+
+      async function testOpenAI() {
+        try {
+          const res = await api('/config/openai/test', { method: 'POST' });
+          setStatus('openai-status', res.ok ? 'API accesible.' : `Error (${res.status})`, !res.ok);
+        } catch (err) {
+          setStatus('openai-status', err.message, true);
+        }
+      }
+
+      async function loadNightscout() {
+        try {
+          const res = await api('/config/nightscout');
+          if (res.url) document.getElementById('nightscout-url').value = res.url;
+          if (res.token) document.getElementById('nightscout-token').placeholder = res.token;
+        } catch (err) {
+          setStatus('nightscout-status', err.message, true);
+        }
+      }
+
+      async function submitNightscout(event) {
+        event.preventDefault();
+        const payload = {
+          url: event.target.url.value.trim(),
+          token: event.target.token.value.trim()
+        };
+        try {
+          await api('/config/nightscout', { method: 'POST', body: JSON.stringify(payload) });
+          setStatus('nightscout-status', 'Guardado.');
+        } catch (err) {
+          setStatus('nightscout-status', err.message, true);
+        }
+      }
+
+      async function testNightscout() {
+        const url = document.getElementById('nightscout-url').value.trim();
+        const token = document.getElementById('nightscout-token').value.trim();
+        if (!url) {
+          setStatus('nightscout-status', 'Introduce la URL primero.', true);
+          return;
+        }
+        try {
+          const res = await api('/config/nightscout/test', { method: 'POST', body: JSON.stringify({ url, token }) });
+          setStatus('nightscout-status', res.ok ? 'Nightscout responde.' : `Error (${res.status})`, !res.ok);
+        } catch (err) {
+          setStatus('nightscout-status', err.message, true);
+        }
+      }
+
+      async function otaStatus() {
+        try {
+          const res = await api('/ota/status');
+          setStatus('ota-status-info', `HEAD ${res.head} · ${res.remote}/${res.branch} · behind ${res.behind ?? '?'} · ahead ${res.ahead ?? '?'}`);
+        } catch (err) {
+          setStatus('ota-status-info', err.message, true);
+        }
+      }
+
+      async function otaCheck() {
+        try {
+          const res = await api('/ota/check', { method: 'POST' });
+          setStatus('ota-status-info', `behind ${res.behind}, ahead ${res.ahead}`);
+          document.getElementById('ota-pending').textContent = (res.pending || []).join('\n');
+        } catch (err) {
+          setStatus('ota-status-info', err.message, true);
+        }
+      }
+
+      async function otaSetChannel(event) {
+        event.preventDefault();
+        const branch = event.target.branch.value.trim();
+        if (!branch) {
+          setStatus('ota-action-status', 'Indica la rama.', true);
+          return;
+        }
+        try {
+          const res = await api('/ota/set-channel', { method: 'POST', body: JSON.stringify({ branch }) });
+          setStatus('ota-action-status', `Canal activo: ${res.remote}/${res.branch}`);
+        } catch (err) {
+          setStatus('ota-action-status', err.message, true);
+        }
+      }
+
+      async function otaSimple(endpoint, extra = {}) {
+        try {
+          const body = JSON.stringify({ confirm: 'QUIERO CONTINUAR', ...extra });
+          const res = await api(endpoint, { method: 'POST', body });
+          setStatus('ota-action-status', res.note || 'OK');
+        } catch (err) {
+          setStatus('ota-action-status', err.message, true);
+        }
+      }
+
+      async function otaUpdateTo(event) {
+        event.preventDefault();
+        const ref = event.target.ref.value.trim();
+        if (!ref) {
+          setStatus('ota-action-status', 'Indica commit/tag.', true);
+          return;
+        }
+        await otaSimple('/ota/update-to', { ref });
+      }
+
+      async function loadRecovery() {
+        try {
+          const logs = await api('/recovery/logs');
+          document.getElementById('recovery-logs').textContent = Object.entries(logs).map(([svc, text]) => `== ${svc} ==\n${text}`).join('\n\n');
+        } catch (err) {
+          setStatus('recovery-status', err.message, true);
+        }
+        try {
+          const diag = await api('/recovery/diagnostics');
+          document.getElementById('recovery-diagnostics').textContent = JSON.stringify(diag, null, 2);
+        } catch (err) {
+          setStatus('recovery-status', err.message, true);
+        }
+      }
+
+      async function recoveryAction(endpoint) {
+        try {
+          const res = await api(endpoint, { method: 'POST', body: JSON.stringify({ confirm: 'QUIERO CONTINUAR' }) });
+          setStatus('recovery-status', res.note || JSON.stringify(res));
+        } catch (err) {
+          setStatus('recovery-status', err.message, true);
+        }
+      }
+
+      async function loadAll() {
+        await Promise.all([
+          loadWifiStatus(),
+          loadWifiScan(),
+          loadOpenAI(),
+          loadNightscout(),
+          otaStatus(),
+          loadRecovery()
+        ]);
+      }
+
+      document.addEventListener('DOMContentLoaded', async () => {
+        bindTabs();
+        document.getElementById('login-form').addEventListener('submit', handleLogin);
+        document.getElementById('token').value = state.token;
+        document.getElementById('wifi-refresh').addEventListener('click', loadWifiStatus);
+        document.getElementById('wifi-scan').addEventListener('click', loadWifiScan);
+        document.getElementById('wifi-connect').addEventListener('submit', submitWifiConnect);
+        document.getElementById('openai-form').addEventListener('submit', submitOpenAI);
+        document.getElementById('openai-test').addEventListener('click', testOpenAI);
+        document.getElementById('nightscout-form').addEventListener('submit', submitNightscout);
+        document.getElementById('nightscout-test').addEventListener('click', testNightscout);
+        document.getElementById('ota-status').addEventListener('click', otaStatus);
+        document.getElementById('ota-check').addEventListener('click', otaCheck);
+        document.getElementById('ota-channel').addEventListener('submit', otaSetChannel);
+        document.getElementById('ota-update').addEventListener('click', () => otaSimple('/ota/update'));
+        document.getElementById('ota-update-to').addEventListener('submit', otaUpdateTo);
+        document.getElementById('ota-rollback').addEventListener('click', () => otaSimple('/ota/rollback'));
+        document.getElementById('recovery-restart').addEventListener('click', () => recoveryAction('/recovery/restart'));
+        document.getElementById('recovery-miniweb').addEventListener('click', () => recoveryAction('/recovery/restart-miniweb'));
+        document.getElementById('recovery-reset-wifi').addEventListener('click', () => recoveryAction('/recovery/reset-wifi'));
+        document.getElementById('recovery-factory').addEventListener('click', () => recoveryAction('/recovery/factory'));
+        document.getElementById('recovery-rollback').addEventListener('click', () => recoveryAction('/recovery/rollback'));
+        await refreshAuth();
+        let status;
+        try {
+          status = await api('/auth/status');
+        } catch (err) {
+          status = { authenticated: false };
+        }
+        if (status && status.authenticated) {
+          await loadAll();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/scripts/setup-venv-miniweb.sh
+++ b/scripts/setup-venv-miniweb.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-VENV=/opt/bascula/current/.venv
+VENV="/opt/bascula/current/.venv"
 sudo apt-get update
 sudo apt-get install -y python3-venv python3-full
-if [ ! -d "$VENV" ]; then
-  sudo python3 -m venv "$VENV"
-  sudo chown -R pi:pi "$VENV"
-fi
+[ -d "$VENV" ] || { python3 -m venv "$VENV"; sudo chown -R pi:pi "$VENV"; }
 "$VENV/bin/pip" install --upgrade pip
-"$VENV/bin/pip" install "uvicorn>=0.29,<0.33" "fastapi>=0.114,<0.120"
+"$VENV/bin/pip" install "uvicorn>=0.29,<0.33" "fastapi>=0.114,<0.120" "python-dotenv>=1.0" "jinja2>=3.1" "itsdangerous>=2.1"
+echo "[ok] venv listo en $VENV"

--- a/scripts/test-miniweb-config.sh
+++ b/scripts/test-miniweb-config.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+H="${1:-127.0.0.1}"
+P="${2:-8080}"
+T="${3:-}"
+HDR=()
+if [[ -n "$T" ]]; then
+  HDR=(-H "X-API-Token: $T")
+fi
+curl -sf "http://$H:$P/config" >/dev/null
+curl -sf "http://$H:$P/config/wifi/status" "${HDR[@]}" >/dev/null
+echo "[ok] config wifi/status"

--- a/scripts/test-miniweb-ota.sh
+++ b/scripts/test-miniweb-ota.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+H="${1:-127.0.0.1}"
+P="${2:-8080}"
+T="${3:-}"
+HDR=()
+if [[ -n "$T" ]]; then
+  HDR=(-H "X-API-Token: $T")
+fi
+curl -sf "http://$H:$P/ota/status" "${HDR[@]}" >/dev/null
+curl -sf -X POST "http://$H:$P/ota/check" "${HDR[@]}" >/dev/null
+echo "[ok] OTA status & check"

--- a/scripts/test-miniweb.sh
+++ b/scripts/test-miniweb.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+H="${1:-127.0.0.1}"
+P="${2:-8080}"
+curl -sf "http://$H:$P/health" >/dev/null
+curl -sf "http://$H:$P/info" >/dev/null
+echo "[ok] miniweb responde en http://$H:$P"

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Bascula Miniweb (FastAPI)
+Description=Bascula Miniweb (FastAPI via .venv)
 After=network-online.target
 Wants=network-online.target
 
@@ -10,8 +10,16 @@ WorkingDirectory=/opt/bascula/current
 Environment=PYTHONPATH=/opt/bascula/current
 Environment=UVICORN_HOST=0.0.0.0
 Environment=UVICORN_PORT=8080
+# Seguridad opcional:
+# Environment=MINIWEB_TOKEN=<token_largo>
+# Environment=MINIWEB_SECRET=<hex_64>
+# Environment=MINIWEB_HIDE_INFO=0
+# OTA opcional:
+# Environment=OTA_REMOTE=origin
+# Environment=OTA_BRANCH=main
 ExecStart=/opt/bascula/current/.venv/bin/uvicorn bascula.miniweb:app --host ${UVICORN_HOST} --port ${UVICORN_PORT} --log-level info
 Restart=on-failure
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- replace the FastAPI mini web with an authenticated console covering config, recovery, and OTA workflows
- add a dark-mode Jinja template with tabs and client-side helpers for Wi-Fi, OpenAI, Nightscout, OTA, and recovery actions
- document deployment & security, ship the systemd unit/venv scripts, and add smoke-test helpers for the new endpoints

## Testing
- python -m compileall bascula/miniweb.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b20ee80083269adce981d35ec7f9