### PR TITLE
Adjust quick action layout offsets

### DIFF
--- a/bascula/ui/theme_holo.py
+++ b/bascula/ui/theme_holo.py
@@ -745,6 +745,10 @@ def neon_border(
         return None
 
     border_canvas.place(relx=0, rely=0, relwidth=1, relheight=1)
+    try:
+        border_canvas.lower()
+    except Exception:
+        pass
 
     def _raise_content() -> None:
         parent = getattr(border_canvas, "master", None)
@@ -790,6 +794,10 @@ def neon_border(
             color=color,
             tags_prefix="neon",
         )
+        try:
+            border_canvas.lower()
+        except Exception:
+            pass
 
     try:
         widget.bind("<Configure>", _redraw, add=True)


### PR DESCRIPTION
## Summary
- reposition the quick action host with centimeter-based offsets and enhanced gap calculations while keeping existing managers intact
- ensure the neon border canvas is always lowered behind its host content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da762e7c688326bb4758ec1c8ad0c5