### PR TITLE
Fix miniweb app resolution and general tab colors

### DIFF
--- a/bascula/ui/settings_tabs/tabs_general.py
+++ b/bascula/ui/settings_tabs/tabs_general.py
@@ -6,7 +6,10 @@ import tkinter as tk
 from tkinter import ttk
 
 from bascula.ui.widgets import (
-    COL_CARD, COL_TEXT, COL_ACCENT,
+    COL_CARD,
+    COL_CARD_HOVER,
+    COL_TEXT,
+    COL_ACCENT,
 )
 from bascula.ui.input_helpers import bind_numeric_entry
 from bascula.ui.settings_tabs.utils import create_scrollable_tab


### PR DESCRIPTION
## Summary
- resolve the FastAPI target when MiniwebServer is constructed with Settings instances
- import the hover color used by the General settings tab to avoid runtime errors

## Testing
- python -m compileall bascula/miniweb.py bascula/ui/settings_tabs/tabs_general.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c1810c808326b5884209dd4daa9a