### PR TITLE
Tighten home quick actions layout

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -212,6 +212,11 @@ class BasculaApp:
     """Application entry point responsible for wiring UI and services."""
 
     def __init__(self) -> None:
+        env_mode = (os.environ.get("BASCULA_ENV") or "").strip().lower()
+        if env_mode == "prod":
+            import importlib
+
+            importlib.invalidate_caches()
         self.root = create_root()
         apply_kiosk_window_prefs(self.root)
         self.root.title("Báscula Cam")

--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -282,6 +282,13 @@ def apply_holo_theme(root: Optional[Misc] = None) -> None:
         relief="flat",
     )
     style.configure(
+        "Home.Buttons.TFrame",
+        background=PALETTE["bg"],
+        borderwidth=0,
+        relief="flat",
+        padding=0,
+    )
+    style.configure(
         "Toolbutton.TButton",
         background=PALETTE["bg"],
         foreground=PALETTE["text_muted"],


### PR DESCRIPTION
## Summary
- tighten the Home quick action grid with fixed margins/gaps, centered layout, and aligned separator
- extend NeoGhostButton to accept explicit rectangular sizing and adjust inner content padding
- remove hidden frame padding and invalidate caches on prod startup to keep UI updates visible

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/widgets.py bascula/ui/theme_holo.py bascula/ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d92d4bb79c83268dfa3d5ead5210a5