### PR TITLE
Remove home view neon separator

### DIFF
--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -517,8 +517,16 @@ def draw_neon_separator(
     *,
     color: str = "#00E5FF",
     tags: str = "holo-separator",
+    enabled: bool = True,
 ) -> None:
     """Render a holographic neon separator line between two coordinates."""
+
+    if not enabled:
+        try:
+            canvas.delete(tags)
+        except Exception:
+            pass
+        return
 
     try:
         start_x = int(x0)


### PR DESCRIPTION
## Summary
- disable the Home view's center neon separator and remove its redraw hooks
- adjust layout metrics so the buttons rely on their own padding without separator spacing
- add an `enabled` flag to the neon separator helper to support conditional rendering

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/theme_holo.py

------
https://chatgpt.com/codex/tasks/task_e_68d93d296e708326b4337c5f4dd061ce