### PR TITLE
Amplify tare quick actions and realign speaker icon

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -226,7 +226,16 @@ class AppShell:
                 button.image = icon  # type: ignore[attr-defined]
             else:
                 button.configure(image="", text=fallback_text, compound="center")
-            button.pack(side="left", padx=(0, SPACING["sm"]))
+            pad_args = {"side": "left", "padx": (0, SPACING["sm"])}
+            if name == "speaker":
+                try:
+                    offset_px = max(2, int(self.root.winfo_fpixels("1m") * 0.20))
+                except Exception:
+                    offset_px = 8
+                pad_args["pady"] = (offset_px, 0)
+            else:
+                pad_args["pady"] = (0, 0)
+            button.pack(**pad_args)
             button.tooltip = tooltip  # type: ignore[attr-defined]
             button.configure(state="disabled")
             self._icon_widgets[name] = button


### PR DESCRIPTION
## Summary
- increase font and icon size for the Tara and g↔ml quick actions
- apply conditional padding so the speaker icon sits lower in the toolbar

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da7b537bb48326ba978e9e1af722d4