### PR TITLE
Fix home view layout regressions

### DIFF
--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -745,6 +745,10 @@ def neon_border(
         return None
 
     border_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
+    try:
+        border_canvas.lower()
+    except Exception:
+        pass
 
     def _raise_content() -> None:
         parent = getattr(border_canvas, "master", None)
@@ -788,6 +792,10 @@ def neon_border(
             border_canvas.place_configure(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
         except Exception:
             border_canvas.place(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
+        try:
+            border_canvas.lower()
+        except Exception:
+            pass
         draw_neon_frame(
             border_canvas,
             width=canvas_w,


### PR DESCRIPTION
## Summary
- stabilize quick action layout by freezing geometry propagation and updating placement without dropping existing managers
- keep the mascot overlay anchored on the left and below the weight container to avoid covering critical UI
- ensure neon border canvases sit behind their host widgets so buttons remain clickable

## Testing
- python -m bascula.ui.app --view=home

------
https://chatgpt.com/codex/tasks/task_e_68d96793675483269f19196fdfb75183