### PR TITLE
Fix toolbar hints to persist until cleared

### DIFF
--- a/bascula/ui/app_shell.py
+++ b/bascula/ui/app_shell.py
@@ -141,10 +141,7 @@ class AppShell:
         def _cmd() -> None:
             if tooltip:
                 self._hint_show(tooltip)
-            try:
-                base_cmd()
-            finally:
-                self._hint_clear()
+            base_cmd()
 
         return _cmd
 
@@ -331,10 +328,7 @@ class AppShell:
                 def _cmd() -> None:
                     if tooltip_text:
                         self._hint_show(tooltip_text)
-                    try:
-                        base()
-                    finally:
-                        self._hint_clear()
+                    base()
 
                 return _cmd
 


### PR DESCRIPTION
## Summary
- stop clearing icon hints immediately so they remain visible until timeout or release events
- apply the same delayed clearing behavior to status icons wrapped with _make_cmd

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab5bad3808326bb4b7c877dd1b57d