### PR TITLE
Refine home layout and timer alerts

### DIFF
--- a/bascula/services/audio.py
+++ b/bascula/services/audio.py
@@ -89,6 +89,18 @@ class AudioService:
     def beep_alarm(self) -> None:
         self._beep(440, 750)
 
+    def timer_finished(self) -> bool:
+        """Play a short tri-tone sequence used when the timer reaches zero."""
+
+        if not self.enabled:
+            return False
+        if not self.backend.aplay:
+            log.info("aplay missing, no se puede reproducir secuencia de temporizador")
+            return False
+        for frequency, duration in ((880, 180), (660, 180), (1020, 280)):
+            self._beep(frequency, duration)
+        return True
+
     def speak(self, text: str) -> None:
         if not self.enabled or not self.tts_enabled:
             log.debug("Skipping speech while audio disabled")

--- a/bascula/ui/dialogs/timer.py
+++ b/bascula/ui/dialogs/timer.py
@@ -174,6 +174,16 @@ class TimerDialog(ctk.CTkToplevel if CTK_AVAILABLE and ctk is not None else tk.T
         )
         cancel_btn.pack(side="left", expand=True, fill="x", padx=(0, 8))
 
+        clear_btn = self._create_button(
+            actions,
+            text="Borrar",
+            command=self._handle_clear,
+            width=150,
+            height=48,
+            secondary=True,
+        )
+        clear_btn.pack(side="left", expand=True, fill="x", padx=8)
+
         accept_btn = self._create_button(
             actions,
             text="Aceptar",
@@ -273,6 +283,11 @@ class TimerDialog(ctk.CTkToplevel if CTK_AVAILABLE and ctk is not None else tk.T
 
     def _backspace(self) -> None:
         self._digits = self._digits[:-1]
+        self._update_display()
+
+    def _handle_clear(self) -> None:
+        self._digits = ""
+        self._status_var.set("")
         self._update_display()
 
     def _apply_preset(self, seconds: int) -> None:

--- a/bascula/ui/icon_loader.py
+++ b/bascula/ui/icon_loader.py
@@ -136,7 +136,7 @@ def _text_icon_image(text: str, size: int) -> Image.Image:
 
     image = Image.new("RGBA", (side, side), (0, 0, 0, 0))
     draw = ImageDraw.Draw(image)
-    padding = max(4, side // 8)
+    padding = max(8, min(14, int(round(side * 0.08))))
     max_box = side - padding * 2
 
     font = _resolve_font(side)

--- a/bascula/ui/screens.py
+++ b/bascula/ui/screens.py
@@ -140,12 +140,13 @@ class HomeScreen(BaseScreen):
         text: str | None,
         state: str = "idle",
         flash: bool = False,
+        blink: bool = False,
     ) -> None:
         shell = getattr(self.app, "shell", None)
         if shell is None or not hasattr(shell, "set_timer_state"):
             return
         try:
-            shell.set_timer_state(text, state=state, flash=flash)
+            shell.set_timer_state(text, state=state, flash=flash, blink=blink)
         except Exception:
             LOGGER.debug("No se pudo actualizar el temporizador en la toolbar", exc_info=True)
 

--- a/bascula/ui/settings_tabs/tabs_general.py
+++ b/bascula/ui/settings_tabs/tabs_general.py
@@ -144,7 +144,7 @@ def add_tab(screen, notebook):
             _show_toast("Audio no disponible", 1200)
             return
         if not _tts_available(audio):
-            _show_toast("TTS no disponible", 1200)
+            _show_toast("Voz no disponible", 1200)
             return
         try:
             audio.speak("Prueba de voz")
@@ -154,7 +154,7 @@ def add_tab(screen, notebook):
 
     tk.Button(
         row1,
-        text="Prueba beep",
+        text="Probar beep",
         command=on_test_beep,
         bg=COL_ACCENT,
         fg='white',
@@ -163,17 +163,16 @@ def add_tab(screen, notebook):
         cursor='hand2',
     ).pack(side='left', padx=8)
 
-    if _tts_available(_get_audio_service()):
-        tk.Button(
-            row1,
-            text="Prueba voz",
-            command=on_test_voice,
-            bg=COL_ACCENT,
-            fg='white',
-            bd=0,
-            relief='flat',
-            cursor='hand2',
-        ).pack(side='left', padx=4)
+    tk.Button(
+        row1,
+        text="Probar voz",
+        command=on_test_voice,
+        bg=COL_ACCENT,
+        fg='white',
+        bd=0,
+        relief='flat',
+        cursor='hand2',
+    ).pack(side='left', padx=4)
 
     # Wake Word
     row2 = tk.Frame(inner, bg=COL_CARD)


### PR DESCRIPTION
## Summary
- reshape the home quick-action grid with rectangular neon buttons, preserved weight band spacing, and full-width separators while moving the countdown to the toolbar with blinking in the final 10 seconds
- add support for the new geometry in NeoGhostButton, text icons, and timer dialog controls, plus a tri-tone timer-finished cue with TTS fallback and settings test buttons
- teach the app shell and screen plumbing to handle toolbar blinking updates safely

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/widgets.py bascula/ui/icon_loader.py bascula/services/audio.py bascula/ui/settings_tabs/tabs_general.py bascula/ui/dialogs/timer.py bascula/ui/app_shell.py bascula/ui/screens.py

------
https://chatgpt.com/codex/tasks/task_e_68d9256094b08326993fab5b10c89ed9