### PR TITLE
Fix quick action neon border layout

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -218,7 +218,11 @@ class AppShell:
                 button.image = icon  # type: ignore[attr-defined]
             else:
                 button.configure(image="", text=fallback_text, compound="center")
-            button.pack(side="left", padx=(0, SPACING["sm"]))
+            try:
+                pad_top = int(self.root.winfo_fpixels("1m") * 3)
+            except Exception:
+                pad_top = 10
+            button.pack(side="left", padx=(0, SPACING["sm"]), pady=(pad_top, 0))
             button.tooltip = tooltip  # type: ignore[attr-defined]
             button.configure(state="disabled")
             self._icon_widgets[name] = button

--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -781,10 +781,17 @@ def neon_border(
             _raise_content()
         except Exception:
             pass
+        safe_inset = get_neon_frame_inset(padding)
+        canvas_w = max(1, w + 2 * safe_inset + 1)
+        canvas_h = max(1, h + 2 * safe_inset + 1)
+        try:
+            border_canvas.place_configure(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
+        except Exception:
+            border_canvas.place(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
         draw_neon_frame(
             border_canvas,
-            width=w,
-            height=h,
+            width=canvas_w,
+            height=canvas_h,
             padding=padding,
             radius=radius,
             color=color,


### PR DESCRIPTION
## Summary
- resize and reposition the quick actions host to include neon padding, apply the requested offsets, and refresh button/icon styling in blue neon
- update the shared neon_border helper so the canvas grows with the glow and avoids clipping artefacts
- lower the status toolbar icons with a dynamic top padding so the volume control sits a few millimetres lower

## Testing
- python -m compileall bascula/ui/views/home.py bascula/ui/theme_holo.py bascula/ui/app_shell.py

------
https://chatgpt.com/codex/tasks/task_e_68d963061f0c8326a410c5d777c28574