### PR TITLE
Restore Home view quick actions layout and neon border stacking

### DIFF
--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -744,7 +744,7 @@ def neon_border(
     except Exception:
         return None
 
-    border_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
+    border_canvas.place(x=0, y=0, relwidth=1.0, relheight=1.0)
     try:
         border_canvas.lower()
     except Exception:
@@ -789,9 +789,13 @@ def neon_border(
         canvas_w = max(1, w + 2 * safe_inset + 1)
         canvas_h = max(1, h + 2 * safe_inset + 1)
         try:
-            border_canvas.place_configure(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
+            border_canvas.configure(width=canvas_w, height=canvas_h)
         except Exception:
-            border_canvas.place(x=-safe_inset, y=-safe_inset, width=canvas_w, height=canvas_h)
+            pass
+        try:
+            border_canvas.place_configure(x=-safe_inset, y=-safe_inset)
+        except Exception:
+            border_canvas.place(x=-safe_inset, y=-safe_inset)
         try:
             border_canvas.lower()
         except Exception:

--- a/bascula/ui/views/home.py
+++ b/bascula/ui/views/home.py
@@ -641,6 +641,19 @@ class HomeView(ttk.Frame):
                 host.lower(weight_container)
             except Exception:
                 pass
+            mascot_widget: tk.Misc | None = None
+            if self._mascota is not None:
+                mascot_widget = self._mascota
+            elif self._mascota_fallback is not None:
+                mascot_widget = self._mascota_fallback
+            if mascot_widget is not None:
+                try:
+                    mascot_widget.lower(weight_container)
+                except Exception:
+                    try:
+                        mascot_widget.lower()
+                    except Exception:
+                        pass
         try:
             self._buttons_frame.lift()
         except Exception:
@@ -1175,47 +1188,6 @@ class HomeView(ttk.Frame):
         if frame is None or host is None:
             return
 
-        def _reset_layout() -> None:
-            """Fallback to a simple packed layout when fancy offsets fail."""
-
-            try:
-                host.place_forget()
-            except Exception:
-                pass
-            try:
-                frame.place_forget()
-            except Exception:
-                pass
-
-            pad_x = getattr(self, "_buttons_outer_padx", (0, 0))
-            pad_y = getattr(self, "_buttons_outer_pady", (0, 0))
-
-            try:
-                info = host.pack_info()
-            except Exception:
-                info = None
-
-            if info:
-                try:
-                    host.pack_configure(padx=pad_x, pady=pad_y, anchor="n")
-                except Exception:
-                    pass
-            else:
-                try:
-                    host.pack(fill="x", anchor="n", padx=pad_x, pady=pad_y)
-                except Exception:
-                    pass
-
-            try:
-                frame.pack(fill="both", expand=True)
-            except Exception:
-                pass
-
-            try:
-                frame.pack_propagate(False)
-            except Exception:
-                pass
-
         for widget in (host, frame):
             for fn_name in ("pack_propagate", "grid_propagate"):
                 try:
@@ -1424,7 +1396,6 @@ class HomeView(ttk.Frame):
                 if desired_x > max_offset:
                     desired_x = max_offset
 
-        placement_ok = True
         try:
             host.place(
                 anchor="n",
@@ -1435,17 +1406,16 @@ class HomeView(ttk.Frame):
                 height=host_h,
             )
         except Exception:
-            placement_ok = False
+            return
 
-        if placement_ok:
-            try:
-                frame.place_forget()
-            except Exception:
-                pass
-            try:
-                frame.pack(fill="both", expand=True)
-            except Exception:
-                pass
+        try:
+            frame.place_forget()
+        except Exception:
+            pass
+        try:
+            frame.pack(fill="both", expand=True)
+        except Exception:
+            pass
 
         try:
             host.lift()
@@ -1458,50 +1428,44 @@ class HomeView(ttk.Frame):
                 pass
 
         border_redraw_needed = False
-        if placement_ok:
-            try:
-                info = host.place_info()
-                y_now = int(float(info.get("y", desired_y)))
-                x_now = int(float(info.get("x", desired_x)))
-                relx_now = float(info.get("relx", relx))
-            except Exception:
-                y_now = desired_y
-                x_now = desired_x
-                relx_now = relx
+        try:
+            info = host.place_info()
+            y_now = int(float(info.get("y", desired_y)))
+            x_now = int(float(info.get("x", desired_x)))
+            relx_now = float(info.get("relx", relx))
+        except Exception:
+            y_now = desired_y
+            x_now = desired_x
+            relx_now = relx
 
-            if scr_h and (y_now < safe_top - 8 or y_now + host_h > scr_h - safe_bottom):
-                placement_ok = False
-            if placement_ok and scr_w:
-                centre_x_now = scr_w * relx_now
-                left_now = int(round(centre_x_now + x_now - host_w / 2))
-                right_now = left_now + host_w
-                min_left = base_left
-                max_right = scr_w - right_safety
-                if max_right < min_left + host_w:
-                    max_right = min_left + host_w
-                if left_now < min_left or right_now > max_right:
-                    min_offset = int(round(min_left - (centre_x_now - host_w / 2)))
-                    max_offset = int(round(max_right - (centre_x_now + host_w / 2)))
-                    if min_offset > max_offset:
-                        new_x = int(round((min_offset + max_offset) / 2))
-                    else:
-                        new_x = min(max(x_now, min_offset), max_offset)
-                    try:
-                        host.place_configure(x=new_x)
-                        border_redraw_needed = True
-                    except Exception:
-                        placement_ok = False
-
-            if placement_ok and scr_h and y_now + host_h > scr_h - safe_bottom:
-                new_y = max(8, scr_h - safe_bottom - host_h)
+        if scr_w:
+            centre_x_now = scr_w * relx_now
+            left_now = int(round(centre_x_now + x_now - host_w / 2))
+            right_now = left_now + host_w
+            min_left = base_left
+            max_right = scr_w - right_safety
+            if max_right < min_left + host_w:
+                max_right = min_left + host_w
+            if left_now < min_left or right_now > max_right:
+                min_offset = int(round(min_left - (centre_x_now - host_w / 2)))
+                max_offset = int(round(max_right - (centre_x_now + host_w / 2)))
+                if min_offset > max_offset:
+                    new_x = int(round((min_offset + max_offset) / 2))
+                else:
+                    new_x = min(max(x_now, min_offset), max_offset)
                 try:
-                    host.place_configure(y=new_y)
+                    host.place_configure(x=new_x)
                     border_redraw_needed = True
                 except Exception:
-                    placement_ok = False
+                    pass
 
-        if not placement_ok:
-            _reset_layout()
+        if scr_h and y_now + host_h > scr_h - safe_bottom:
+            new_y = max(8, scr_h - safe_bottom - host_h)
+            try:
+                host.place_configure(y=new_y)
+                border_redraw_needed = True
+            except Exception:
+                pass
 
         for button in getattr(self, "_quick_action_buttons", []):
             try:


### PR DESCRIPTION
## Summary
- stabilize the Home quick-action container by updating geometry before placing, keeping the packed frame, and clamping offsets within the viewport
- keep the mascot overlay lowered beneath the weight container to avoid covering the scale readout
- adjust the neon border canvas placement so it always lowers behind its sibling widgets after redraws

## Testing
- python -m bascula.ui.app --view=home

------
https://chatgpt.com/codex/tasks/task_e_68d96c59cee88326ad8dda56f09962d8