### PR TITLE
fix(ui): stabilize neon separator, resize home buttons and repair timer dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Proyecto para integrar una báscula basada en ESP32+HX711 con una Raspberry Pi 5
 ## Tema holográfico, TimerPopup y miniweb LAN
 
 - **Tema holográfico**: el módulo `bascula/ui/theme_holo.py` define la nueva paleta (fondo oscuro con acentos cian/magenta) y estilos ttk compatibles con teclados y tablas existentes. Las pantallas principales todavía no lo usan; primero se introduce el tema como dependencia opcional para pruebas rápidas.
-- **TimerPopup independiente**: se puede lanzar el temporizador con teclado numérico sin tocar las pantallas actuales. Ejecuta el siguiente _smoke test_ desde un terminal con entorno gráfico:
+- **TimerPopup integrado**: permite iniciar/detener el temporizador desde una ventana modal coherente con el tema holográfico. Ejecuta el siguiente _smoke test_ desde un terminal con entorno gráfico:
 
   ```bash
   python3 - <<'PY'
@@ -31,12 +31,12 @@ Proyecto para integrar una báscula basada en ESP32+HX711 con una Raspberry Pi 5
   from bascula.ui.widgets import TimerPopup
   r = Tk(); apply_holo_theme(r)
   def ok(s): print("OK seconds:", s)
-  TimerPopup(r, initial_seconds=90, on_accept=ok)
+  TimerPopup(r, initial_seconds=90, on_start=ok)
   r.mainloop()
   PY
   ```
 
-  Usa `Enter` para aceptar, `Esc` para cancelar y `Backspace` (o el botón **Borrar**) para retroceder dígitos. El botón `:` conmuta la edición hacia los segundos. El teclado completo permite marcar minutos/segundos sin desplegar pantallas nuevas.
+  Usa `Enter` para iniciar o detener, y `Esc` para cerrar la ventana. Los campos de minutos y segundos aceptan valores numéricos directos desde teclado sin bloquear la UI principal.
 
 - **Mini web completa (LAN)**: `bascula.miniweb` es la consola FastAPI de administración expuesta en `0.0.0.0:8080` dentro del entorno virtual oficial (`/opt/bascula/current/.venv`). Incluye pestañas Wi-Fi, OpenAI, Nightscout, OTA y Recovery, junto al login por PIN/token. Para desplegarla desde una imagen limpia:
 

--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -701,7 +701,13 @@ class BasculaApp:
         return mode
 
     def handle_timer(self) -> None:
-        TimerPopup(self.root, initial_seconds=self._timer_seconds, on_accept=self._start_timer)
+        TimerPopup(
+            self.root,
+            initial_seconds=self._timer_seconds,
+            on_start=self._start_timer,
+            on_stop=self._stop_timer,
+            running=bool(self._timer_job),
+        )
 
     def _start_timer(self, seconds: int) -> None:
         self._timer_seconds = max(0, int(seconds))
@@ -711,6 +717,16 @@ class BasculaApp:
             self.timer_var.set("")
             return
         self._tick_timer()
+
+    def _stop_timer(self) -> None:
+        if self._timer_job:
+            try:
+                self.root.after_cancel(self._timer_job)
+            except Exception:
+                pass
+            self._timer_job = None
+        self._timer_seconds = 0
+        self.timer_var.set("")
 
     def _tick_timer(self) -> None:
         mins, secs = divmod(self._timer_seconds, 60)

--- a/bascula/ui/views/home.py
+++ b/bascula/ui/views/home.py
@@ -156,8 +156,8 @@ class HomeView(ttk.Frame):
         self._separator_canvas = separator_canvas
 
         buttons_frame = ttk.Frame(self, style="Home.Buttons.TFrame")
-        buttons_frame.pack(fill="both", expand=True)
-        self._buttons_border = neon_border(buttons_frame, padding=8, radius=24)
+        buttons_frame.pack(fill="both", expand=True, padx=SPACING["sm"], pady=(0, SPACING["sm"]))
+        self._buttons_border = neon_border(buttons_frame, padding=6, radius=20)
 
         self.buttons: Dict[str, tk.Misc] = {}
         self._tara_long_press_job: str | None = None
@@ -212,9 +212,9 @@ class HomeView(ttk.Frame):
             show_text = spec.get("icon") is None or icon_image is None
             button = NeoGhostButton(
                 buttons_frame,
-                width=208,
-                height=156,
-                radius=22,
+                width=188,
+                height=140,
+                radius=20,
                 outline_color=PALETTE["neon_fuchsia"],
                 outline_width=2,
                 text=spec["text"],
@@ -227,8 +227,8 @@ class HomeView(ttk.Frame):
             button.grid(
                 row=index // 3,
                 column=index % 3,
-                padx=SPACING["sm"],
-                pady=SPACING["sm"],
+                padx=SPACING["xs"],
+                pady=SPACING["xs"],
                 sticky="nsew",
             )
             button.name = spec["name"]  # type: ignore[attr-defined]
@@ -236,10 +236,10 @@ class HomeView(ttk.Frame):
                 self.controller.register_widget(spec["name"], button)
             self.buttons[spec["name"]] = button
             column = index % 3
-            buttons_frame.grid_columnconfigure(column, weight=1, minsize=120)
+            buttons_frame.grid_columnconfigure(column, weight=1, minsize=112)
 
         for row_index in range((len(button_specs) + 2) // 3):
-            buttons_frame.grid_rowconfigure(row_index, weight=1, minsize=120)
+            buttons_frame.grid_rowconfigure(row_index, weight=1, minsize=112)
 
         self._configure_tare_long_press()
         self.bind("<Configure>", self._on_configure, add=True)
@@ -384,11 +384,20 @@ class HomeView(ttk.Frame):
         if width <= 0:
             return
         height = max(10, int(self._separator_canvas.cget("height") or 12))
+        usable_width = max(12, width - 12)
+        x0 = max(0, (width - usable_width) // 2)
+        x1 = x0 + usable_width
+        centre_y = height // 2
+        if x1 <= x0:
+            return
         self._separator_canvas.configure(width=width, height=height)
         draw_neon_separator(
             self._separator_canvas,
+            x0,
+            centre_y,
+            x1,
+            centre_y,
             color="#00E5FF",
-            margin=16,
         )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ensure the holographic theme reuses a single ttk.Style and keep draw_neon_separator focused on rendering only
- tweak the home screen neon separator and button sizing to fit 800×480 displays without clipping
- rebuild the timer popup as a modal start/stop controller and wire the new flow into the app

## Testing
- python -m compileall bascula/ui

------
https://chatgpt.com/codex/tasks/task_e_68d8d24183f48326bb6eff523ba19f40