### PR TITLE
Align home quick actions with NeoGhostButton minimum

### DIFF
--- a/bascula/ui/icon_loader.py
+++ b/bascula/ui/icon_loader.py
@@ -29,7 +29,7 @@ except AttributeError:  # pragma: no cover - compatibility fallback
     _RESAMPLE = Image.LANCZOS
 
 
-def load_icon(name: str, size: int = 72) -> ImageTk.PhotoImage:
+def load_icon(name: str, size: int = 72, *, target_diameter: int | None = None) -> ImageTk.PhotoImage:
     """Return a Tk image for the given icon name.
 
     Parameters
@@ -40,10 +40,19 @@ def load_icon(name: str, size: int = 72) -> ImageTk.PhotoImage:
     size:
         Target square size in pixels. Icons are rescaled with high-quality
         filtering and cached for reuse.
+    target_diameter:
+        Optional diameter of the UI element that will host the icon. When
+        provided, the icon size is constrained so it cannot exceed the
+        available circular footprint minus a safety margin.
     """
 
     raw_name = str(name or "")
     key_size = int(max(1, size))
+    if target_diameter is not None:
+        safe_target = int(max(1, target_diameter))
+        margin = max(12, safe_target // 6)
+        safe_size = max(16, safe_target - margin)
+        key_size = min(key_size, safe_size)
 
     if raw_name.startswith("text:"):
         normalized_name = raw_name


### PR DESCRIPTION
## Summary
- align the HomeView quick action layout with NeoGhostButton.MIN_DIAMETER so buttons never shrink below their widget minimum
- recalculate column counts for narrow windows and propagate the final diameter through padding, frame height, and icon resizing
- add optional target_diameter handling to load_icon to keep icons within the computed button footprint

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/icon_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fbd027c88326aaedb657be6756f2