### PR TITLE
Update timer toolbar display and audio feedback

### DIFF
--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -134,6 +134,21 @@ class HomeScreen(BaseScreen):
         except Exception:
             self.app.handle_timer()
 
+    def update_toolbar_timer(
+        self,
+        *,
+        text: str | None,
+        state: str = "idle",
+        flash: bool = False,
+    ) -> None:
+        shell = getattr(self.app, "shell", None)
+        if shell is None or not hasattr(shell, "set_timer_state"):
+            return
+        try:
+            shell.set_timer_state(text, state=state, flash=flash)
+        except Exception:
+            LOGGER.debug("No se pudo actualizar el temporizador en la toolbar", exc_info=True)
+
     def update_weight(self, value: Optional[float], stable: bool, unit: str) -> None:
         self.view.set_units(unit)
         grams_value = value


### PR DESCRIPTION
## Summary
- Surface the holographic timer countdown in the toolbar, hide it when idle, and show a transient "Tiempo finalizado" flash
- Trigger the shared audio service for alarm beeps plus optional TTS when the timer reaches zero
- Refresh the General settings audio test buttons with dedicated beep and voice actions that respect availability

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/screens.py bascula/ui/settings_tabs/tabs_general.py

------
https://chatgpt.com/codex/tasks/task_e_68d921f68f04832695509a3bfe7c1f67