### PR TITLE
Keep timer countdown visible after dialog closes

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -44,7 +44,13 @@ from .theme_ctk import (
 )
 from .ui_config import dump_ui_config, load_ui_config
 from . import theme_holo
-from .views.timer import TimerController, TimerDialog, TimerEvent, TimerState
+from .views.timer import (
+    TimerController,
+    TimerDialog,
+    TimerEvent,
+    TimerState,
+    get_timer_controller,
+)
 from .windowing import apply_kiosk_window_prefs
 
 from PIL import Image
@@ -301,7 +307,9 @@ class BasculaApp:
         self.nightscout_service.set_listener(self._on_glucose)
         self.nightscout_service.start()
 
-        self._timer_controller = TimerController(self.root, on_finish=self._on_timer_finished)
+        self._timer_controller = get_timer_controller(
+            self.root, on_finish=self._on_timer_finished
+        )
         self._timer_last_event = TimerEvent(TimerState.IDLE, None)
         self._timer_controller.add_listener(self._on_timer_event)
         self._timer_dialog: TimerDialog | None = None

--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -7,7 +7,12 @@ import tkinter as tk
 from tkinter import ttk
 from typing import Callable, Dict, Iterable, Optional
 
-from .views.timer import TimerController, TimerEvent, TimerState
+from .views.timer import (
+    TimerController,
+    TimerEvent,
+    TimerState,
+    get_timer_controller,
+)
 
 from .theme_neo import COLORS, SPACING, font_sans
 from .icon_loader import load_icon
@@ -88,6 +93,12 @@ class AppShell:
         self._configure_window()
         self._build_layout()
         self._setup_cursor_timer()
+
+        if timer_controller is None:
+            try:
+                timer_controller = get_timer_controller(self.root)
+            except Exception:
+                timer_controller = None
 
         self.attach_timer_controller(timer_controller)
 


### PR DESCRIPTION
## Summary
- expose a shared timer controller accessor so listeners stay active after the dialog is hidden
- ensure the toolbar automatically registers for timer events to paint the countdown text
- reuse the shared timer controller from the main application while preserving finish callbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa7e9331083268fd395bf4758dc0b