### PR TITLE
Fix speaker toolbar hint to auto-hide

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -69,6 +69,8 @@ class AppShell:
         self._icon_actions: Dict[str, Callable[[], None]] = {}
         self._icon_widgets: Dict[str, tk.Button] = {}
         self._notify_job: Optional[str] = None
+        self._toolbar_hint_text = ""
+        self._toolbar_hint_job: Optional[str] = None
         self._timer_label: Optional[tk.Label] = None
         self._timer_pack: Optional[dict] = None
         self._timer_blink_job: Optional[str] = None
@@ -90,6 +92,28 @@ class AppShell:
         self.attach_timer_controller(timer_controller)
 
         self.root.deiconify()
+
+    def _make_icon_command(
+        self, name: str, tooltip: str, base_cmd: Callable[[], None]
+    ) -> Callable[[], None]:
+        def _cmd() -> None:
+            if tooltip:
+                self._show_ephemeral_hint(tooltip, duration_ms=800)
+            try:
+                base_cmd()
+            finally:
+                pass
+
+        return _cmd
+
+    def _bind_hint_autohide(self, widget: tk.Misc | None) -> None:
+        if widget is None:
+            return
+        for sequence in ("<ButtonRelease-1>", "<Leave>", "<FocusOut>"):
+            try:
+                widget.bind(sequence, lambda _e: self._clear_toolbar_hint(), add=True)
+            except Exception:
+                pass
 
     def run(self) -> None:
         """Enter the Tk mainloop."""
@@ -234,10 +258,15 @@ class AppShell:
             self.container.columnconfigure(0, weight=1)
             self.container.rowconfigure(1, weight=1)
 
-            actions = [
-                {"text": tooltip, "command": (lambda n=name: self._handle_action(n))}
-                for name, _asset, _fallback, tooltip in ICON_CONFIG
-            ]
+            actions = []
+            for name, _asset, _fallback, tooltip in ICON_CONFIG:
+                base_cmd = (lambda n=name: self._handle_action(n))
+                actions.append(
+                    {
+                        "text": tooltip,
+                        "command": self._make_icon_command(name, tooltip, base_cmd),
+                    }
+                )
             self.top_bar = Toolbar(self.container, actions=actions)
             self.top_bar.grid(row=0, column=0, sticky="ew")
 
@@ -262,11 +291,37 @@ class AppShell:
         for name, asset_name, fallback_text, tooltip in ICON_CONFIG:
             asset_filename = asset_name if asset_name.lower().endswith(".png") else f"{asset_name}.png"
             icon = load_icon(asset_filename, 48 if CTK_AVAILABLE else 32)
+            holder: tk.Misc | None = None
+            parent: tk.Misc = container
+            pad_y = (0, 0)
+            if name == "speaker":
+                try:
+                    offset_px = max(2, int(self.root.winfo_fpixels("1m") * 0.20))
+                except Exception:
+                    offset_px = 8
+                pad_y = (offset_px, 0)
+                if CTK_AVAILABLE:
+                    holder = holo_frame(container, fg_color=HOLO_COLORS["surface"])
+                else:
+                    holder = tk.Frame(
+                        container,
+                        bg=COLORS["surface"],
+                        bd=0,
+                        relief="flat",
+                        highlightthickness=0,
+                    )
+                    try:
+                        holder.configure(takefocus=False)
+                    except Exception:
+                        pass
+                parent = holder
+
+            base_cmd = (lambda n=name: self._handle_action(n))
             if CTK_AVAILABLE:
                 width = 78
                 height = 64
                 button = holo_button(
-                    container,
+                    parent,
                     text=fallback_text,
                     image=icon,
                     compound="top",
@@ -276,12 +331,12 @@ class AppShell:
                     fg_color=HOLO_COLORS["surface_alt"],
                     hover_color=HOLO_COLORS["accent"],
                     text_color=HOLO_COLORS["text"],
-                    command=lambda n=name: self._handle_action(n),
+                    command=base_cmd,
                 )
             else:
                 width = 6
                 button = tk.Button(
-                    container,
+                    parent,
                     text=fallback_text,
                     image=icon,
                     compound="top",
@@ -295,28 +350,28 @@ class AppShell:
                     relief="flat",
                     bd=0,
                     highlightthickness=0,
-                    command=lambda n=name: self._handle_action(n),
+                    command=base_cmd,
                 )
                 button.configure(width=width)
