### PR TITLE
Adopt holographic home view and tabbed settings screen

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -17,7 +17,8 @@ from ..system.audio_config import AudioCard, detect_primary_card, list_cards
 from ..services.nightscout import NightscoutService
 from ..services.nutrition import NutritionService
 from ..services.scale import BackendUnavailable, ScaleService
-from .screens import FoodsScreen, HomeScreen, RecipesScreen, SettingsScreen
+from .screens import FoodsScreen, HomeScreen, RecipesScreen
+from .screens_tabs_ext import TabbedSettingsMenuScreen
 from .theme_ctk import (
     COLORS as HOLO_COLORS,
     CTK_AVAILABLE,
@@ -440,7 +441,7 @@ class BasculaApp:
             "home": HomeScreen(self.container, self),
             "alimentos": FoodsScreen(self.container, self),
             "recetas": RecipesScreen(self.container, self),
-            "settings": SettingsScreen(self.container, self),
+            "settings": TabbedSettingsMenuScreen(self.container, self),
         }
         for screen in self.screens.values():
             screen.place(relx=0, rely=0, relwidth=1, relheight=1)
@@ -589,9 +590,10 @@ class BasculaApp:
         self.scale_service.zero()
         self.audio_service.beep_ok()
 
-    def handle_toggle_units(self) -> None:
+    def handle_toggle_units(self) -> str:
         mode = self.scale_service.toggle_units()
         messagebox.showinfo("Unidades", f"Modo {mode} activo")
+        return mode
 
     def handle_timer(self) -> None:
         TimerPopup(self.root, initial_seconds=self._timer_seconds, on_accept=self._start_timer)


### PR DESCRIPTION
## Summary
- replace the legacy home screen layout with the NeoGhost-based HomeView to restore ghost buttons, icons, and decimals control
- reconnect the holographic tabbed settings experience by wiring the app to TabbedSettingsMenuScreen
- update home weight handling to react to unit changes and no-signal states while returning the active unit from the toggle handler

## Testing
- pytest tests/test_ui_windowing.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b358f1188326818bdd2d32f0908c