### PR TITLE
Synchronize mini-web PIN management

### DIFF
--- a/bascula/config/pin.py
+++ b/bascula/config/pin.py
@@ -1,0 +1,189 @@
+"""Helpers for managing the mini-web PIN stored in the YAML config."""
+from __future__ import annotations
+
+import logging
+import random
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import requests
+import yaml
+
+log = logging.getLogger(__name__)
+
+CONFIG_YAML_PATH = Path("/etc/bascula/config.yaml")
+DEFAULT_PIN_LENGTH = 6
+MIN_PIN_LENGTH = 4
+MAX_PIN_LENGTH = 6
+DEFAULT_FILE_MODE = 0o640
+DEFAULT_RELOAD_URL = "http://127.0.0.1:8080/config/reload"
+DEFAULT_RELOAD_TIMEOUT = 1.0
+
+
+class PinPersistenceError(RuntimeError):
+    """Raised when the PIN cannot be persisted to the YAML configuration."""
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        log.debug("No se pudo leer %s", path, exc_info=True)
+    return {}
+
+
+def _write_yaml(
+    path: Path,
+    payload: Dict[str, Any],
+    *,
+    file_mode: int = DEFAULT_FILE_MODE,
+    owner: Optional[str] = None,
+    group: Optional[str] = None,
+) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(".tmp")
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(payload, handle, sort_keys=False, allow_unicode=True)
+        tmp_path.replace(path)
+        try:
+            path.chmod(file_mode)
+        except PermissionError:
+            log.debug("Sin permisos para chmod %s", path)
+        if owner or group:
+            try:
+                shutil.chown(path, user=owner or None, group=group or None)
+            except (LookupError, PermissionError, OSError):
+                log.debug("Sin permisos para chown %s", path, exc_info=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise PinPersistenceError(f"No se pudo escribir {path}: {exc}") from exc
+
+
+def is_valid_pin(pin: str, *, min_length: int = MIN_PIN_LENGTH, max_length: int = MAX_PIN_LENGTH) -> bool:
+    pin = str(pin or "").strip()
+    return pin.isdigit() and min_length <= len(pin) <= max_length
+
+
+def generate_pin(length: int = DEFAULT_PIN_LENGTH) -> str:
+    rng = random.SystemRandom()
+    return "".join(rng.choice("0123456789") for _ in range(length))
+
+
+def ensure_miniweb_pin(
+    *,
+    config_path: Optional[Path] = None,
+    file_mode: int = DEFAULT_FILE_MODE,
+    owner: Optional[str] = None,
+    group: Optional[str] = None,
+    pin_factory: Optional[Callable[[int], str]] = None,
+    length: int = DEFAULT_PIN_LENGTH,
+    min_length: int = MIN_PIN_LENGTH,
+    max_length: int = MAX_PIN_LENGTH,
+) -> Tuple[str, bool]:
+    """Ensure a valid PIN is present in the YAML configuration.
+
+    Returns a tuple with the effective PIN and a flag indicating if it was freshly
+    generated and written to disk.
+    """
+
+    path = config_path or CONFIG_YAML_PATH
+    data = _load_yaml(path)
+    network = data.get("network") if isinstance(data, dict) else {}
+    if not isinstance(network, dict):
+        network = {}
+
+    raw_pin = str(network.get("miniweb_pin") or network.get("pin") or "").strip()
+    if is_valid_pin(raw_pin, min_length=min_length, max_length=max_length):
+        return raw_pin, False
+
+    factory = pin_factory or generate_pin
+    new_pin = factory(length)
+    network["miniweb_pin"] = new_pin
+    data = dict(data)
+    data["network"] = dict(network)
+    _write_yaml(path, data, file_mode=file_mode, owner=owner, group=group)
+    return new_pin, True
+
+
+def set_miniweb_pin(
+    new_pin: str,
+    *,
+    config_path: Optional[Path] = None,
+    file_mode: int = DEFAULT_FILE_MODE,
+    owner: Optional[str] = None,
+    group: Optional[str] = None,
+    min_length: int = MIN_PIN_LENGTH,
+    max_length: int = MAX_PIN_LENGTH,
+) -> None:
+    path = config_path or CONFIG_YAML_PATH
+    if not is_valid_pin(new_pin, min_length=min_length, max_length=max_length):
+        raise ValueError("El PIN debe contener solo dígitos y tener longitud válida")
+
+    data = _load_yaml(path)
+    if not isinstance(data, dict):
+        data = {}
+    network = data.get("network") if isinstance(data.get("network"), dict) else {}
+    updated = dict(data)
+    updated_network = dict(network)
+    updated_network["miniweb_pin"] = str(new_pin)
+    updated_network.pop("pin", None)
+    updated["network"] = updated_network
+    _write_yaml(path, updated, file_mode=file_mode, owner=owner, group=group)
+
+
+def regenerate_miniweb_pin(
+    *,
+    config_path: Optional[Path] = None,
+    file_mode: int = DEFAULT_FILE_MODE,
+    owner: Optional[str] = None,
+    group: Optional[str] = None,
+    pin_factory: Optional[Callable[[int], str]] = None,
+    length: int = DEFAULT_PIN_LENGTH,
+) -> str:
+    factory = pin_factory or generate_pin
+    new_pin = factory(length)
+    set_miniweb_pin(
+        new_pin,
+        config_path=config_path,
+        file_mode=file_mode,
+        owner=owner,
+        group=group,
+    )
+    return new_pin
+
+
+def reload_miniweb_config(
+    *,
+    url: str = DEFAULT_RELOAD_URL,
+    timeout: float = DEFAULT_RELOAD_TIMEOUT,
+) -> bool:
+    try:
+        response = requests.post(url, timeout=timeout)
+        return bool(response.ok)
+    except Exception:
+        log.debug("No se pudo recargar la mini-web en %s", url, exc_info=True)
+        return False
+
+
+__all__ = [
+    "CONFIG_YAML_PATH",
+    "DEFAULT_FILE_MODE",
+    "DEFAULT_PIN_LENGTH",
+    "DEFAULT_RELOAD_TIMEOUT",
+    "DEFAULT_RELOAD_URL",
+    "MAX_PIN_LENGTH",
+    "MIN_PIN_LENGTH",
+    "PinPersistenceError",
+    "ensure_miniweb_pin",
+    "generate_pin",
+    "is_valid_pin",
+    "regenerate_miniweb_pin",
+    "reload_miniweb_config",
+    "set_miniweb_pin",
+]

--- a/bascula/system/miniweb_pin.py
+++ b/bascula/system/miniweb_pin.py
@@ -1,79 +1,47 @@
-"""Helpers to keep the standalone miniweb PIN in sync."""
-
+"""Backward compatible helpers to manage the mini-web PIN."""
 from __future__ import annotations
 
-import json
 import logging
-import os
-import random
 import shutil
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional
 
+from bascula.config.pin import (
+    CONFIG_YAML_PATH,
+    DEFAULT_FILE_MODE,
+    PinPersistenceError,
+    ensure_miniweb_pin,
+    is_valid_pin,
+    set_miniweb_pin,
+)
 from bascula.config.settings import CONFIG_PATH, Settings
 
 log = logging.getLogger(__name__)
 
-
-DEFAULT_AUTH_PATH = Path("/var/lib/bascula/miniweb/auth.json")
 DEFAULT_DIR_MODE = 0o750
-DEFAULT_FILE_MODE = 0o640
 
 
-def _normalize_pin(value: Optional[str]) -> str:
-    if value is None:
-        return ""
-    pin = str(value).strip()
-    return pin
-
-
-def _load_auth_payload(path: Path) -> Dict[str, Any]:
-    if not path.exists():
-        return {}
+def _apply_dir_permissions(path: Path, *, mode: int, owner: Optional[str], group: Optional[str]) -> None:
     try:
-        with path.open("r", encoding="utf-8") as handle:
-            data = json.load(handle)
-        if isinstance(data, dict):
-            return data
+        path.mkdir(parents=True, exist_ok=True)
     except Exception:
-        log.debug("No se pudo leer %s", path, exc_info=True)
-    return {}
-
-
-def _write_auth_payload(path: Path, payload: Dict[str, Any], *, mode: int) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(path)
+        log.debug("No se pudo crear el directorio %s", path, exc_info=True)
+        return
     try:
         path.chmod(mode)
     except PermissionError:
         log.debug("Sin permisos para chmod %s", path)
-
-
-def _ensure_ownership(path: Path, *, owner: Optional[str], group: Optional[str]) -> None:
-    if owner is None and group is None:
-        return
-    try:
-        shutil.chown(path, user=owner or None, group=group or None)
-    except (LookupError, PermissionError, OSError):
-        log.debug("Sin permisos para chown %s", path, exc_info=True)
-
-
-def _generate_pin(min_digits: int = 4, max_digits: int = 6) -> str:
-    rng = random.SystemRandom()
-    length = rng.randint(min_digits, max_digits)
-    lower = 10 ** (length - 1)
-    upper = (10 ** length) - 1
-    return f"{rng.randint(lower, upper):0{length}d}"
+    if owner or group:
+        try:
+            shutil.chown(path, user=owner or None, group=group or None)
+        except (LookupError, PermissionError, OSError):
+            log.debug("Sin permisos para chown %s", path, exc_info=True)
 
 
 def sync_miniweb_pin(
     settings: Settings,
     *,
-    auth_path: Path | None = None,
-    config_path: Path | None = None,
+    config_path: Optional[Path] = None,
     owner: Optional[str] = None,
     group: Optional[str] = None,
     file_mode: int = DEFAULT_FILE_MODE,
@@ -81,63 +49,55 @@ def sync_miniweb_pin(
     save_settings: bool = True,
     prefer_config: bool = False,
 ) -> str:
-    """Ensure the config.json and auth.json pins stay in sync.
+    """Synchronise the Settings object with the YAML-stored PIN."""
 
-    Returns the effective PIN after synchronisation.
-    """
-
-    auth_file = auth_path or DEFAULT_AUTH_PATH
-    cfg_path = config_path or CONFIG_PATH
-
-    auth_file.parent.mkdir(parents=True, exist_ok=True)
-
-    auth_payload = _load_auth_payload(auth_file)
-    auth_pin = _normalize_pin(auth_payload.get("pin")) if isinstance(auth_payload, dict) else ""
-
-    config_pin = _normalize_pin(getattr(settings.network, "miniweb_pin", ""))
-
-    if prefer_config:
-        final_pin = config_pin or auth_pin or ""
-    else:
-        final_pin = auth_pin or config_pin or ""
-
-    if not final_pin:
-        final_pin = _generate_pin()
-
-    settings_changed = False
-    if final_pin != config_pin:
-        settings.network.miniweb_pin = final_pin
-        settings_changed = True
-
-    if not isinstance(auth_payload, dict):
-        auth_payload = {}
-
-    if auth_payload.get("pin") != final_pin or not auth_file.exists():
-        auth_payload = dict(auth_payload)
-        auth_payload["pin"] = final_pin
-        auth_payload["updated_at"] = datetime.now(tz=timezone.utc).isoformat()
-        _write_auth_payload(auth_file, auth_payload, mode=file_mode)
-    else:
-        try:
-            auth_file.chmod(file_mode)
-        except PermissionError:
-            log.debug("Sin permisos para chmod %s", auth_file)
+    yaml_path = config_path or CONFIG_YAML_PATH
+    desired_pin = str(getattr(settings.network, "miniweb_pin", "") or "").strip()
 
     try:
-        auth_file.parent.chmod(dir_mode)
-    except PermissionError:
-        log.debug("Sin permisos para chmod %s", auth_file.parent)
+        config_pin, _ = ensure_miniweb_pin(
+            config_path=yaml_path,
+            file_mode=file_mode,
+            owner=owner,
+            group=group,
+        )
+    except PinPersistenceError:
+        log.exception("No se pudo garantizar el PIN de la mini-web en %s", yaml_path)
+        config_pin = ""
 
-    _ensure_ownership(auth_file.parent, owner=owner, group=group)
-    _ensure_ownership(auth_file, owner=owner, group=group)
+    final_pin = config_pin
 
-    if settings_changed and save_settings:
+    if not prefer_config and is_valid_pin(desired_pin):
+        if desired_pin != config_pin:
+            try:
+                set_miniweb_pin(
+                    desired_pin,
+                    config_path=yaml_path,
+                    file_mode=file_mode,
+                    owner=owner,
+                    group=group,
+                )
+                final_pin = desired_pin
+            except (ValueError, PinPersistenceError):
+                log.exception("No se pudo actualizar el PIN de la mini-web en %s", yaml_path)
+        else:
+            final_pin = config_pin
+    else:
+        final_pin = config_pin if is_valid_pin(config_pin) else desired_pin
+
+    if not is_valid_pin(final_pin):
+        final_pin = config_pin or desired_pin
+
+    settings.network.miniweb_pin = final_pin or ""
+
+    if save_settings:
         try:
-            settings.save(cfg_path)
+            settings.save(CONFIG_PATH)
         except Exception:
             log.exception("No se pudo guardar la configuración tras sincronizar el PIN")
 
+    _apply_dir_permissions(yaml_path.parent, mode=dir_mode, owner=owner, group=group)
     return final_pin
 
 
-__all__ = ["sync_miniweb_pin", "DEFAULT_AUTH_PATH", "DEFAULT_FILE_MODE", "DEFAULT_DIR_MODE"]
+__all__ = ["sync_miniweb_pin", "DEFAULT_DIR_MODE", "DEFAULT_FILE_MODE"]

--- a/bascula/ui/screens_tabs_ext.py
+++ b/bascula/ui/screens_tabs_ext.py
@@ -8,8 +8,8 @@ import socket
 import subprocess
 import tkinter as tk
 from tkinter import ttk
-from pathlib import Path
 
+from bascula.config.pin import PinPersistenceError
 from bascula.ui.fonts import font_tuple
 from bascula.ui.screens import BaseScreen
 from bascula.ui.theme_holo import (
@@ -337,14 +337,37 @@ class TabbedSettingsMenuScreen(BaseScreen):
                 ip = None
         return ip
 
+    def get_miniweb_pin_text(self) -> str:
+        try:
+            pin = self.app.get_miniweb_pin()
+        except AttributeError:
+            pin = ""
+        value = pin or "N/D"
+        return f"PIN mini-web: {value}"
+
     def read_pin(self) -> str:
         try:
-            path = Path.home() / ".config" / "bascula" / "pin.txt"
-            if path.exists():
-                return path.read_text(encoding="utf-8", errors="ignore").strip()
+            pin = self.app.get_miniweb_pin()
+            return pin or "N/D"
+        except AttributeError:
+            return "N/D"
+
+    def regenerate_miniweb_pin(self) -> bool:
+        try:
+            new_pin = self.app.regenerate_miniweb_pin()
+        except PinPersistenceError:
+            try:
+                self.toast.show("No se pudo guardar el PIN", 1800)
+            except Exception:
+                pass
+            return False
+        except AttributeError:
+            return False
+        try:
+            self.toast.show(f"PIN regenerado: {new_pin}", 1400)
         except Exception:
             pass
-        return "N/D"
+        return True
 
 
 __all__ = ["TabbedSettingsMenuScreen"]

--- a/bascula/ui/settings_tabs/tabs_network.py
+++ b/bascula/ui/settings_tabs/tabs_network.py
@@ -28,19 +28,42 @@ def add_tab(screen, notebook):
     url_var = tk.StringVar(value=url_text())
     tk.Label(inner, textvariable=url_var, bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans", 12)).pack(anchor='w', pady=(6, 0))
 
-    # PIN de emparejamiento (si existe)
+    # PIN mini-web y opciones de regeneración
     pin_row = tk.Frame(inner, bg=COL_CARD); pin_row.pack(fill='x', pady=(8,0))
-    tk.Label(pin_row, text='PIN:', bg=COL_CARD, fg=COL_TEXT).pack(side='left')
-    pin_var = tk.StringVar(value=screen.read_pin())
-    tk.Label(pin_row, textvariable=pin_var, bg=COL_CARD, fg=COL_TEXT, font=("DejaVu Sans Mono", 12)).pack(side='left', padx=6)
+    pin_var = tk.StringVar(value=screen.get_miniweb_pin_text())
+    tk.Label(
+        pin_row,
+        textvariable=pin_var,
+        bg=COL_CARD,
+        fg=COL_TEXT,
+        font=("DejaVu Sans", 13, "bold"),
+    ).pack(side='left', padx=6)
+
+    def update_pin_label() -> None:
+        pin_var.set(screen.get_miniweb_pin_text())
+
+    def on_regenerate_pin() -> None:
+        if screen.regenerate_miniweb_pin():
+            update_pin_label()
 
     def on_refresh():
         ip = screen.get_current_ip() or 'No conectada'
         ip_var.set(ip)
         url_var.set(url_text())
-        pin_var.set(screen.read_pin())
+        update_pin_label()
 
     tk.Button(inner, text='Refrescar', command=on_refresh, bg=COL_ACCENT, fg='white', bd=0, relief='flat', cursor='hand2').pack(anchor='w', pady=6)
+
+    tk.Button(
+        pin_row,
+        text='Regenerar PIN',
+        command=on_regenerate_pin,
+        bg=COL_ACCENT,
+        fg='white',
+        bd=0,
+        relief='flat',
+        cursor='hand2',
+    ).pack(side='left', padx=(12, 0))
 
     # QR del panel web (si hay dependencias)
     qr_frame = tk.Frame(inner, bg=COL_CARD)

--- a/tests/test_miniweb_pin_sync.py
+++ b/tests/test_miniweb_pin_sync.py
@@ -1,96 +1,88 @@
-import json
-from pathlib import Path
+import yaml
+import pytest
 
+from bascula.config import pin as pin_module
 from bascula.config.settings import Settings
 from bascula.system.miniweb_pin import DEFAULT_FILE_MODE, sync_miniweb_pin
 
 
-def _load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+def test_ensure_pin_generates_and_persists(tmp_path):
+    config_path = tmp_path / "config.yaml"
 
-
-def test_sync_generates_pin_and_writes_files(tmp_path, monkeypatch):
-    cfg_dir = tmp_path / "cfg"
-    cfg_dir.mkdir()
-    cfg_path = cfg_dir / "config.json"
-    auth_path = tmp_path / "auth.json"
-
-    monkeypatch.setenv("BASCULA_SETTINGS_DIR", str(cfg_dir))
-
-    settings = Settings()
-    settings.network.miniweb_pin = ""
-
-    pin = sync_miniweb_pin(
-        settings,
-        auth_path=auth_path,
-        config_path=cfg_path,
-        owner=None,
-        group=None,
-        prefer_config=True,
+    pin, created = pin_module.ensure_miniweb_pin(
+        config_path=config_path,
+        pin_factory=lambda length: "123456",
     )
 
-    assert pin
-    assert pin.isdigit()
-    assert 4 <= len(pin) <= 6
-
-    data = _load_json(cfg_path)
-    assert data["network"]["miniweb_pin"] == pin
-
-    payload = _load_json(auth_path)
-    assert payload["pin"] == pin
-    assert auth_path.stat().st_mode & 0o777 == DEFAULT_FILE_MODE
+    assert created is True
+    assert pin == "123456"
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert data["network"]["miniweb_pin"] == "123456"
+    assert config_path.stat().st_mode & 0o777 == DEFAULT_FILE_MODE
 
 
-def test_sync_prefers_auth_when_not_forced(tmp_path, monkeypatch):
+def test_regenerate_pin_from_ui_calls_reload(tmp_path, monkeypatch):
+    _ = pytest.importorskip("tkinter")
+    from bascula.ui import app as app_module
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"network": {"miniweb_pin": "111111"}}))
+
+    monkeypatch.setenv("BASCULA_SETTINGS_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setattr(pin_module, "generate_pin", lambda length=6: "654321")
+
+    reload_calls = []
+    monkeypatch.setattr(app_module, "reload_miniweb_config", lambda: reload_calls.append(True) or True)
+
+    settings = Settings()
+    settings.network.miniweb_pin = "111111"
+
+    class DummyVar:
+        def __init__(self, value: str = "") -> None:
+            self._value = value
+
+        def set(self, value: str) -> None:
+            self._value = value
+
+        def get(self) -> str:
+            return self._value
+
+    app = object.__new__(app_module.BasculaApp)
+    app._config_yaml_path = config_path
+    app._miniweb_owner = None
+    app._miniweb_group = None
+    app.settings = settings
+    app._miniweb_pin = "111111"
+    app.miniweb_pin_var = DummyVar("111111")
+
+    new_pin = app.regenerate_miniweb_pin()
+
+    assert new_pin == "654321"
+    assert app.miniweb_pin_var.get() == "654321"
+    assert reload_calls, "Reload endpoint was not called"
+
+    stored = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert stored["network"]["miniweb_pin"] == "654321"
+
+
+def test_sync_miniweb_pin_updates_yaml(tmp_path, monkeypatch):
     cfg_dir = tmp_path / "cfg"
     cfg_dir.mkdir()
-    cfg_path = cfg_dir / "config.json"
-    auth_path = tmp_path / "auth.json"
-
     monkeypatch.setenv("BASCULA_SETTINGS_DIR", str(cfg_dir))
-
-    auth_path.write_text(json.dumps({"pin": "8888"}), encoding="utf-8")
 
     settings = Settings()
     settings.network.miniweb_pin = "4444"
 
+    config_yaml = tmp_path / "config.yaml"
     pin = sync_miniweb_pin(
         settings,
-        auth_path=auth_path,
-        config_path=cfg_path,
-        owner=None,
-        group=None,
-        prefer_config=False,
-    )
-
-    assert pin == "8888"
-    assert settings.network.miniweb_pin == "8888"
-    data = _load_json(cfg_path)
-    assert data["network"]["miniweb_pin"] == "8888"
-
-
-def test_sync_prefers_config_when_requested(tmp_path, monkeypatch):
-    cfg_dir = tmp_path / "cfg"
-    cfg_dir.mkdir()
-    cfg_path = cfg_dir / "config.json"
-    auth_path = tmp_path / "auth.json"
-
-    monkeypatch.setenv("BASCULA_SETTINGS_DIR", str(cfg_dir))
-
-    auth_path.write_text(json.dumps({"pin": "2222"}), encoding="utf-8")
-
-    settings = Settings()
-    settings.network.miniweb_pin = "7777"
-
-    pin = sync_miniweb_pin(
-        settings,
-        auth_path=auth_path,
-        config_path=cfg_path,
+        config_path=config_yaml,
         owner=None,
         group=None,
         prefer_config=True,
     )
 
-    assert pin == "7777"
-    payload = _load_json(auth_path)
-    assert payload["pin"] == "7777"
+    assert pin.isdigit()
+    assert 4 <= len(pin) <= 6
+    data = yaml.safe_load(config_yaml.read_text(encoding="utf-8"))
+    assert data["network"]["miniweb_pin"] == pin


### PR DESCRIPTION
## Summary
- add helper utilities to persist and regenerate the mini-web PIN in `/etc/bascula/config.yaml`
- update the app and network settings UI to display the current PIN and offer a regenerate button with proper feedback
- refresh the mini-web PIN synchronisation logic and unit tests to cover the new workflow

## Testing
- pytest tests/test_miniweb_pin_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e171f7b083269c5f1f08fcf650cf