+            button.configure(command=self._make_icon_command(name, tooltip, base_cmd))
             if icon is not None:
                 self.icon_images[name] = icon
                 button.configure(image=icon, compound="top", text=fallback_text)
                 button.image = icon  # type: ignore[attr-defined]
             else:
                 button.configure(image="", text=fallback_text, compound="center")
-            pad_args = {"side": "left", "padx": (0, SPACING["sm"])}
-            if name == "speaker":
-                try:
-                    offset_px = max(2, int(self.root.winfo_fpixels("1m") * 0.20))
-                except Exception:
-                    offset_px = 8
-                pad_args["pady"] = (offset_px, 0)
+            if holder is not None:
+                holder.pack(side="left", padx=(0, SPACING["sm"]), pady=pad_y)
+                button.pack(fill="both", expand=True)
             else:
-                pad_args["pady"] = (0, 0)
-            button.pack(**pad_args)
+                button.pack(side="left", padx=(0, SPACING["sm"]), pady=pad_y)
             button.tooltip = tooltip  # type: ignore[attr-defined]
             button.configure(state="disabled")
             self._icon_widgets[name] = button
+
+            self._bind_hint_autohide(button)
+            if holder is not None:
+                self._bind_hint_autohide(holder)
 
             if name == "timer":
                 self._timer_pack = {"side": "left", "padx": (0, SPACING["sm"])}
@@ -380,10 +435,13 @@ class AppShell:
             else:
                 button.configure(image="", text=fallback_text)
 
-            button.configure(command=lambda n=name: self._handle_action(n))
+            base_cmd = (lambda n=name: self._handle_action(n))
+            button.configure(command=self._make_icon_command(name, tooltip, base_cmd))
             button.configure(state="disabled")
             button.tooltip = tooltip  # type: ignore[attr-defined]
             self._icon_widgets[name] = button
+
+            self._bind_hint_autohide(button)
 
             if name == "speaker":
                 try:
@@ -485,6 +543,40 @@ class AppShell:
         except Exception as exc:  # pragma: no cover - defensive
             log.exception("Error executing action %s", name)
             self.notify(str(exc))
+
+    def _show_ephemeral_hint(self, text: Optional[str], *, duration_ms: int = 800) -> None:
+        if not text:
+            return
+        if self._toolbar_hint_job is not None:
+            job = self._toolbar_hint_job
+            self._toolbar_hint_job = None
+            try:
+                self.root.after_cancel(job)
+            except Exception:
+                pass
+        self._toolbar_hint_text = text
+        self._apply_notification_text()
+        if duration_ms <= 0:
+            return
+        try:
+            self._toolbar_hint_job = self.root.after(
+                max(0, int(duration_ms)), self._clear_toolbar_hint
+            )
+        except Exception:
+            self._toolbar_hint_job = None
+
+    def _clear_toolbar_hint(self) -> None:
+        job = self._toolbar_hint_job
+        self._toolbar_hint_job = None
+        if job is not None:
+            try:
+                self.root.after_cancel(job)
+            except Exception:
+                pass
+        if not self._toolbar_hint_text:
+            return
+        self._toolbar_hint_text = ""
+        self._apply_notification_text()
 
     def notify(self, message: str, duration_ms: int = 4000) -> None:
         label = self.notification_label
@@ -644,6 +736,11 @@ class AppShell:
                 self._notification_message, self._notification_default_color
             )
             return
+        if self._toolbar_hint_text:
+            self._configure_notification_label(
+                self._toolbar_hint_text, self._notification_default_color
+            )
+            return
         if not self._timer_display_text:
             self._configure_notification_label("", self._notification_default_color)
             return
@@ -719,6 +816,13 @@ class AppShell:
             except Exception:
                 pass
             self._notify_job = None
+        if self._toolbar_hint_job is not None:
+            try:
+                self.root.after_cancel(self._toolbar_hint_job)
+            except Exception:
+                pass
+            self._toolbar_hint_job = None
+        self._toolbar_hint_text = ""
         if self._cursor_job is not None:
             try:
                 self.root.after_cancel(self._cursor_job)


### PR DESCRIPTION
## Summary
- wrap toolbar icon commands to show ephemeral hints with a shared helper
- bind hint auto-hide handlers to toolbar buttons and the speaker holder frame
- add ephemeral hint state management so speaker hints clear after 800 ms

## Testing
- python -m compileall bascula/ui/app_shell.py

------
https://chatgpt.com/codex/tasks/task_e_68daa52a218083268421adc8b0645c71