### PR TITLE
Improve audit logging and timer countdown handling

### DIFF
--- a/bascula/ui/app.py
+++ b/bascula/ui/app.py
@@ -44,13 +44,7 @@ from .theme_ctk import (
 )
 from .ui_config import dump_ui_config, load_ui_config
 from . import theme_holo
-from .views.timer import (
-    TimerController,
-    TimerDialog,
-    TimerEvent,
-    TimerState,
-    get_timer_controller,
-)
+from .views.timer import TimerDialog, TimerEvent, TimerState, get_timer_controller
 from .windowing import apply_kiosk_window_prefs
 
 from PIL import Image

--- a/main.py
+++ b/main.py
@@ -1,5 +1,28 @@
 """Legacy entry point for running the Báscula Tk application."""
 
+import os, sys, logging
+
+if os.environ.get("BASCULA_UI_AUDIT") == "1":
+    _log = logging.getLogger("boot.audit")
+    _log.setLevel(logging.DEBUG)
+    if not _log.handlers:
+        import sys as _s
+
+        h = logging.StreamHandler(_s.stdout)
+        h.setFormatter(logging.Formatter("AUDIT %(message)s"))
+        _log.addHandler(h)
+    _log.propagate = False
+    _log.debug(f"PYTHON={sys.executable}")
+    _log.debug(f"sys.path[0]={sys.path[0]}")
+    try:
+        import bascula.ui.app_shell as _sh
+        import bascula.ui.views.timer as _tm
+
+        _log.debug(f"app_shell={_sh.__file__}")
+        _log.debug(f"timer={_tm.__file__}")
+    except Exception as e:  # pragma: no cover - defensive logging
+        _log.debug(f"import error: {e}")
+
 from bascula.ui.app import BasculaApp as BasculaAppTk
 
 


### PR DESCRIPTION
## Summary
- add BASCULA_UI_AUDIT bootstrap logging in the production entry point and UI modules
- adjust toolbar speaker layout and hint behaviour to keep countdown text visible
- emit toolbar countdown updates from the timer controller and show the frameless dialog centered on screen

## Testing
- python -m compileall main.py bascula/ui/app_shell.py bascula/ui/views/timer.py bascula/ui/app.py

------
https://chatgpt.com/codex/tasks/task_e_68db4c5aec248326a031b33766e59369