### PR TITLE
Fix miniweb venv creation and rate limiter state permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Proyecto para integrar una báscula basada en ESP32+HX711 con una Raspberry Pi 5
   sudo systemctl mask bascula-web.service
   ```
 
+  **Troubleshooting:** si `/var/lib/bascula/miniweb` no se crea automáticamente, ejecútalo manualmente:
+
+  ```bash
+  sudo install -d -o pi -g pi -m 0750 /var/lib/bascula/miniweb
+  ```
+
   La primera visita a `http://<IP_RPi>:8080/config` solicita el PIN configurado en Ajustes → Red (o la variable `MINIWEB_PIN`). También puedes definir un token largo en la unit:
 
   ```bash

--- a/scripts/setup-venv-miniweb.sh
+++ b/scripts/setup-venv-miniweb.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 VENV="/opt/bascula/current/.venv"
+
 sudo apt-get update
 sudo apt-get install -y python3-venv python3-full
-[ -d "$VENV" ] || { python3 -m venv "$VENV"; sudo chown -R pi:pi "$VENV"; }
-"$VENV/bin/pip" install --upgrade pip
-"$VENV/bin/pip" install "uvicorn>=0.29,<0.33" "fastapi>=0.114,<0.120" "python-dotenv>=1.0" "jinja2>=3.1" "itsdangerous>=2.1"
+
+sudo install -d -m 0755 -o pi -g pi "$VENV"
+sudo -u pi python3 -m venv "$VENV"
+
+sudo -u pi "$VENV/bin/pip" install --upgrade pip
+sudo -u pi "$VENV/bin/pip" install \
+    "uvicorn>=0.29,<0.33" \
+    "fastapi>=0.114,<0.120" \
+    "python-dotenv>=1.0" \
+    "jinja2>=3.1" \
+    "itsdangerous>=2.1"
 echo "[ok] venv listo en $VENV"

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -17,6 +17,7 @@ Environment=UVICORN_PORT=8080
 # OTA opcional:
 # Environment=OTA_REMOTE=origin
 # Environment=OTA_BRANCH=main
+ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0750 /var/lib/bascula/miniweb
 ExecStart=/opt/bascula/current/.venv/bin/uvicorn bascula.miniweb:app --host ${UVICORN_HOST} --port ${UVICORN_PORT} --log-level info
 Restart=on-failure
 RestartSec=2


### PR DESCRIPTION
## Summary
- ensure the miniweb virtualenv is created in /opt/bascula/current/.venv with pi ownership and install packages as the pi user
- create /var/lib/bascula/miniweb with proper ownership on service start and persist the rate limiter under that directory with a /tmp fallback
- document the manual directory creation step in the README troubleshooting section

## Testing
- pytest tests/test_miniweb.py


------
https://chatgpt.com/codex/tasks/task_e_68d8ba1021c883268ebe312b01513612