### PR TITLE
UI: fix home icons loading + dynamic weight font size + neon separator alignment

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -172,11 +172,7 @@ class AppShell:
     def _build_status_icons(self, container: tk.Misc) -> None:
         for name, asset_name, fallback_text, tooltip in ICON_CONFIG:
             asset_filename = asset_name if asset_name.lower().endswith(".png") else f"{asset_name}.png"
-            icon = None
-            try:
-                icon = load_icon(asset_filename, 48 if CTK_AVAILABLE else 32)
-            except FileNotFoundError:
-                log.debug("Icono no encontrado para %s", asset_filename)
+            icon = load_icon(asset_filename, 48 if CTK_AVAILABLE else 32)
             if CTK_AVAILABLE:
                 width = 78
                 height = 64
@@ -278,11 +274,7 @@ class AppShell:
 
             button = buttons[idx]
             asset_filename = asset_name if asset_name.lower().endswith(".png") else f"{asset_name}.png"
-            icon = None
-            try:
-                icon = load_icon(asset_filename, 24)
-            except FileNotFoundError:
-                log.debug("Icono no encontrado para %s", asset_filename)
+            icon = load_icon(asset_filename, 24)
             if icon is not None:
                 self.icon_images[name] = icon
                 button.configure(image=icon, compound="left")

--- a/ci/tests/test_icon_loader.py
+++ b/ci/tests/test_icon_loader.py
@@ -9,15 +9,31 @@ import pytest
 from bascula.ui.icon_loader import load_icon
 
 
-def test_load_icon_round_trip() -> None:
+@pytest.fixture(scope="module")
+def tk_root() -> tk.Tk:
     try:
         root = tk.Tk()
     except tk.TclError as exc:  # pragma: no cover - headless CI guard
         pytest.skip(f"Tk no disponible: {exc}")
     root.withdraw()
-    try:
-        icon = load_icon("tare.png", 96)
-        assert icon.width() == 96
-        assert icon.height() == 96
-    finally:
-        root.destroy()
+    yield root
+    root.destroy()
+
+
+def test_load_icon_round_trip(tk_root: tk.Tk) -> None:
+    icon = load_icon("tare.png", 72)
+    assert icon.width() == 72
+    assert icon.height() == 72
+    assert load_icon("tare.png", 72) is icon
+
+
+def test_load_icon_missing_returns_placeholder(tk_root: tk.Tk) -> None:
+    placeholder = load_icon("__missing__.png", 64)
+    assert placeholder.width() == 64
+    assert placeholder.height() == 64
+
+
+def test_load_icon_case_insensitive(tk_root: tk.Tk) -> None:
+    icon = load_icon("TaRe", 48)
+    assert icon.width() == 48
+    assert icon.height() == 48


### PR DESCRIPTION
## Summary
- enhance icon_loader to normalize names, cache by size, and provide a neon placeholder when assets are missing
- refresh the holographic home view with centralized icon mapping, oversized weight typography, and responsive neon separator rendering
- update theme utilities and icon loader tests to cover the new drawing helper and fallback behaviour

## Testing
- PYTHONPATH=. pytest ci/tests/test_icon_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d8cd691c4483268cbddc6f19abb45a