### PR TITLE
Make timer dialog modal and undecorated

### DIFF
--- a/bascula/ui/views/timer.py
+++ b/bascula/ui/views/timer.py
@@ -255,15 +255,22 @@ class TimerDialog(tk.Toplevel):
     ) -> None:
         super().__init__(parent)
         self.withdraw()
-        self.title("Temporizador")
-        self.overrideredirect(False)
+        self.overrideredirect(True)
+        try:
+            self.attributes("-topmost", True)
+        except Exception:
+            pass
+        try:
+            self.transient(parent.winfo_toplevel())
+        except Exception:
+            pass
         self.resizable(False, False)
         self.configure(bg=theme_holo.COLOR_BG)
 
         self._parent = parent
         self._controller = controller
-        self._width = width
-        self._height = height
+        self._default_width = width
+        self._default_height = height
         self._digits = ""
         self._last_applied_seconds = 0
         self._keypad: Optional[NeoKeypad] = None
@@ -276,6 +283,7 @@ class TimerDialog(tk.Toplevel):
 
         self.bind("<Escape>", lambda _e: self.close())
         self.bind("<Return>", lambda _e: self._accept())
+        
         self.bind("<KeyPress>", self._handle_keypress, add=True)
 
         self.protocol("WM_DELETE_WINDOW", self.close)
@@ -283,13 +291,15 @@ class TimerDialog(tk.Toplevel):
     # ------------------------------------------------------------------
     def show(self, *, initial_seconds: Optional[int] = None) -> None:
         self._reset_view(initial_seconds)
-        self._center_on_parent()
-        self.deiconify()
+        self.update_idletasks()
+        width = min(int(self.winfo_reqwidth()), 980)
+        height = min(int(self.winfo_reqheight()), 560)
+        if not width:
+            width = int(self._default_width)
+        if not height:
+            height = int(self._default_height)
+        self._center_and_show(width, height)
         self.lift()
-        try:
-            self.grab_set()
-        except Exception:
-            pass
         self.after_idle(self._focus_keypad)
 
     def close(self) -> None:
@@ -456,30 +466,29 @@ class TimerDialog(tk.Toplevel):
         elif event.char and event.char.isdigit():
             self._handle_digit(event.char)
 
-    def _center_on_parent(self) -> None:
-        parent = self._parent.winfo_toplevel() if hasattr(self._parent, "winfo_toplevel") else self._parent
+    def _center_and_show(self, width: Optional[int] = None, height: Optional[int] = None) -> None:
+        self.update_idletasks()
+        sw = int(self.winfo_screenwidth())
+        sh = int(self.winfo_screenheight())
+        if width is None:
+            width = int(self.winfo_reqwidth())
+        if height is None:
+            height = int(self.winfo_reqheight())
+        width = min(int(width), 980)
+        height = min(int(height), 560)
+        x = max(0, (sw - width) // 2)
+        y = max(0, (sh - height) // 2)
         try:
-            parent.update_idletasks()
+            self.configure(bg=theme_holo.COLOR_BG)
         except Exception:
             pass
-
+        self.geometry(f"{width}x{height}+{x}+{y}")
         try:
-            pw = int(parent.winfo_width())
-            ph = int(parent.winfo_height())
-            px = int(parent.winfo_rootx())
-            py = int(parent.winfo_rooty())
+            self.grab_set()
         except Exception:
-            pw = 1024
-            ph = 600
-            px = 0
-            py = 0
-
-        w = min(self._width, pw)
-        h = min(self._height, ph)
-        x = px + (pw - w) // 2
-        y = py + (ph - h) // 2
-        screen_w = max(800, int(self.winfo_screenwidth()))
-        screen_h = max(480, int(self.winfo_screenheight()))
-        x = max(0, min(x, screen_w - w))
-        y = max(0, min(y, screen_h - h))
-        self.geometry(f"{w}x{h}+{x}+{y}")
+            pass
+        try:
+            self.focus_set()
+        except Exception:
+            pass
+        self.deiconify()


### PR DESCRIPTION
## Summary
- remove the native window chrome from `TimerDialog` and mark it as topmost/transient for modal behavior
- add `_center_and_show` to center the dialog, enforce themed background, grab focus, and cap its size for small displays
- update `show` to use the new centering helper so the keypad and accept button remain visible while keeping the neon styling

## Testing
- `python -m compileall bascula/ui/views/timer.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9694551988326b470853b017753f3