### PR TITLE
Decouple miniweb deployment into standalone service

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Proyecto para integrar una báscula basada en ESP32+HX711 con una Raspberry Pi 5
   sudo systemctl enable --now bascula-miniweb
   ```
 
+  El instalador integral (`scripts/install-all.sh`) despliega y habilita automáticamente `bascula-miniweb.service`. Una vez
+  finalizado podrás acceder a la consola desde `http://<ip_raspberry>:8080/` incluso si la UI principal no está disponible.
+
   Comprueba que ningún servicio heredado está ocupando el puerto:
 
   ```bash

--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -10,7 +10,6 @@ from tkinter import messagebox
 from typing import Any, Callable, Dict, Optional
 
 from ..config.settings import ScaleSettings, Settings
-from ..miniweb import MiniwebServer
 from ..runtime import HeartbeatWriter
 from ..services.audio import AudioService
 from ..system.audio_config import AudioCard, detect_primary_card, list_cards
@@ -164,14 +163,6 @@ class BasculaApp:
 
         self.settings = Settings.load()
         self._cfg: Dict[str, Any] = self._load_legacy_cfg()
-        self.miniweb_server = MiniwebServer(self.settings)
-        try:
-            started = self.miniweb_server.start()
-        except Exception:  # pragma: no cover - defensive
-            started = False
-            log.exception("Miniweb launch raised an unexpected error")
-        if not started and self.settings.network.miniweb_enabled:
-            log.error("Miniweb failed to start; check previous log messages")
         self._audio_cards: list[AudioCard] = []
         self._audio_device_map: dict[str, str] = {}
         self._audio_device_labels: list[str] = []
@@ -743,11 +734,6 @@ class BasculaApp:
             self._persist_settings()
         self.scale_service.stop()
         self.nightscout_service.stop()
-        if hasattr(self, "miniweb_server") and self.miniweb_server is not None:
-            try:
-                self.miniweb_server.stop()
-            except Exception:
-                log.debug("Error deteniendo miniweb", exc_info=True)
         if hasattr(self, "heartbeat"):
             try:
                 self.heartbeat.stop()

--- a/systemd/bascula-miniweb.service
+++ b/systemd/bascula-miniweb.service
@@ -1,28 +1,25 @@
 [Unit]
-Description=Bascula Miniweb (FastAPI via .venv)
+Description=Bascula Mini-Web (FastAPI)
 After=network-online.target
-Wants=network-online.target
+Requires=network-online.target
 
 [Service]
 Type=simple
 User=pi
-# Ensure directory creation runs with elevated permissions before dropping to User=pi
+Group=pi
 PermissionsStartOnly=true
 WorkingDirectory=/opt/bascula/current
 Environment=PYTHONPATH=/opt/bascula/current
-Environment=UVICORN_HOST=0.0.0.0
-Environment=UVICORN_PORT=8080
-# Seguridad opcional:
-# Environment=MINIWEB_TOKEN=<token_largo>
-# Environment=MINIWEB_SECRET=<hex_64>
-# Environment=MINIWEB_HIDE_INFO=0
-# OTA opcional:
-# Environment=OTA_REMOTE=origin
-# Environment=OTA_BRANCH=main
-ExecStartPre=/usr/bin/install -d -o pi -g pi -m 0750 /var/lib/bascula/miniweb
-ExecStart=/opt/bascula/current/.venv/bin/uvicorn bascula.miniweb:app --host ${UVICORN_HOST} --port ${UVICORN_PORT} --log-level info
-Restart=on-failure
+Environment=BASCULA_ENV=prod
+Environment=BASCULA_MINIWEB_PORT=8080
+Environment=BASCULA_MINIWEB_STATE=/var/lib/bascula/miniweb
+ExecStartPre=/usr/bin/install -d -m 0750 -o pi -g pi /var/lib/bascula/miniweb
+ExecStartPre=/usr/bin/install -D -m 0644 -o pi -g pi /dev/null /var/log/bascula/miniweb.log
+ExecStart=/opt/bascula/current/.venv/bin/uvicorn bascula.miniweb:app --host 0.0.0.0 --port 8080 --proxy-headers --no-access-log --log-level info
+Restart=always
 RestartSec=2
+StandardOutput=append:/var/log/bascula/miniweb.log
+StandardError=inherit
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- configure `bascula-miniweb.service` to run the FastAPI app via the project virtualenv with proper permissions, logging, and restart policy
- update `scripts/install-all.sh` to provision the miniweb virtualenv dependencies, install/enable the new service, perform health checks, and disable the legacy unit
- stop launching miniweb from the Tk UI and document access to the standalone service in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c7d4e3f08326918077d7ff55cff4