### PR TITLE
Fix miniweb startup and rounded button outline

### DIFF
--- a/bascula/miniweb.py
+++ b/bascula/miniweb.py
@@ -1060,8 +1060,16 @@ class MiniwebServer:
             if self._startup_error is not None:
                 return
             server = self._server
-            if server and server.started.is_set():
-                return
+            if server:
+                started = getattr(server, "started", None)
+                if started is None:
+                    return
+                is_set = getattr(started, "is_set", None)
+                if callable(is_set):
+                    if is_set():
+                        return
+                else:
+                    return
             thread = self._thread
             if thread and not thread.is_alive():
                 return

--- a/bascula/ui/widgets.py
+++ b/bascula/ui/widgets.py
@@ -308,6 +308,9 @@ class NeoGhostButton(tk.Canvas):
         self.create_arc(x0, y1 - 2 * radius, x0 + 2 * radius, y1, start=180, extent=90, tags=tags, **arc_opts)
         line_opts = common.copy()
         line_opts.pop("style", None)
+        outline_color = line_opts.pop("outline", None)
+        if outline_color is not None:
+            line_opts.setdefault("fill", outline_color)
         self.create_line(x0 + radius, y0, x1 - radius, y0, tags=tags, **line_opts)
         self.create_line(x1, y0 + radius, x1, y1 - radius, tags=tags, **line_opts)
         self.create_line(x0 + radius, y1, x1 - radius, y1, tags=tags, **line_opts)

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=pi
+PermissionsStartOnly=true
 WorkingDirectory=/opt/bascula/current
 Environment=PYTHONPATH=/opt/bascula/current
 Environment=UVICORN_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- avoid passing unsupported outline parameters to Tk canvas lines when drawing rounded buttons
- guard miniweb startup polling against non-Event flags and treat other types as started
- ensure bascula-miniweb systemd unit can create its state directory before dropping privileges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8bd9ffee48326b91513dac7dbadba