### PR TITLE
Add configurable mascot overlay lifecycle

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -69,6 +69,11 @@ class HomeScreen(BaseScreen):
 
         self.view = HomeView(self, controller=self)
         self.view.pack(fill="both", expand=True)
+        if hasattr(app, "register_home_view"):
+            try:
+                app.register_home_view(self.view)
+            except Exception:
+                LOGGER.debug("No se pudo registrar la vista Home", exc_info=True)
 
         self.view.on_tare = app.handle_tare
         self.view.on_zero = app.handle_zero


### PR DESCRIPTION
## Summary
- persist the ui.show_mascota flag in both ui.toml and config.yaml and expose BasculaApp helpers to toggle the mascot on route and modal changes
- render the Basculín overlay from HomeView with a dedicated host, safe geometry management, and a text fallback when the canvas cannot be created
- stop MascotaCanvas timers when hidden and make popups/timer dialogs notify the app so the overlay hides while modals are active

## Testing
- pytest tests/test_miniweb_pin_sync.py tests/test_miniweb_ui_app.py

------
https://chatgpt.com/codex/tasks/task_e_68d9074d89c88326a4242311963528d4