### PR TITLE
Fix milliliter conversion in HomeScreen weight updates

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -118,7 +118,16 @@ class HomeScreen(BaseScreen):
 
     def update_weight(self, value: Optional[float], stable: bool, unit: str) -> None:
         self.view.set_units(unit)
-        self.view.update_weight(value, stable)
+        grams_value = value
+        if value is not None and unit.strip().lower() == "ml":
+            try:
+                factor = float(self.get_ml_factor())
+            except Exception:
+                factor = 1.0
+            if factor <= 0:
+                factor = 1.0
+            grams_value = value * factor
+        self.view.update_weight(grams_value, stable)
 
 
 class FoodsScreen(BaseScreen):


### PR DESCRIPTION
## Summary
- replace the legacy home screen layout with the NeoGhost-based HomeView to restore ghost buttons, icons, and decimals control
- reconnect the holographic tabbed settings experience by wiring the app to TabbedSettingsMenuScreen
- update home weight handling to react to unit changes and no-signal states while returning the active unit from the toggle handler
- fix milliliter readings being divided twice by converting them back to grams before updating the HomeView

## Testing
- pytest tests/test_ui_windowing.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b659711083269631db161b22625b